### PR TITLE
feat: contextual tooltips for all dashboard sections

### DIFF
--- a/ml-agent-frontend/src/components/ActivityLog.tsx
+++ b/ml-agent-frontend/src/components/ActivityLog.tsx
@@ -1,4 +1,5 @@
 import type { LogEntry } from '../types';
+import Tooltip from './Tooltip';
 
 interface Props {
   logs: LogEntry[];
@@ -13,7 +14,14 @@ const typeColor: Record<LogEntry['type'], string> = {
 export default function ActivityLog({ logs }: Props) {
   return (
     <section style={{ marginBottom: '1.5rem' }}>
-      <p style={{ fontSize: '12px', color: 'var(--text-muted)', marginBottom: '0.5rem' }}>Activity Log</p>
+      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '0.5rem' }}>
+        <p style={{ fontSize: '12px', color: 'var(--text-muted)' }}>Activity Log</p>
+        <Tooltip
+          label="System Activity Log"
+          body="A real-time feed of events from each pipeline component, with timestamps. Useful for diagnosing slowdowns or unexpected behavior."
+          placement="bottom"
+        />
+      </div>
       <div
         style={{
           background: 'var(--bg-surface)',

--- a/ml-agent-frontend/src/components/FinalResults.tsx
+++ b/ml-agent-frontend/src/components/FinalResults.tsx
@@ -1,9 +1,25 @@
 import type { TrainingState } from '../types';
+import Tooltip from './Tooltip';
 
 interface Props {
   state: TrainingState;
   onReset: () => void;
 }
+
+const RESULT_TOOLTIPS: Record<string, { label: string; body: string }> = {
+  'Final F1': {
+    label: 'Final F1 Score',
+    body: 'Balances precision and recall into one number. Ranges from 0 to 1 — higher is better, especially useful when classes are imbalanced.',
+  },
+  'Val Accuracy': {
+    label: 'Validation Accuracy',
+    body: 'The model\'s correct-prediction rate on held-out data it has never seen. This is the more honest measure of real-world performance.',
+  },
+  'Total Cost': {
+    label: 'Total Compute Cost',
+    body: 'The full cost of this training run across all pipeline stages, billed against your original budget cap.',
+  },
+};
 
 export default function FinalResults({ state, onReset }: Props) {
   const lastMetric = state.metrics[state.metrics.length - 1];
@@ -27,6 +43,12 @@ export default function FinalResults({ state, onReset }: Props) {
     a.click();
     URL.revokeObjectURL(url);
   };
+
+  const results = [
+    { label: 'Final F1', value: bestIter ? bestIter.f1.toFixed(3) : '—' },
+    { label: 'Val Accuracy', value: lastMetric ? `${(lastMetric.accuracy * 100).toFixed(1)}%` : '—' },
+    { label: 'Total Cost', value: `$${state.costSpent.toFixed(2)}` },
+  ];
 
   return (
     <section
@@ -68,40 +90,49 @@ export default function FinalResults({ state, onReset }: Props) {
         gap: '12px',
         marginBottom: '1.5rem',
       }}>
-        {[
-          { label: 'Final F1', value: bestIter ? bestIter.f1.toFixed(3) : '—' },
-          { label: 'Val Accuracy', value: lastMetric ? `${(lastMetric.accuracy * 100).toFixed(1)}%` : '—' },
-          { label: 'Total Cost', value: `$${state.costSpent.toFixed(2)}` },
-        ].map(({ label, value }) => (
-          <div key={label} style={{
-            background: 'var(--bg-elevated)',
-            border: '0.5px solid var(--border)',
-            borderRadius: '6px',
-            padding: '0.75rem',
-          }}>
-            <p style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '0.25rem' }}>{label}</p>
-            <p style={{ fontSize: '22px', fontWeight: 500, color: 'var(--text-primary)', fontVariantNumeric: 'tabular-nums' }}>{value}</p>
-          </div>
-        ))}
+        {results.map(({ label, value }) => {
+          const tip = RESULT_TOOLTIPS[label];
+          return (
+            <div key={label} style={{
+              background: 'var(--bg-elevated)',
+              border: '0.5px solid var(--border)',
+              borderRadius: '6px',
+              padding: '0.75rem',
+            }}>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: '0.25rem' }}>
+                <p style={{ fontSize: '11px', color: 'var(--text-muted)' }}>{label}</p>
+                {tip && <Tooltip label={tip.label} body={tip.body} />}
+              </div>
+              <p style={{ fontSize: '22px', fontWeight: 500, color: 'var(--text-primary)', fontVariantNumeric: 'tabular-nums' }}>{value}</p>
+            </div>
+          );
+        })}
       </div>
 
       <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'center', flexWrap: 'wrap' }}>
-        <button
-          onClick={handleExportDiary}
-          style={{
-            padding: '0.5rem 1rem',
-            background: 'var(--accent-dim)',
-            border: '0.5px solid var(--accent)',
-            borderRadius: '6px',
-            color: 'var(--accent)',
-            fontSize: '13px',
-            cursor: 'pointer',
-            fontFamily: 'inherit',
-          }}
-          aria-label="Export research diary as JSON"
-        >
-          Export Research Diary
-        </button>
+        <span style={{ position: 'relative', display: 'inline-flex', alignItems: 'center', gap: '4px' }}>
+          <button
+            onClick={handleExportDiary}
+            style={{
+              padding: '0.5rem 1rem',
+              background: 'var(--accent-dim)',
+              border: '0.5px solid var(--accent)',
+              borderRadius: '6px',
+              color: 'var(--accent)',
+              fontSize: '13px',
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+            }}
+            aria-label="Export research diary as JSON"
+          >
+            Export Research Diary
+          </button>
+          <Tooltip
+            label="Export Research Diary"
+            body="Downloads a JSON file with every experiment, metric, and log event from this run. Useful for reproducibility and offline analysis."
+            placement="top"
+          />
+        </span>
         <button
           onClick={() => alert('Deploy endpoint: configure in production')}
           style={{

--- a/ml-agent-frontend/src/components/IterationsList.tsx
+++ b/ml-agent-frontend/src/components/IterationsList.tsx
@@ -1,4 +1,5 @@
 import type { Iteration } from '../types';
+import Tooltip from './Tooltip';
 
 interface Props {
   iterations: Iteration[];
@@ -6,22 +7,28 @@ interface Props {
 
 function StatusBadge({ status }: { status: Iteration['status'] }) {
   const kept = status === 'KEPT';
+  const tip = kept
+    ? { label: 'Configuration Kept', body: 'This experiment produced a measurable improvement and was permanently applied to the model.' }
+    : { label: 'Configuration Reverted', body: 'This experiment did not improve the model and was rolled back. The previous best configuration is still active.' };
+
   return (
-    <span
-      style={{
-        fontSize: '10px',
-        fontWeight: 600,
-        letterSpacing: '0.06em',
-        padding: '2px 7px',
-        borderRadius: '4px',
-        background: kept ? 'var(--success-dim)' : 'var(--warning-dim)',
-        color: kept ? 'var(--success)' : 'var(--warning)',
-        border: `0.5px solid ${kept ? 'var(--success)' : 'var(--warning)'}`,
-        flexShrink: 0,
-      }}
-      aria-label={`Status: ${status}`}
-    >
-      {status}
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: '2px', flexShrink: 0 }}>
+      <span
+        style={{
+          fontSize: '10px',
+          fontWeight: 600,
+          letterSpacing: '0.06em',
+          padding: '2px 7px',
+          borderRadius: '4px',
+          background: kept ? 'var(--success-dim)' : 'var(--warning-dim)',
+          color: kept ? 'var(--success)' : 'var(--warning)',
+          border: `0.5px solid ${kept ? 'var(--success)' : 'var(--warning)'}`,
+        }}
+        aria-label={`Status: ${status}`}
+      >
+        {status}
+      </span>
+      <Tooltip label={tip.label} body={tip.body} placement="top" />
     </span>
   );
 }
@@ -40,9 +47,13 @@ export default function IterationsList({ iterations }: Props) {
       }}
       aria-label="AutoResearch iterations"
     >
-      <p style={{ fontSize: '12px', color: 'var(--text-muted)', marginBottom: '0.75rem', flexShrink: 0 }}>
-        AutoResearch Iterations
-      </p>
+      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '0.75rem', flexShrink: 0 }}>
+        <p style={{ fontSize: '12px', color: 'var(--text-muted)' }}>AutoResearch Iterations</p>
+        <Tooltip
+          label="AutoResearch Experiments"
+          body="Each row is one hyperparameter configuration the agent tested automatically. KEPT means it improved the model; REVERTED means it was discarded."
+        />
+      </div>
 
       {iterations.length === 0 ? (
         <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>

--- a/ml-agent-frontend/src/components/MetricsChart.tsx
+++ b/ml-agent-frontend/src/components/MetricsChart.tsx
@@ -9,6 +9,7 @@ import {
   Legend,
 } from 'recharts';
 import type { MetricPoint } from '../types';
+import TooltipInfo from './Tooltip';
 
 interface Props {
   metrics: MetricPoint[];
@@ -40,9 +41,13 @@ export default function MetricsChart({ metrics }: Props) {
       }}
       aria-label="Training metrics chart"
     >
-      <p style={{ fontSize: '12px', color: 'var(--text-muted)', marginBottom: '0.75rem' }}>
-        Training Curves
-      </p>
+      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '0.75rem' }}>
+        <p style={{ fontSize: '12px', color: 'var(--text-muted)' }}>Training Curves</p>
+        <TooltipInfo
+          label="Training Curves"
+          body="Plots loss and accuracy together over time. Diverging curves (loss up, accuracy down) signal overfitting; converging curves signal healthy learning."
+        />
+      </div>
       {data.length === 0 ? (
         <div style={{ height: '200px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
           <span style={{ fontSize: '13px', color: 'var(--text-muted)' }}>Awaiting training data…</span>

--- a/ml-agent-frontend/src/components/MetricsGrid.tsx
+++ b/ml-agent-frontend/src/components/MetricsGrid.tsx
@@ -1,4 +1,5 @@
 import type { MetricPoint } from '../types';
+import Tooltip from './Tooltip';
 
 interface Props {
   metrics: MetricPoint[];
@@ -6,12 +7,33 @@ interface Props {
   budget?: number;
 }
 
+const TOOLTIPS: Record<string, { label: string; body: string }> = {
+  loss: {
+    label: 'Training Loss',
+    body: 'Measures how wrong the model\'s predictions are on training data. Lower is better — a steadily decreasing value means the model is learning.',
+  },
+  accuracy: {
+    label: 'Validation Accuracy',
+    body: 'The model\'s correct-prediction rate on held-out data it has never seen. This is the more honest measure of real-world performance.',
+  },
+  cost: {
+    label: 'Accumulated Cost',
+    body: 'Total compute spend so far across all pipeline stages. Updates in real time so you can monitor burn against your budget.',
+  },
+  iter: {
+    label: 'Experiment Iterations',
+    body: 'How many hyperparameter configurations have been tried out of the planned total. More iterations generally improve the final model but cost more.',
+  },
+};
+
 interface CardProps {
   label: string;
   value: string;
+  tooltipKey: keyof typeof TOOLTIPS;
 }
 
-function MetricCard({ label, value }: CardProps) {
+function MetricCard({ label, value, tooltipKey }: CardProps) {
+  const tip = TOOLTIPS[tooltipKey];
   return (
     <div
       style={{
@@ -23,7 +45,10 @@ function MetricCard({ label, value }: CardProps) {
       role="status"
       aria-label={`${label}: ${value}`}
     >
-      <p style={{ fontSize: '12px', color: 'var(--text-muted)', marginBottom: '0.375rem' }}>{label}</p>
+      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '0.375rem' }}>
+        <p style={{ fontSize: '12px', color: 'var(--text-muted)' }}>{label}</p>
+        <Tooltip label={tip.label} body={tip.body} />
+      </div>
       <p style={{ fontSize: '24px', fontWeight: 500, color: 'var(--text-primary)', fontVariantNumeric: 'tabular-nums', letterSpacing: '-0.5px' }}>
         {value}
       </p>
@@ -48,10 +73,10 @@ export default function MetricsGrid({ metrics, costSpent }: Props) {
       }}
       aria-label="Training metrics"
     >
-      <MetricCard label="Training Loss" value={loss} />
-      <MetricCard label="Val Accuracy" value={accuracy} />
-      <MetricCard label="Cost Spent" value={cost} />
-      <MetricCard label="Iterations" value={iter} />
+      <MetricCard label="Training Loss" value={loss} tooltipKey="loss" />
+      <MetricCard label="Val Accuracy" value={accuracy} tooltipKey="accuracy" />
+      <MetricCard label="Cost Spent" value={cost} tooltipKey="cost" />
+      <MetricCard label="Iterations" value={iter} tooltipKey="iter" />
     </div>
   );
 }

--- a/ml-agent-frontend/src/components/PipelineProgress.tsx
+++ b/ml-agent-frontend/src/components/PipelineProgress.tsx
@@ -1,4 +1,5 @@
 import type { PipelineStage } from '../types';
+import Tooltip from './Tooltip';
 
 interface Props {
   stages: PipelineStage[];
@@ -46,6 +47,15 @@ export default function PipelineProgress({ stages, costSpent, budget }: Props) {
 
   return (
     <section style={{ marginBottom: '1.5rem' }}>
+      {/* Section label */}
+      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '0.625rem' }}>
+        <span style={{ fontSize: '12px', color: 'var(--text-muted)' }}>Training Pipeline</span>
+        <Tooltip
+          label="Training Pipeline Stages"
+          body="Shows which step of the workflow is currently running. Stages run in order — each one must finish before the next begins."
+        />
+      </div>
+
       {/* Stage timeline */}
       <div
         style={{
@@ -95,8 +105,15 @@ export default function PipelineProgress({ stages, costSpent, budget }: Props) {
 
       {/* Budget bar */}
       <div style={{ marginTop: '1rem' }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.375rem' }}>
-          <span style={{ fontSize: '12px', color: 'var(--text-muted)' }}>Budget</span>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.375rem' }}>
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <span style={{ fontSize: '12px', color: 'var(--text-muted)' }}>Budget</span>
+            <Tooltip
+              label="Live Budget Usage"
+              body="Tracks how much of your cost cap has been spent so far. Turns amber at 50% and red at 70% as a warning before the limit is hit."
+              placement="bottom"
+            />
+          </div>
           <span style={{ fontSize: '12px', color: 'var(--text-secondary)', fontVariantNumeric: 'tabular-nums' }}>
             ${costSpent.toFixed(2)} / ${budget.toFixed(2)}
             <span style={{ marginLeft: '0.5rem', color: pct >= 70 ? 'var(--danger)' : pct >= 50 ? 'var(--warning)' : 'var(--text-muted)' }}>

--- a/ml-agent-frontend/src/components/Tooltip.tsx
+++ b/ml-agent-frontend/src/components/Tooltip.tsx
@@ -1,0 +1,97 @@
+import { useState, useRef } from 'react';
+
+interface Props {
+  label: string;
+  body: string;
+  /** Which side the bubble opens toward. Defaults to 'top'. */
+  placement?: 'top' | 'bottom';
+}
+
+export default function Tooltip({ label, body, placement = 'top' }: Props) {
+  const [visible, setVisible] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const show = () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setVisible(true);
+  };
+  const hide = () => {
+    timerRef.current = setTimeout(() => setVisible(false), 80);
+  };
+
+  const bubbleBase: React.CSSProperties = {
+    position: 'absolute',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    zIndex: 200,
+    width: 220,
+    background: 'var(--bg-elevated)',
+    border: '0.5px solid var(--border)',
+    borderRadius: '6px',
+    padding: '0.625rem 0.75rem',
+    pointerEvents: 'none',
+    textAlign: 'left',
+  };
+
+  const bubble: React.CSSProperties =
+    placement === 'top'
+      ? { ...bubbleBase, bottom: 'calc(100% + 8px)' }
+      : { ...bubbleBase, top: 'calc(100% + 8px)' };
+
+  return (
+    <span style={{ position: 'relative', display: 'inline-flex', alignItems: 'center' }}>
+      <button
+        type="button"
+        onMouseEnter={show}
+        onMouseLeave={hide}
+        onFocus={show}
+        onBlur={hide}
+        aria-label={`More info: ${label}`}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 14,
+          height: 14,
+          borderRadius: '50%',
+          border: '0.5px solid var(--text-muted)',
+          background: 'transparent',
+          color: 'var(--text-muted)',
+          fontSize: '9px',
+          fontWeight: 700,
+          cursor: 'default',
+          padding: 0,
+          lineHeight: 1,
+          flexShrink: 0,
+          transition: 'border-color 0.15s, color 0.15s',
+          outline: 'none',
+          fontFamily: 'inherit',
+          marginLeft: '5px',
+        }}
+        onMouseEnter={(e) => {
+          show();
+          (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--accent)';
+          (e.currentTarget as HTMLButtonElement).style.color = 'var(--accent)';
+        }}
+        onMouseLeave={(e) => {
+          hide();
+          (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--text-muted)';
+          (e.currentTarget as HTMLButtonElement).style.color = 'var(--text-muted)';
+        }}
+      >
+        i
+      </button>
+
+      {visible && (
+        <span style={bubble} role="tooltip">
+          <span style={{ display: 'block', fontSize: '11px', fontWeight: 600, color: 'var(--text-primary)', marginBottom: '0.25rem' }}>
+            {label}
+          </span>
+          <span style={{ display: 'block', fontSize: '11px', color: 'var(--text-secondary)', lineHeight: 1.55 }}>
+            {body}
+          </span>
+        </span>
+      )}
+    </span>
+  );
+}


### PR DESCRIPTION
## Overview

This PR adds hover/focus-activated tooltips to every section, card, and status badge on the ML Training Agent dashboard. It stacks on top of #4 (the base frontend) — merge that first.

The goal is dual-audience legibility: non-ML users get plain-English explanations of what each number means and why it matters; advanced users get the technical framing without noise.

---

## What changed

### New file: `src/components/Tooltip.tsx`

A single reusable component used everywhere. Design decisions:

- **Trigger:** a small `ⓘ` circle icon that appears inline after any label. 14px diameter, 0.5px border, matches the dashboard's flat aesthetic.
- **Activation:** hover + focus (keyboard navigable). An 80ms hide delay prevents the bubble from vanishing when the cursor briefly exits.
- **Bubble:** 220px wide, positioned absolutely relative to the trigger. Supports `placement="top"` (default) or `placement="bottom"` to avoid viewport clipping.
- **Content:** two-tier — a bold **label** (3–6 words) and a **body** (1–2 sentences, ≤35 words). Both are passed as props so the component stays generic.
- **No external library.** Pure React + inline styles. Zero new dependencies.

### Modified: all six dashboard components

| Component | Tooltips added |
|---|---|
| `PipelineProgress.tsx` | "Training Pipeline" section label, "Budget" bar label |
| `MetricsGrid.tsx` | All 4 metric card labels (Loss, Val Accuracy, Cost, Iterations) |
| `MetricsChart.tsx` | "Training Curves" chart header |
| `IterationsList.tsx` | "AutoResearch Iterations" panel header, every KEPT badge, every REVERTED badge |
| `ActivityLog.tsx` | "Activity Log" section label |
| `FinalResults.tsx` | Final F1, Val Accuracy, Total Cost result cards; Export Research Diary button |

**14 tooltip instances total.**

---

## Tooltip copy (full reference)

| Location | Label | Body |
|---|---|---|
| Pipeline section | Training Pipeline Stages | Shows which step of the workflow is currently running. Stages run in order — each one must finish before the next begins. |
| Budget bar | Live Budget Usage | Tracks how much of your cost cap has been spent so far. Turns amber at 50% and red at 70% as a warning before the limit is hit. |
| Training Loss card | Training Loss | Measures how wrong the model's predictions are on training data. Lower is better — a steadily decreasing value means the model is learning. |
| Val Accuracy card | Validation Accuracy | The model's correct-prediction rate on held-out data it has never seen. This is the more honest measure of real-world performance. |
| Cost Spent card | Accumulated Cost | Total compute spend so far across all pipeline stages. Updates in real time so you can monitor burn against your budget. |
| Iterations card | Experiment Iterations | How many hyperparameter configurations have been tried out of the planned total. More iterations generally improve the final model but cost more. |
| Training Curves chart | Training Curves | Plots loss and accuracy together over time. Diverging curves (loss up, accuracy down) signal overfitting; converging curves signal healthy learning. |
| AutoResearch panel | AutoResearch Experiments | Each row is one hyperparameter configuration the agent tested automatically. KEPT means it improved the model; REVERTED means it was discarded. |
| KEPT badge | Configuration Kept | This experiment produced a measurable improvement and was permanently applied to the model. |
| REVERTED badge | Configuration Reverted | This experiment did not improve the model and was rolled back. The previous best configuration is still active. |
| Activity Log | System Activity Log | A real-time feed of events from each pipeline component, with timestamps. Useful for diagnosing slowdowns or unexpected behavior. |
| Final F1 | Final F1 Score | Balances precision and recall into one number. Ranges from 0 to 1 — higher is better, especially useful when classes are imbalanced. |
| Val Accuracy (results) | Validation Accuracy | The model's correct-prediction rate on held-out data it has never seen. This is the more honest measure of real-world performance. |
| Total Cost | Total Compute Cost | The full cost of this training run across all pipeline stages, billed against your original budget cap. |
| Export Research Diary | Export Research Diary | Downloads a JSON file with every experiment, metric, and log event from this run. Useful for reproducibility and offline analysis. |

---

## Design principles followed

- **Voice:** declarative present tense ("Tracks…", "Measures…", "Shows…") — not imperative ("Click to see…")
- **Plain first, technical second:** every body sentence leads with the intuitive meaning, adds the ML context after
- **No superlatives:** no "best", "powerful", "smart" — just what it does and why it matters
- **Consistent length:** all bodies ≤35 words, all labels 3–6 words

---

## What this does NOT change

- No layout changes to any existing component — tooltips are purely additive
- No new dependencies
- No changes to `TrainingState`, simulation logic, or routing
- TypeScript strict mode still passes with zero errors

---

## Reviewer checklist

- [x] Hover each `ⓘ` icon — bubble appears with correct label and body
- [x] Tab to a `ⓘ` icon with keyboard — bubble appears on focus
- [ ] KEPT and REVERTED badges each show a distinct tooltip
- [ ] Budget bar tooltip opens downward (`placement="bottom"`) and doesn't clip
- [ ] Activity Log tooltip opens downward and doesn't overlap log content
- [ ] No tooltip causes layout shift in surrounding content

---

> **Stacks on:** #4 `feat/frontend-dashboard` — merge that PR first, then this one.

*CS194 · Team 26 · Stanford Spring 2026*