### PR TITLE
feat(autoresearch): implement PROPOSE phase of AutoResearch Loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+*.egg-info/
+dist/
+build/
+.eggs/
+
+# Virtual envs
+.venv/
+venv/
+env/
+.env
+
+# AutoResearch runtime outputs (diary, run logs — not source)
+outputs/
+
+# Editor / OS
+.DS_Store
+.idea/
+.vscode/
+*.swp
+*.swo

--- a/autoresearch_system_map.tex
+++ b/autoresearch_system_map.tex
@@ -1,0 +1,320 @@
+\documentclass[11pt, letterpaper]{article}
+
+\usepackage[margin=1in]{geometry}
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{inconsolata}          % monospace font for diagrams
+\usepackage{xcolor}
+\usepackage{titlesec}
+\usepackage{fancyhdr}
+\usepackage{mdframed}
+\usepackage{parskip}
+\usepackage{hyperref}
+
+% ── Colour palette ────────────────────────────────────────────────────────────
+\definecolor{bgdark}{HTML}{0f1419}
+\definecolor{accent}{HTML}{60a5fa}
+\definecolor{success}{HTML}{4ade80}
+\definecolor{warning}{HTML}{fb923c}
+\definecolor{danger}{HTML}{f87171}
+\definecolor{muted}{HTML}{6b7280}
+\definecolor{surfacebg}{HTML}{1a1f2e}
+
+% ── Section styling ───────────────────────────────────────────────────────────
+\titleformat{\section}{\large\bfseries\color{accent}}{}{0em}{}[\color{muted}\titlerule]
+\titleformat{\subsection}{\normalsize\bfseries\color{accent}}{}{0em}{}
+
+% ── Header / footer ───────────────────────────────────────────────────────────
+\pagestyle{fancy}
+\fancyhf{}
+\rhead{\color{muted}\small CS194 Spring 2026 — Team 26}
+\lhead{\color{muted}\small AutoResearch System Map}
+\cfoot{\color{muted}\small \thepage}
+\renewcommand{\headrulewidth}{0.4pt}
+
+% ── Diagram box ───────────────────────────────────────────────────────────────
+\newmdenv[
+  backgroundcolor=surfacebg,
+  linecolor=accent,
+  linewidth=0.6pt,
+  roundcorner=4pt,
+  innerleftmargin=12pt,
+  innerrightmargin=12pt,
+  innertopmargin=10pt,
+  innerbottommargin=10pt,
+  fontcolor=black,
+]{diagrambox}
+
+% ── Use Inconsolata throughout diagrams ───────────────────────────────────────
+\newcommand{\diagram}[1]{%
+  \begin{diagrambox}
+  \ttfamily\small\obeylines\obeyspaces
+  #1
+  \end{diagrambox}%
+}
+
+\renewcommand{\familydefault}{\sfdefault}
+
+% ─────────────────────────────────────────────────────────────────────────────
+\begin{document}
+
+\begin{center}
+  {\LARGE\bfseries\color{accent} Autonomous ML Training Agent}\\[4pt]
+  {\large System Architecture \& AutoResearch PROPOSE Loop}\\[6pt]
+  {\color{muted}\small CS194 Spring 2026 $\cdot$ Team 26 $\cdot$
+  Owner: Matthew Torre, Hayley Antczak}
+\end{center}
+
+\vspace{0.5em}
+\hrule height 0.6pt
+\vspace{1.2em}
+
+% ═════════════════════════════════════════════════════════════════════════════
+\section{Main Pipeline (runs once, left to right)}
+
+The Manager orchestrates five agents in sequence. Each agent hands a typed
+contract to the next; no agent reaches into another's internals.
+
+\vspace{0.5em}
+\begin{verbatim}
+ User prompt + budget
+        |
+        v
+ +------------+  OrchestrationConfig   +----------------+  DatasetResult
+ |  MANAGER   | ---------------------> | DATA GENERATOR | ------------->
+ |            |                        |                |               |
+ | Claude     |                        | finds/generates|               |
+ | Sonnet     |                        | training data  |               |
+ +------------+                        +----------------+               |
+                                                                        v
+                                                             +--------------------+
+                                                             |  DECISION ENGINE   |
+                                                             |  picks base model  |
+                                                             |  + hyperparams     |
+                                                             +----------+---------+
+                                                                        |
+                                                                  TrainingPlan
+                                                                        |
+                                                                        v
+                                                             +--------------------+
+                                                             |   AUTORESEARCH     |
+                                                             |   (PROPOSE loop)   |  <-- detail below
+                                                             +----------+---------+
+                                                                        |
+                                                                  TrainedModel
+                                                                        |
+                                                                        v
+                                                                    Done
+\end{verbatim}
+
+\vspace{0.5em}
+\begin{center}
+\begin{tabular}{lll}
+\hline
+\textbf{Arrow} & \textbf{Type} & \textbf{Contents} \\
+\hline
+Manager $\to$ DataGen        & \texttt{OrchestrationConfig} & prompt, budget, task type \\
+DataGen $\to$ DecisionEngine & \texttt{DatasetResult}       & train/val/test split paths \\
+DecisionEngine $\to$ AutoRes & \texttt{TrainingPlan}        & base model, LoRA config, eval metric \\
+AutoRes $\to$ Manager        & \texttt{TrainedModel}        & weights path, metrics, cost breakdown \\
+\hline
+\end{tabular}
+\end{center}
+
+% ═════════════════════════════════════════════════════════════════════════════
+\section{AutoResearch — PROPOSE Loop (cycles up to 20×)}
+
+AutoResearch is itself a LangGraph \texttt{StateGraph} with a cycle.
+One pass = one hyperparameter experiment.
+
+\begin{verbatim}
+        +---------------------------------------------------+
+        |              STOP CONDITIONS                      |
+        |  * spend >= budget                                |
+        |  * 3 consecutive non-improving iterations         |
+        |  * 20 total iterations reached                    |
+        +------------------------+--------------------------+
+                                 | __end__
+                                 |
+  +------------------------------+---------------------------------+
+  |                              |                                 |
+  |   +----------+         +-----+----+                           |
+  |   |   INIT   |         |   LOG    |                           |
+  |   |          |         |          |                           |
+  |   | create   |         | append   | <-----------------------+ |
+  |   | eval     |         | diary    |                         | |
+  |   | suite    |         | entry    |                         | |
+  |   +----+-----+         |          |                         | |
+  |        |               | every 10 |                         | |
+  |        v               | iters:   |                         | |
+  |   +----------+         | adapt    |                         | |
+  |   | BASELINE |         | eval     |                         | |
+  |   |          |         | suite    |                         | |
+  |   | run orig |         +----+-----+                         | |
+  |   | script;  |              | propose (loop)                | |
+  |   | set      |              v                         +-----+-+----+
+  |   | baseline |        +----------+                    | KEEP or    |
+  |   | score    |        |  PROPOSE |                    | REVERT     |
+  |   +----+-----+        |          |                    |            |
+  |        |              | Claude   |                    | KEPT:      |
+  |        +------------->| Haiku    |                    |  update    |
+  |                       | picks 1  |                    |  best,     |
+  |                       | hyperparm|                    |  streak=0  |
+  |                       | change;  |                    |            |
+  |                       | writes   |                    | REVERTED:  |
+  |                       | patch to |                    |  restore   |
+  |                       | disk     |                    |  file,     |
+  |                       +----+-----+                    |  streak+1  |
+  |                            |                          +-----+------+
+  |                            v                                ^
+  |                       +----------+                          |
+  |                       |   RUN    |--- NaN/crash ----------->|
+  |                       | [STUB]   |              +----------------------+
+  |                       |          |              | REVERT_AND_CONTINUE  |
+  |                       | Tinker   |              | restore file,        |
+  |                       | GPU job  |              | mark REVERTED        |
+  |                       +----+-----+              +----------------------+
+  |                            | ok
+  |                            v
+  |                       +----------+
+  |                       | EVALUATE |
+  |                       | [STUB]   |
+  |                       |          |
+  |                       | run_evals|
+  |                       | compare  |
+  |                       | vs       |-----------------------------------------+
+  |                       | baseline |
+  |                       +----------+
+  |
+  +--- LangGraph StateGraph (AutoResearchState flows through every node)
+\end{verbatim}
+
+% ═════════════════════════════════════════════════════════════════════════════
+\section{PROPOSE Step — Zoomed In (the only fully implemented node)}
+
+\begin{verbatim}
+  current_config (dict)
+  + diary (last 5 entries)              configs/current.json  (on disk)
+  + task analysis                              |
+         |                                     |
+         v                                     | apply_patch() reads original
+  propose_hypothesis()                         v
+  calls Claude Haiku              +----------------------------+
+                                  |  BEFORE (original file)    |
+  prompt contains:                |  {                         |
+  * current hyperparams           |    learning_rate: 3e-4     |
+  * recent KEPT/REVERTED          |    lora_rank: 16           |
+    history                       |    batch_size: 16  ...     |
+  * task type + primary metric    |  }                         |
+                                  +----------------------------+
+  Claude returns JSON:                         |
+  {                                            | write .tmp -> rename
+    "description": "Decrease lr               | (atomic; no partial writes)
+      3e-4 to 1.5e-4 to reduce                v
+      loss spikes.",              +----------------------------+
+    "patch": {                    |  AFTER  (patched file)     |
+      "learning_rate": 0.00015   |  {                         |
+    },                            |    learning_rate: 1.5e-4   | <- changed
+    "expected_effect":            |    lora_rank: 16           |
+      "val_loss drops ~5%.",      |    batch_size: 16  ...     |
+    "search_strategy": "local"    |  }                         |
+  }                               +----------------------------+
+                                             |
+                                  original saved in state as
+                                  original_content (for revert)
+\end{verbatim}
+
+% ═════════════════════════════════════════════════════════════════════════════
+\section{File Structure}
+
+\begin{verbatim}
+spr26-Team-26/
+|
++-- configs/
+|   +-- current.json              <- active hyperparams; mutated by apply_patch()
+|
++-- outputs/
+|   +-- logs/
+|   |   +-- research_diary.jsonl  <- one JSON line per iteration (KEPT/REVERTED)
+|   +-- experiments/
+|       +-- <job_id>/
+|           +-- metrics.json      <- train_loss, val_loss, primary_metric
+|           +-- model/            <- saved weights  (read by run_evals)
+|           +-- logs.txt          <- Tinker stdout
+|
++-- src/
+|   +-- autoresearch/
+|   |   +-- autoresearch.py       <- graph + all node/edge/helper functions   [DONE]
+|   |   +-- proposer.py           <- RandomSearch + LocalPerturbation         [DONE]
+|   |   +-- config.py             <- TrainingConfig dataclass + BOUNDS dict   [DONE]
+|   |   +-- diff_utils.py         <- format_patch_as_diff / parse_diff        [DONE]
+|   |   +-- loop.py               <- CLI scaffold for PROPOSE-only testing    [DONE]
+|   |
+|   +-- tinker_api/
+|   |   +-- tinker_api.py         <- HTTP client (Sid) -- stubs only
+|   |
+|   +-- manager/manager.py        <- top-level orchestrator (Sid)
+|   +-- data_generator/           <- finds/generates datasets (Ron, Angel)
+|   +-- decision_engine/          <- picks model + baseline config (Ron, Angel)
+|   +-- cost_manager/             <- budget tracking thread (Sid)
+|   +-- observability/            <- log_event() -> colored CLI + run.jsonl   [DONE]
+|   +-- types.py                  <- all TypedDicts (shared contract)         [DONE]
+|
++-- tests/
+|   +-- test_propose_infra.py     <- 30 edge-case tests                       [DONE]
+|   +-- test_autoresearch.py      <- stub tests for graph/eval/decide
+|
++-- ml-agent-frontend/            <- React dashboard  (localhost:5174)
+    +-- src/
+        +-- hooks/useTrainingSimulation.ts  <- simulates pipeline + propose iters
+        +-- components/IterationsList.tsx   <- hypothesis + config diff per iter
+        +-- components/ActivityLog.tsx      <- mirrors log_event() output
+\end{verbatim}
+
+% ═════════════════════════════════════════════════════════════════════════════
+\section{Implementation Status}
+
+\begin{center}
+\begin{tabular}{llll}
+\hline
+\textbf{Component} & \textbf{File} & \textbf{Owner} & \textbf{Status} \\
+\hline
+\texttt{propose\_hypothesis}         & autoresearch.py  & Torre/Antczak & \textcolor{success}{Done} \\
+\texttt{apply\_patch / revert\_patch} & autoresearch.py  & Torre/Antczak & \textcolor{success}{Done} \\
+\texttt{propose\_node}               & autoresearch.py  & Torre/Antczak & \textcolor{success}{Done} \\
+\texttt{keep\_node / revert\_node}   & autoresearch.py  & Torre/Antczak & \textcolor{success}{Done} \\
+\texttt{log\_node}                   & autoresearch.py  & Torre/Antczak & \textcolor{success}{Done} \\
+\texttt{early\_stop / decision / continue edges} & autoresearch.py & Torre/Antczak & \textcolor{success}{Done} \\
+\texttt{compare\_scores}             & autoresearch.py  & Torre/Antczak & \textcolor{success}{Done} \\
+\texttt{decide\_keep\_or\_revert}    & autoresearch.py  & Torre/Antczak & \textcolor{success}{Done} \\
+\texttt{flag\_regression}            & autoresearch.py  & Torre/Antczak & \textcolor{success}{Done} \\
+\texttt{create\_eval\_suite}         & autoresearch.py  & Torre/Antczak & \textcolor{success}{Done} \\
+\texttt{adapt\_eval\_suite}          & autoresearch.py  & Torre/Antczak & \textcolor{success}{Done} \\
+\texttt{build\_autoresearch\_graph}  & autoresearch.py  & Torre/Antczak & \textcolor{success}{Done} \\
+RandomSearch + LocalPerturbation     & proposer.py      & Torre/Antczak & \textcolor{success}{Done} \\
+TrainingConfig + BOUNDS              & config.py        & Torre/Antczak & \textcolor{success}{Done} \\
+Diff utilities                       & diff\_utils.py   & Torre/Antczak & \textcolor{success}{Done} \\
+Edge-case tests (30)                 & test\_propose\_infra.py & Torre/Antczak & \textcolor{success}{Done} \\
+\hline
+\texttt{run\_evals}                  & autoresearch.py  & Torre/Antczak & \textcolor{warning}{Needs model infra} \\
+\texttt{tinker\_api.*}               & tinker\_api.py   & Potti         & \textcolor{warning}{Stub} \\
+Manager, DataGen, DecisionEngine     & various          & Potti/Polonsky/Raychev & \textcolor{warning}{Stub} \\
+\hline
+\end{tabular}
+\end{center}
+
+\vspace{1em}
+\noindent\color{muted}\small
+\textbf{Key data flow summary:}
+\texttt{TrainingPlan} arrives from DecisionEngine $\to$
+\texttt{init\_node} creates \texttt{EvalSuite} $\to$
+\texttt{baseline\_node} sets \texttt{best\_score} $\to$
+\texttt{propose\_node} (Claude Haiku) patches \texttt{configs/current.json} $\to$
+\texttt{run\_node} (Tinker) trains $\to$
+\texttt{evaluate\_node} computes \texttt{ScoreDelta} $\to$
+\texttt{keep\_node} or \texttt{revert\_node} $\to$
+\texttt{log\_node} appends to \texttt{research\_diary.jsonl} $\to$
+\texttt{continue\_edge} loops or exits $\to$
+\texttt{TrainedModel} returned to Manager.
+
+\end{document}

--- a/configs/current.json
+++ b/configs/current.json
@@ -1,0 +1,13 @@
+{
+  "model_name": "distilbert-base-uncased",
+  "learning_rate": 0.0003,
+  "batch_size": 16,
+  "weight_decay": 0.01,
+  "num_epochs": 3,
+  "max_seq_length": 512,
+  "lora_rank": 16,
+  "lora_alpha": 32,
+  "optimizer": "adamw",
+  "warmup_steps": 100,
+  "dropout": 0.1
+}

--- a/ml-agent-frontend/src/components/ActivityLog.tsx
+++ b/ml-agent-frontend/src/components/ActivityLog.tsx
@@ -1,4 +1,5 @@
 import type { LogEntry } from '../types';
+import Tooltip from './Tooltip';
 
 interface Props {
   logs: LogEntry[];
@@ -13,7 +14,14 @@ const typeColor: Record<LogEntry['type'], string> = {
 export default function ActivityLog({ logs }: Props) {
   return (
     <section style={{ marginBottom: '1.5rem' }}>
-      <p style={{ fontSize: '12px', color: 'var(--text-muted)', marginBottom: '0.5rem' }}>Activity Log</p>
+      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '0.5rem' }}>
+        <p style={{ fontSize: '12px', color: 'var(--text-muted)' }}>Activity Log</p>
+        <Tooltip
+          label="System Activity Log"
+          body="A real-time feed of events from each pipeline component, with timestamps. Useful for diagnosing slowdowns or unexpected behavior."
+          placement="bottom"
+        />
+      </div>
       <div
         style={{
           background: 'var(--bg-surface)',

--- a/ml-agent-frontend/src/components/FinalResults.tsx
+++ b/ml-agent-frontend/src/components/FinalResults.tsx
@@ -1,9 +1,25 @@
 import type { TrainingState } from '../types';
+import Tooltip from './Tooltip';
 
 interface Props {
   state: TrainingState;
   onReset: () => void;
 }
+
+const RESULT_TOOLTIPS: Record<string, { label: string; body: string }> = {
+  'Final F1': {
+    label: 'Final F1 Score',
+    body: 'Balances precision and recall into one number. Ranges from 0 to 1 — higher is better, especially useful when classes are imbalanced.',
+  },
+  'Val Accuracy': {
+    label: 'Validation Accuracy',
+    body: 'The model\'s correct-prediction rate on held-out data it has never seen. This is the more honest measure of real-world performance.',
+  },
+  'Total Cost': {
+    label: 'Total Compute Cost',
+    body: 'The full cost of this training run across all pipeline stages, billed against your original budget cap.',
+  },
+};
 
 export default function FinalResults({ state, onReset }: Props) {
   const lastMetric = state.metrics[state.metrics.length - 1];
@@ -27,6 +43,12 @@ export default function FinalResults({ state, onReset }: Props) {
     a.click();
     URL.revokeObjectURL(url);
   };
+
+  const results = [
+    { label: 'Final F1', value: bestIter ? bestIter.f1.toFixed(3) : '—' },
+    { label: 'Val Accuracy', value: lastMetric ? `${(lastMetric.accuracy * 100).toFixed(1)}%` : '—' },
+    { label: 'Total Cost', value: `$${state.costSpent.toFixed(2)}` },
+  ];
 
   return (
     <section
@@ -68,40 +90,49 @@ export default function FinalResults({ state, onReset }: Props) {
         gap: '12px',
         marginBottom: '1.5rem',
       }}>
-        {[
-          { label: 'Final F1', value: bestIter ? bestIter.f1.toFixed(3) : '—' },
-          { label: 'Val Accuracy', value: lastMetric ? `${(lastMetric.accuracy * 100).toFixed(1)}%` : '—' },
-          { label: 'Total Cost', value: `$${state.costSpent.toFixed(2)}` },
-        ].map(({ label, value }) => (
-          <div key={label} style={{
-            background: 'var(--bg-elevated)',
-            border: '0.5px solid var(--border)',
-            borderRadius: '6px',
-            padding: '0.75rem',
-          }}>
-            <p style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '0.25rem' }}>{label}</p>
-            <p style={{ fontSize: '22px', fontWeight: 500, color: 'var(--text-primary)', fontVariantNumeric: 'tabular-nums' }}>{value}</p>
-          </div>
-        ))}
+        {results.map(({ label, value }) => {
+          const tip = RESULT_TOOLTIPS[label];
+          return (
+            <div key={label} style={{
+              background: 'var(--bg-elevated)',
+              border: '0.5px solid var(--border)',
+              borderRadius: '6px',
+              padding: '0.75rem',
+            }}>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: '0.25rem' }}>
+                <p style={{ fontSize: '11px', color: 'var(--text-muted)' }}>{label}</p>
+                {tip && <Tooltip label={tip.label} body={tip.body} />}
+              </div>
+              <p style={{ fontSize: '22px', fontWeight: 500, color: 'var(--text-primary)', fontVariantNumeric: 'tabular-nums' }}>{value}</p>
+            </div>
+          );
+        })}
       </div>
 
       <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'center', flexWrap: 'wrap' }}>
-        <button
-          onClick={handleExportDiary}
-          style={{
-            padding: '0.5rem 1rem',
-            background: 'var(--accent-dim)',
-            border: '0.5px solid var(--accent)',
-            borderRadius: '6px',
-            color: 'var(--accent)',
-            fontSize: '13px',
-            cursor: 'pointer',
-            fontFamily: 'inherit',
-          }}
-          aria-label="Export research diary as JSON"
-        >
-          Export Research Diary
-        </button>
+        <span style={{ position: 'relative', display: 'inline-flex', alignItems: 'center', gap: '4px' }}>
+          <button
+            onClick={handleExportDiary}
+            style={{
+              padding: '0.5rem 1rem',
+              background: 'var(--accent-dim)',
+              border: '0.5px solid var(--accent)',
+              borderRadius: '6px',
+              color: 'var(--accent)',
+              fontSize: '13px',
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+            }}
+            aria-label="Export research diary as JSON"
+          >
+            Export Research Diary
+          </button>
+          <Tooltip
+            label="Export Research Diary"
+            body="Downloads a JSON file with every experiment, metric, and log event from this run. Useful for reproducibility and offline analysis."
+            placement="top"
+          />
+        </span>
         <button
           onClick={() => alert('Deploy endpoint: configure in production')}
           style={{

--- a/ml-agent-frontend/src/components/IterationsList.tsx
+++ b/ml-agent-frontend/src/components/IterationsList.tsx
@@ -1,4 +1,5 @@
 import type { Iteration } from '../types';
+import Tooltip from './Tooltip';
 
 interface Props {
   iterations: Iteration[];
@@ -6,22 +7,28 @@ interface Props {
 
 function StatusBadge({ status }: { status: Iteration['status'] }) {
   const kept = status === 'KEPT';
+  const tip = kept
+    ? { label: 'Configuration Kept', body: 'This experiment produced a measurable improvement and was permanently applied to the model.' }
+    : { label: 'Configuration Reverted', body: 'This experiment did not improve the model and was rolled back. The previous best configuration is still active.' };
+
   return (
-    <span
-      style={{
-        fontSize: '10px',
-        fontWeight: 600,
-        letterSpacing: '0.06em',
-        padding: '2px 7px',
-        borderRadius: '4px',
-        background: kept ? 'var(--success-dim)' : 'var(--warning-dim)',
-        color: kept ? 'var(--success)' : 'var(--warning)',
-        border: `0.5px solid ${kept ? 'var(--success)' : 'var(--warning)'}`,
-        flexShrink: 0,
-      }}
-      aria-label={`Status: ${status}`}
-    >
-      {status}
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: '2px', flexShrink: 0 }}>
+      <span
+        style={{
+          fontSize: '10px',
+          fontWeight: 600,
+          letterSpacing: '0.06em',
+          padding: '2px 7px',
+          borderRadius: '4px',
+          background: kept ? 'var(--success-dim)' : 'var(--warning-dim)',
+          color: kept ? 'var(--success)' : 'var(--warning)',
+          border: `0.5px solid ${kept ? 'var(--success)' : 'var(--warning)'}`,
+        }}
+        aria-label={`Status: ${status}`}
+      >
+        {status}
+      </span>
+      <Tooltip label={tip.label} body={tip.body} placement="top" />
     </span>
   );
 }
@@ -40,9 +47,13 @@ export default function IterationsList({ iterations }: Props) {
       }}
       aria-label="AutoResearch iterations"
     >
-      <p style={{ fontSize: '12px', color: 'var(--text-muted)', marginBottom: '0.75rem', flexShrink: 0 }}>
-        AutoResearch Iterations
-      </p>
+      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '0.75rem', flexShrink: 0 }}>
+        <p style={{ fontSize: '12px', color: 'var(--text-muted)' }}>AutoResearch Iterations</p>
+        <Tooltip
+          label="AutoResearch Experiments"
+          body="Each row is one hyperparameter configuration the agent tested automatically. KEPT means it improved the model; REVERTED means it was discarded."
+        />
+      </div>
 
       {iterations.length === 0 ? (
         <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>

--- a/ml-agent-frontend/src/components/IterationsList.tsx
+++ b/ml-agent-frontend/src/components/IterationsList.tsx
@@ -6,8 +6,14 @@ interface Props {
 }
 
 function StatusBadge({ status }: { status: Iteration['status'] }) {
+  const isPending = status === 'PENDING';
   const kept = status === 'KEPT';
-  const tip = kept
+
+  const color = kept ? 'var(--success)' : isPending ? 'var(--accent)' : 'var(--warning)';
+  const bg    = kept ? 'var(--success-dim)' : isPending ? 'var(--accent-dim)' : 'var(--warning-dim)';
+  const tip = isPending
+    ? { label: 'Evaluating', body: 'This experiment is currently running. The agent is waiting for the training job to finish before deciding to keep or revert.' }
+    : kept
     ? { label: 'Configuration Kept', body: 'This experiment produced a measurable improvement and was permanently applied to the model.' }
     : { label: 'Configuration Reverted', body: 'This experiment did not improve the model and was rolled back. The previous best configuration is still active.' };
 
@@ -20,13 +26,14 @@ function StatusBadge({ status }: { status: Iteration['status'] }) {
           letterSpacing: '0.06em',
           padding: '2px 7px',
           borderRadius: '4px',
-          background: kept ? 'var(--success-dim)' : 'var(--warning-dim)',
-          color: kept ? 'var(--success)' : 'var(--warning)',
-          border: `0.5px solid ${kept ? 'var(--success)' : 'var(--warning)'}`,
+          background: bg,
+          color,
+          border: `0.5px solid ${color}`,
+          opacity: isPending ? 0.85 : 1,
         }}
         aria-label={`Status: ${status}`}
       >
-        {status}
+        {isPending ? '⏳ RUNNING' : status}
       </span>
       <Tooltip label={tip.label} body={tip.body} placement="top" />
     </span>
@@ -76,27 +83,56 @@ export default function IterationsList({ iterations }: Props) {
               role="listitem"
               style={{
                 display: 'flex',
-                alignItems: 'center',
-                gap: '0.625rem',
+                flexDirection: 'column',
+                gap: '4px',
                 padding: '0.5rem 0.625rem',
                 background: 'var(--bg-elevated)',
                 borderRadius: '6px',
                 border: '0.5px solid var(--border-subtle)',
               }}
             >
-              <span style={{ fontSize: '12px', fontWeight: 600, color: 'var(--accent)', flexShrink: 0, minWidth: '1.5rem' }}>
-                #{iterations.length - idx}
-              </span>
-              <span style={{ flex: 1, fontSize: '12px', color: 'var(--text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                {iter.experiment}
-              </span>
-              <span style={{ fontSize: '11px', color: 'var(--text-muted)', flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
-                L {iter.loss.toFixed(3)}
-              </span>
-              <span style={{ fontSize: '11px', color: 'var(--text-muted)', flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
-                F1 {iter.f1.toFixed(3)}
-              </span>
-              <StatusBadge status={iter.status} />
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.625rem' }}>
+                <span style={{ fontSize: '12px', fontWeight: 600, color: 'var(--accent)', flexShrink: 0, minWidth: '1.5rem' }}>
+                  #{iterations.length - idx}
+                </span>
+                <span style={{ flex: 1, fontSize: '12px', color: 'var(--text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {iter.experiment}
+                </span>
+                <span style={{ fontSize: '11px', color: 'var(--text-muted)', flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
+                  L {iter.loss.toFixed(3)}
+                </span>
+                <span style={{ fontSize: '11px', color: 'var(--text-muted)', flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
+                  F1 {iter.f1.toFixed(3)}
+                </span>
+                <StatusBadge status={iter.status} />
+              </div>
+              {iter.diff && (
+                <pre
+                  aria-label="Config diff"
+                  style={{
+                    margin: 0,
+                    marginLeft: '1.75rem',
+                    fontSize: '10px',
+                    lineHeight: 1.5,
+                    fontFamily: 'monospace',
+                    color: 'var(--text-muted)',
+                    whiteSpace: 'pre',
+                    overflow: 'hidden',
+                  }}
+                >
+                  {iter.diff.split('\n').map((line, li) => (
+                    <span
+                      key={li}
+                      style={{
+                        display: 'block',
+                        color: line.startsWith('+') ? 'var(--success)' : line.startsWith('-') ? 'var(--danger)' : 'var(--text-muted)',
+                      }}
+                    >
+                      {line}
+                    </span>
+                  ))}
+                </pre>
+              )}
             </div>
           ))}
         </div>

--- a/ml-agent-frontend/src/components/MetricsChart.tsx
+++ b/ml-agent-frontend/src/components/MetricsChart.tsx
@@ -9,6 +9,7 @@ import {
   Legend,
 } from 'recharts';
 import type { MetricPoint } from '../types';
+import TooltipInfo from './Tooltip';
 
 interface Props {
   metrics: MetricPoint[];
@@ -40,9 +41,13 @@ export default function MetricsChart({ metrics }: Props) {
       }}
       aria-label="Training metrics chart"
     >
-      <p style={{ fontSize: '12px', color: 'var(--text-muted)', marginBottom: '0.75rem' }}>
-        Training Curves
-      </p>
+      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '0.75rem' }}>
+        <p style={{ fontSize: '12px', color: 'var(--text-muted)' }}>Training Curves</p>
+        <TooltipInfo
+          label="Training Curves"
+          body="Plots loss and accuracy together over time. Diverging curves (loss up, accuracy down) signal overfitting; converging curves signal healthy learning."
+        />
+      </div>
       {data.length === 0 ? (
         <div style={{ height: '200px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
           <span style={{ fontSize: '13px', color: 'var(--text-muted)' }}>Awaiting training data…</span>

--- a/ml-agent-frontend/src/components/MetricsGrid.tsx
+++ b/ml-agent-frontend/src/components/MetricsGrid.tsx
@@ -1,4 +1,5 @@
 import type { MetricPoint } from '../types';
+import Tooltip from './Tooltip';
 
 interface Props {
   metrics: MetricPoint[];
@@ -6,12 +7,33 @@ interface Props {
   budget?: number;
 }
 
+const TOOLTIPS: Record<string, { label: string; body: string }> = {
+  loss: {
+    label: 'Training Loss',
+    body: 'Measures how wrong the model\'s predictions are on training data. Lower is better — a steadily decreasing value means the model is learning.',
+  },
+  accuracy: {
+    label: 'Validation Accuracy',
+    body: 'The model\'s correct-prediction rate on held-out data it has never seen. This is the more honest measure of real-world performance.',
+  },
+  cost: {
+    label: 'Accumulated Cost',
+    body: 'Total compute spend so far across all pipeline stages. Updates in real time so you can monitor burn against your budget.',
+  },
+  iter: {
+    label: 'Experiment Iterations',
+    body: 'How many hyperparameter configurations have been tried out of the planned total. More iterations generally improve the final model but cost more.',
+  },
+};
+
 interface CardProps {
   label: string;
   value: string;
+  tooltipKey: keyof typeof TOOLTIPS;
 }
 
-function MetricCard({ label, value }: CardProps) {
+function MetricCard({ label, value, tooltipKey }: CardProps) {
+  const tip = TOOLTIPS[tooltipKey];
   return (
     <div
       style={{
@@ -23,7 +45,10 @@ function MetricCard({ label, value }: CardProps) {
       role="status"
       aria-label={`${label}: ${value}`}
     >
-      <p style={{ fontSize: '12px', color: 'var(--text-muted)', marginBottom: '0.375rem' }}>{label}</p>
+      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '0.375rem' }}>
+        <p style={{ fontSize: '12px', color: 'var(--text-muted)' }}>{label}</p>
+        <Tooltip label={tip.label} body={tip.body} />
+      </div>
       <p style={{ fontSize: '24px', fontWeight: 500, color: 'var(--text-primary)', fontVariantNumeric: 'tabular-nums', letterSpacing: '-0.5px' }}>
         {value}
       </p>
@@ -48,10 +73,10 @@ export default function MetricsGrid({ metrics, costSpent }: Props) {
       }}
       aria-label="Training metrics"
     >
-      <MetricCard label="Training Loss" value={loss} />
-      <MetricCard label="Val Accuracy" value={accuracy} />
-      <MetricCard label="Cost Spent" value={cost} />
-      <MetricCard label="Iterations" value={iter} />
+      <MetricCard label="Training Loss" value={loss} tooltipKey="loss" />
+      <MetricCard label="Val Accuracy" value={accuracy} tooltipKey="accuracy" />
+      <MetricCard label="Cost Spent" value={cost} tooltipKey="cost" />
+      <MetricCard label="Iterations" value={iter} tooltipKey="iter" />
     </div>
   );
 }

--- a/ml-agent-frontend/src/components/PipelineProgress.tsx
+++ b/ml-agent-frontend/src/components/PipelineProgress.tsx
@@ -1,4 +1,5 @@
 import type { PipelineStage } from '../types';
+import Tooltip from './Tooltip';
 
 interface Props {
   stages: PipelineStage[];
@@ -46,6 +47,15 @@ export default function PipelineProgress({ stages, costSpent, budget }: Props) {
 
   return (
     <section style={{ marginBottom: '1.5rem' }}>
+      {/* Section label */}
+      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '0.625rem' }}>
+        <span style={{ fontSize: '12px', color: 'var(--text-muted)' }}>Training Pipeline</span>
+        <Tooltip
+          label="Training Pipeline Stages"
+          body="Shows which step of the workflow is currently running. Stages run in order — each one must finish before the next begins."
+        />
+      </div>
+
       {/* Stage timeline */}
       <div
         style={{
@@ -95,8 +105,15 @@ export default function PipelineProgress({ stages, costSpent, budget }: Props) {
 
       {/* Budget bar */}
       <div style={{ marginTop: '1rem' }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.375rem' }}>
-          <span style={{ fontSize: '12px', color: 'var(--text-muted)' }}>Budget</span>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.375rem' }}>
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <span style={{ fontSize: '12px', color: 'var(--text-muted)' }}>Budget</span>
+            <Tooltip
+              label="Live Budget Usage"
+              body="Tracks how much of your cost cap has been spent so far. Turns amber at 50% and red at 70% as a warning before the limit is hit."
+              placement="bottom"
+            />
+          </div>
           <span style={{ fontSize: '12px', color: 'var(--text-secondary)', fontVariantNumeric: 'tabular-nums' }}>
             ${costSpent.toFixed(2)} / ${budget.toFixed(2)}
             <span style={{ marginLeft: '0.5rem', color: pct >= 70 ? 'var(--danger)' : pct >= 50 ? 'var(--warning)' : 'var(--text-muted)' }}>

--- a/ml-agent-frontend/src/components/Tooltip.tsx
+++ b/ml-agent-frontend/src/components/Tooltip.tsx
@@ -1,0 +1,97 @@
+import { useState, useRef } from 'react';
+
+interface Props {
+  label: string;
+  body: string;
+  /** Which side the bubble opens toward. Defaults to 'top'. */
+  placement?: 'top' | 'bottom';
+}
+
+export default function Tooltip({ label, body, placement = 'top' }: Props) {
+  const [visible, setVisible] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const show = () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setVisible(true);
+  };
+  const hide = () => {
+    timerRef.current = setTimeout(() => setVisible(false), 80);
+  };
+
+  const bubbleBase: React.CSSProperties = {
+    position: 'absolute',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    zIndex: 200,
+    width: 220,
+    background: 'var(--bg-elevated)',
+    border: '0.5px solid var(--border)',
+    borderRadius: '6px',
+    padding: '0.625rem 0.75rem',
+    pointerEvents: 'none',
+    textAlign: 'left',
+  };
+
+  const bubble: React.CSSProperties =
+    placement === 'top'
+      ? { ...bubbleBase, bottom: 'calc(100% + 8px)' }
+      : { ...bubbleBase, top: 'calc(100% + 8px)' };
+
+  return (
+    <span style={{ position: 'relative', display: 'inline-flex', alignItems: 'center' }}>
+      <button
+        type="button"
+        onMouseEnter={show}
+        onMouseLeave={hide}
+        onFocus={show}
+        onBlur={hide}
+        aria-label={`More info: ${label}`}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 14,
+          height: 14,
+          borderRadius: '50%',
+          border: '0.5px solid var(--text-muted)',
+          background: 'transparent',
+          color: 'var(--text-muted)',
+          fontSize: '9px',
+          fontWeight: 700,
+          cursor: 'default',
+          padding: 0,
+          lineHeight: 1,
+          flexShrink: 0,
+          transition: 'border-color 0.15s, color 0.15s',
+          outline: 'none',
+          fontFamily: 'inherit',
+          marginLeft: '5px',
+        }}
+        onMouseEnter={(e) => {
+          show();
+          (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--accent)';
+          (e.currentTarget as HTMLButtonElement).style.color = 'var(--accent)';
+        }}
+        onMouseLeave={(e) => {
+          hide();
+          (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--text-muted)';
+          (e.currentTarget as HTMLButtonElement).style.color = 'var(--text-muted)';
+        }}
+      >
+        i
+      </button>
+
+      {visible && (
+        <span style={bubble} role="tooltip">
+          <span style={{ display: 'block', fontSize: '11px', fontWeight: 600, color: 'var(--text-primary)', marginBottom: '0.25rem' }}>
+            {label}
+          </span>
+          <span style={{ display: 'block', fontSize: '11px', color: 'var(--text-secondary)', lineHeight: 1.55 }}>
+            {body}
+          </span>
+        </span>
+      )}
+    </span>
+  );
+}

--- a/ml-agent-frontend/src/hooks/useTrainingSimulation.ts
+++ b/ml-agent-frontend/src/hooks/useTrainingSimulation.ts
@@ -43,10 +43,15 @@ const STAGE_LOGS: Array<Array<{ component: string; message: string; type: LogEnt
     { component: 'Tinker', message: 'Training epoch 1/3 complete', type: 'default' },
   ],
   [
-    { component: 'AutoResearch', message: 'Starting hyperparameter search loop', type: 'default' },
-    { component: 'AutoResearch', message: 'Proposing experiment: LoRA rank sweep', type: 'default' },
+    { component: 'AutoResearch', message: 'PROPOSE: creating eval suite and recording baseline', type: 'default' },
+    { component: 'AutoResearch', message: 'Hypothesis: decrease learning_rate 3e-4→1.5e-4 (local ±20%)', type: 'default' },
+    { component: 'AutoResearch', message: 'KEPT — val_loss improved 0.312→0.289 (+7.4%)', type: 'success' },
+    { component: 'AutoResearch', message: 'Hypothesis: increase lora_rank 16→32 (random search)', type: 'default' },
+    { component: 'AutoResearch', message: 'KEPT — F1 improved 0.871→0.901 (+3.4%)', type: 'success' },
+    { component: 'AutoResearch', message: 'Hypothesis: increase learning_rate 1.5e-4→6e-4 (local ±20%)', type: 'default' },
+    { component: 'AutoResearch', message: 'REVERTED — loss spiked 0.289→0.334, patch rolled back', type: 'warning' },
     { component: 'CostManager', message: 'Cumulative spend approaching 60% of budget', type: 'warning' },
-    { component: 'AutoResearch', message: 'Best config identified — committing weights', type: 'success' },
+    { component: 'AutoResearch', message: 'Best config committed: lora_rank=32, lr=1.5e-4, warmup=500', type: 'success' },
   ],
   [
     { component: 'Manager', message: 'Collecting final metrics and artifacts', type: 'default' },
@@ -56,13 +61,41 @@ const STAGE_LOGS: Array<Array<{ component: string; message: string; type: LogEnt
 ];
 
 const ITERATIONS: Array<Omit<Iteration, 'id'>> = [
-  { experiment: 'Baseline: lr=2e-4, batch=16', loss: 0.312, f1: 0.871, status: 'KEPT' },
-  { experiment: 'LoRA rank=16, alpha=32', loss: 0.298, f1: 0.883, status: 'KEPT' },
-  { experiment: 'LoRA rank=32, dropout=0.1', loss: 0.271, f1: 0.901, status: 'KEPT' },
-  { experiment: 'lr=5e-4 (too aggressive)', loss: 0.334, f1: 0.862, status: 'REVERTED' },
-  { experiment: 'LoRA rank=32, warmup=500', loss: 0.248, f1: 0.914, status: 'KEPT' },
-  { experiment: 'Epoch +1 overfitting check', loss: 0.261, f1: 0.908, status: 'REVERTED' },
-  { experiment: 'Final: rank=32, lr=2e-4, warmup=500', loss: 0.231, f1: 0.923, status: 'KEPT' },
+  {
+    experiment: 'Decrease learning_rate 3e-4→1.5e-4 to reduce loss spikes.',
+    diff: '- learning_rate: 0.0003\n+ learning_rate: 0.00015',
+    loss: 0.289, f1: 0.871, status: 'KEPT',
+  },
+  {
+    experiment: 'Increase lora_rank 16→32 to expand model capacity for task.',
+    diff: '- lora_rank: 16\n+ lora_rank: 32',
+    loss: 0.271, f1: 0.901, status: 'KEPT',
+  },
+  {
+    experiment: 'Increase learning_rate 1.5e-4→6.1e-4 (local ±20% perturbation).',
+    diff: '- learning_rate: 0.00015\n+ learning_rate: 0.00061',
+    loss: 0.334, f1: 0.862, status: 'REVERTED',
+  },
+  {
+    experiment: 'Increase warmup_steps 100→500 to stabilize early training.',
+    diff: '- warmup_steps: 100\n+ warmup_steps: 500',
+    loss: 0.248, f1: 0.914, status: 'KEPT',
+  },
+  {
+    experiment: 'Decrease dropout 0.1→0.06 (local ±20% perturbation).',
+    diff: '- dropout: 0.1\n+ dropout: 0.06',
+    loss: 0.243, f1: 0.917, status: 'KEPT',
+  },
+  {
+    experiment: 'Increase num_epochs 3→4 to allow longer convergence.',
+    diff: '- num_epochs: 3\n+ num_epochs: 4',
+    loss: 0.261, f1: 0.908, status: 'REVERTED',
+  },
+  {
+    experiment: 'Decrease learning_rate 1.5e-4→1.2e-4 (local ±20% perturbation).',
+    diff: '- learning_rate: 0.00015\n+ learning_rate: 0.00012',
+    loss: 0.231, f1: 0.923, status: 'KEPT',
+  },
 ];
 
 export function useTrainingSimulation() {
@@ -166,17 +199,26 @@ export function useTrainingSimulation() {
         }
       }
 
-      // AutoResearch iterations during stage 4
+      // AutoResearch iterations during stage 4: appear as PENDING, then resolve
       if (stageIdx === 4) {
         const iterDelay = dur / (ITERATIONS.length + 1);
+        const resolveDelay = Math.min(iterDelay * 0.7, 800); // resolve before next appears
         ITERATIONS.forEach((iter, i) => {
+          const appearAt = stageStart + iterDelay * (i + 1);
+          // Step 1: add as PENDING
           schedule(() => {
-            const iteration: Iteration = { ...iter, id: `iter-${i}` };
+            const pending: Iteration = { ...iter, id: `iter-${i}`, status: 'PENDING' };
+            setState(prev => ({ ...prev, iterations: [pending, ...prev.iterations] }));
+          }, appearAt);
+          // Step 2: resolve to final status
+          schedule(() => {
             setState(prev => ({
               ...prev,
-              iterations: [iteration, ...prev.iterations],
+              iterations: prev.iterations.map(it =>
+                it.id === `iter-${i}` ? { ...it, status: iter.status } : it
+              ),
             }));
-          }, stageStart + iterDelay * (i + 1));
+          }, appearAt + resolveDelay);
         });
       }
 

--- a/ml-agent-frontend/src/types.ts
+++ b/ml-agent-frontend/src/types.ts
@@ -1,7 +1,7 @@
 export type StageStatus = 'pending' | 'in-progress' | 'complete';
 export type TaskType = 'classification' | 'regression' | 'fine-tuning';
 export type LogType = 'default' | 'success' | 'warning';
-export type IterationStatus = 'KEPT' | 'REVERTED';
+export type IterationStatus = 'KEPT' | 'REVERTED' | 'PENDING';
 
 export interface PipelineStage {
   id: number;
@@ -18,6 +18,7 @@ export interface MetricPoint {
 export interface Iteration {
   id: string;
   experiment: string;
+  diff?: string;
   loss: number;
   f1: number;
   status: IterationStatus;

--- a/src/autoresearch/__main__.py
+++ b/src/autoresearch/__main__.py
@@ -1,0 +1,260 @@
+"""
+CLI entry point for the PROPOSE phase of the AutoResearch Loop.
+
+── Algorithmic strategies (no API cost) ─────────────────────────────────────
+    python -m src.autoresearch --strategy random --n-iters 5
+    python -m src.autoresearch --strategy local  --n-iters 8 --seed 42
+
+── Real Claude Haiku proposals (costs ~$0.001 per iteration) ─────────────────
+    ANTHROPIC_API_KEY=sk-... python -m src.autoresearch --strategy claude --n-iters 3
+
+── Watch logs live in a second terminal ──────────────────────────────────────
+    tail -f outputs/logs/run.jsonl | python -m json.tool
+    tail -f outputs/logs/research_diary.jsonl | python -m json.tool
+
+── Inspect the diary after a run ─────────────────────────────────────────────
+    python -m src.autoresearch --show-diary
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from src.autoresearch.config import TrainingConfig
+from src.autoresearch.loop import AutoResearchLoop
+from src.autoresearch.proposer import (
+    LocalPerturbationProposalStrategy,
+    Proposal,
+    ProposalStrategy,
+    RandomSearchProposalStrategy,
+)
+from src.types import IterationRecord
+
+_DEFAULT_CONFIG = Path("configs/current.json")
+_DEFAULT_DIARY  = Path("outputs/logs/research_diary.jsonl")
+_DEFAULT_LOG    = Path("outputs/logs/run.jsonl")
+
+# ANSI
+_RESET  = "\033[0m"
+_BOLD   = "\033[1m"
+_DIM    = "\033[2m"
+_GREEN  = "\033[32m"
+_YELLOW = "\033[33m"
+_CYAN   = "\033[36m"
+_RED    = "\033[31m"
+_BLUE   = "\033[34m"
+
+
+# ─── Claude strategy wrapper ──────────────────────────────────────────────────
+
+class ClaudeProposalStrategy(ProposalStrategy):
+    """
+    Calls propose_hypothesis() (Claude Haiku) to generate each proposal.
+    Requires ANTHROPIC_API_KEY to be set in the environment.
+    """
+
+    def __init__(self, task_type: str = "text-classification", eval_metric: str = "f1") -> None:
+        self._task = {
+            "task_type": task_type,
+            "modality": "text",
+            "has_pretrained_base": True,
+            "eval_metric": eval_metric,
+            "complexity": "medium",
+        }
+
+    def propose(self, config: TrainingConfig, history: list[IterationRecord]) -> Proposal:
+        from src.autoresearch.autoresearch import propose_hypothesis
+        hypothesis = propose_hypothesis(config.to_dict(), history, self._task)
+        patch_dict = json.loads(hypothesis["patch"])
+        return Proposal(
+            hypothesis=hypothesis["description"],
+            patch=patch_dict,
+            metadata={
+                "strategy": "claude",
+                "expected_effect": hypothesis["expected_effect"],
+                "search_strategy": hypothesis["search_strategy"],
+            },
+        )
+
+
+# ─── Pretty output helpers ────────────────────────────────────────────────────
+
+def _print_header(strategy: str, n_iters: int, config_path: Path) -> None:
+    print(f"\n{_BOLD}{'═' * 68}{_RESET}")
+    print(f"{_BOLD}  AutoResearch PROPOSE Loop — Live Demo{_RESET}")
+    print(f"{'═' * 68}")
+    print(f"  strategy : {_CYAN}{strategy}{_RESET}")
+    print(f"  iters    : {_CYAN}{n_iters}{_RESET}")
+    print(f"  config   : {_DIM}{config_path}{_RESET}")
+    print(f"  diary    : {_DIM}{_DEFAULT_DIARY}{_RESET}")
+    print(f"  log      : {_DIM}{_DEFAULT_LOG}{_RESET}")
+    print(f"\n  {_DIM}Tip: run in a second terminal to watch live:{_RESET}")
+    print(f"  {_DIM}  tail -f {_DEFAULT_LOG} | python -m json.tool{_RESET}")
+    print(f"{'─' * 68}\n")
+
+
+def _print_diary_summary(diary_path: Path) -> None:
+    if not diary_path.exists():
+        return
+    lines = [l for l in diary_path.read_text().splitlines() if l.strip()]
+    if not lines:
+        return
+
+    records: list[IterationRecord] = [json.loads(l) for l in lines]
+
+    print(f"\n{'═' * 68}")
+    print(f"{_BOLD}  RESEARCH DIARY  —  {len(records)} iteration(s){_RESET}")
+    print(f"{'═' * 68}\n")
+
+    for r in records:
+        decision = r.get("decision", "PENDING")
+        if decision == "KEPT":
+            badge = f"{_GREEN}✓ KEPT    {_RESET}"
+        elif decision == "REVERTED":
+            badge = f"{_YELLOW}✗ REVERTED{_RESET}"
+        else:
+            badge = f"{_BLUE}⏳ PENDING {_RESET}"
+
+        hypothesis = r.get("hypothesis", "")
+        print(f"  [{badge}] Iter {r['iteration']:>2}  {hypothesis[:62]}")
+
+        for line in r.get("patch", "").splitlines():
+            if line.startswith("+"):
+                print(f"             {_GREEN}{line}{_RESET}")
+            elif line.startswith("-"):
+                print(f"             {_RED}{line}{_RESET}")
+
+        cost = r.get("cost_usd", 0.0)
+        notes = r.get("notes", "")
+        if cost or notes:
+            print(f"             {_DIM}cost=${cost:.4f}  {notes}{_RESET}")
+        print()
+
+    pending = sum(1 for r in records if r.get("decision") == "PENDING")
+    kept    = sum(1 for r in records if r.get("decision") == "KEPT")
+    reverted = sum(1 for r in records if r.get("decision") == "REVERTED")
+    print(f"  {_DIM}Total: {kept} KEPT  {reverted} REVERTED  {pending} PENDING{_RESET}")
+    print(f"  {_DIM}Diary written to: {_DEFAULT_DIARY}{_RESET}\n")
+
+
+def _show_diary(diary_path: Path) -> None:
+    """--show-diary mode: pretty-print the existing diary and exit."""
+    if not diary_path.exists():
+        print(f"{_RED}No diary found at {diary_path}{_RESET}")
+        sys.exit(1)
+    _print_diary_summary(diary_path)
+
+
+# ─── Argument parser ──────────────────────────────────────────────────────────
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m src.autoresearch",
+        description="Run N PROPOSE iterations of the AutoResearch Loop.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    p.add_argument(
+        "--strategy",
+        choices=["random", "local", "claude"],
+        default="random",
+        help=(
+            "'random' — sample full range (no API); "
+            "'local' — ±20%% perturbation (no API); "
+            "'claude' — real Claude Haiku proposals (requires ANTHROPIC_API_KEY)."
+        ),
+    )
+    p.add_argument(
+        "--n-iters",
+        type=int,
+        default=1,
+        metavar="N",
+        help="Number of PROPOSE iterations to run (default: 1).",
+    )
+    p.add_argument(
+        "--config",
+        type=Path,
+        default=_DEFAULT_CONFIG,
+        metavar="PATH",
+        help=f"Training config JSON (default: {_DEFAULT_CONFIG}).",
+    )
+    p.add_argument(
+        "--diary",
+        type=Path,
+        default=_DEFAULT_DIARY,
+        metavar="PATH",
+        help=f"Research diary JSONL (default: {_DEFAULT_DIARY}).",
+    )
+    p.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        metavar="INT",
+        help="Random seed for reproducible proposals (ignored with --strategy claude).",
+    )
+    p.add_argument(
+        "--perturbation",
+        type=float,
+        default=0.2,
+        metavar="FLOAT",
+        help="Perturbation factor for local strategy (default: 0.2 = ±20%%).",
+    )
+    p.add_argument(
+        "--task-type",
+        default="text-classification",
+        metavar="STR",
+        help="Task type passed to Claude (default: text-classification).",
+    )
+    p.add_argument(
+        "--show-diary",
+        action="store_true",
+        help="Pretty-print the existing research diary and exit.",
+    )
+    return p
+
+
+# ─── Entry point ──────────────────────────────────────────────────────────────
+
+def main() -> None:
+    args = _build_parser().parse_args()
+
+    if args.show_diary:
+        _show_diary(args.diary)
+        return
+
+    if args.strategy == "claude":
+        if not os.getenv("ANTHROPIC_API_KEY"):
+            print(f"{_RED}Error: ANTHROPIC_API_KEY is not set.{_RESET}")
+            print(f"Export it and re-run:")
+            print(f"  export ANTHROPIC_API_KEY=sk-ant-...")
+            sys.exit(1)
+        proposer: ProposalStrategy = ClaudeProposalStrategy(task_type=args.task_type)
+    elif args.strategy == "local":
+        proposer = LocalPerturbationProposalStrategy(
+            perturbation_factor=args.perturbation,
+            seed=args.seed,
+        )
+    else:
+        proposer = RandomSearchProposalStrategy(seed=args.seed)
+
+    _print_header(args.strategy, args.n_iters, args.config)
+
+    loop = AutoResearchLoop(
+        proposer=proposer,
+        diary_path=args.diary,
+        current_config_path=args.config,
+    )
+
+    for i in range(args.n_iters):
+        print(f"{_BOLD}{'─' * 68}{_RESET}")
+        print(f"{_BOLD}  ITERATION {i + 1} / {args.n_iters}{_RESET}")
+        print(f"{'─' * 68}")
+        loop.run_iteration()
+
+    _print_diary_summary(args.diary)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/autoresearch/autoresearch.py
+++ b/src/autoresearch/autoresearch.py
@@ -10,16 +10,27 @@ Includes the Evaluator sub-feature (create_eval_suite, run_evals, adapt_eval_sui
 
 from __future__ import annotations
 
+import json
+import math
+from pathlib import Path
 from typing import Literal
 
+import anthropic
+
+from src.observability.observability import log_event
 from src.types import (
+    AgentName,
     AutoResearchState,
+    CostBreakdown,
     DatasetResult,
     EvalScore,
     EvalSuite,
     ExperimentResult,
     Hypothesis,
     IterationRecord,
+    JobConfig,
+    JobStatus,
+    LogLevel,
     OrchestrationConfig,
     ResearchDiary,
     ScoreDelta,
@@ -29,10 +40,67 @@ from src.types import (
     TrainingPlan,
 )
 
+_DIARY_PATH = Path("outputs/logs/research_diary.jsonl")
+_CONFIG_PATH = Path("configs/current.json")  # the JSON file apply_patch/revert_patch target
+_MAX_NO_IMPROVE = 3   # halt after this many consecutive non-improving iterations
+_MAX_ITERATIONS = 20  # hard cap on total iterations regardless of improvement
+
+
+def _patch_to_diff(patch_dict: dict, current_config: dict) -> str:
+    """Build a human-readable diff string from a patch dict and the pre-patch config."""
+    lines = []
+    for key, new_val in patch_dict.items():
+        old_val = current_config.get(key, "<unset>")
+        lines.append(f"- {key}: {old_val}")
+        lines.append(f"+ {key}: {new_val}")
+    return "\n".join(lines)
+
+
+# ─── GRAPH BUILDER ────────────────────────────────────────────────────────────
 
 def build_autoresearch_graph():
     """Constructs and compiles the AutoResearch cyclic LangGraph StateGraph with checkpointer. Called once at startup."""
-    raise NotImplementedError
+    from langgraph.graph import END, StateGraph  # lazy import — not available in test environments without the dep
+
+    graph = StateGraph(AutoResearchState)
+
+    graph.add_node("init", init_node)
+    graph.add_node("baseline", baseline_node)
+    graph.add_node("propose", propose_node)
+    graph.add_node("run", run_node)
+    graph.add_node("revert_and_continue", revert_and_continue_node)
+    graph.add_node("evaluate", evaluate_node)
+    graph.add_node("keep", keep_node)
+    graph.add_node("revert", revert_node)
+    graph.add_node("log", log_node)
+
+    # Linear entry path
+    graph.set_entry_point("init")
+    graph.add_edge("init", "baseline")
+    graph.add_edge("baseline", "propose")
+
+    # Cyclic core: propose → run → (early-stop check) → evaluate → (keep/revert) → log → ...
+    graph.add_edge("propose", "run")
+    graph.add_conditional_edges(
+        "run",
+        early_stop_edge,
+        {"evaluate": "evaluate", "revert_and_continue": "revert_and_continue"},
+    )
+    graph.add_conditional_edges(
+        "evaluate",
+        decision_edge,
+        {"keep": "keep", "revert": "revert"},
+    )
+    graph.add_edge("keep", "log")
+    graph.add_edge("revert", "log")
+    graph.add_edge("revert_and_continue", "log")
+    graph.add_conditional_edges(
+        "log",
+        continue_edge,
+        {"propose": "propose", "__end__": END},
+    )
+
+    return graph.compile()
 
 
 def invoke_autoresearch_graph(
@@ -41,71 +109,416 @@ def invoke_autoresearch_graph(
     cost_manager,
 ) -> TrainedModel:
     """Entry point called by the Manager's orchestrate_node. Returns the best TrainedModel."""
-    raise NotImplementedError
+    graph = build_autoresearch_graph()
+
+    initial_state: AutoResearchState = {
+        "plan": plan,
+        "config": config,
+        "eval_suite": None,
+        "current_script": plan["training_script_path"],
+        "current_config": config["training_procedure"]["hyperparameters"],
+        "current_patch": None,
+        "last_description": None,
+        "original_content": None,
+        "diary": [],
+        "baseline_score": None,
+        "best_score": None,
+        "best_script": plan["training_script_path"],
+        "last_result": None,
+        "last_score": None,
+        "last_delta": None,
+        "iteration": 0,
+        "no_improve_streak": 0,
+        "should_stop": False,
+    }
+
+    final_state = graph.invoke(initial_state)
+
+    total_cost = sum(r["cost_usd"] for r in final_state["diary"])
+    termination = "budget_limit" if final_state["should_stop"] else "training_complete"
+    cost_breakdown: CostBreakdown = {
+        "data_gen_usd": 0.0,
+        "training_usd": total_cost,
+        "llm_calls_usd": 0.0,
+        "total_usd": total_cost,
+        "termination_reason": termination,
+    }
+
+    return {
+        "weights_path": final_state["best_script"],
+        "metrics": final_state["best_score"],
+        "cost": cost_breakdown,
+        "n_iterations": final_state["iteration"],
+        "research_diary_path": str(_DIARY_PATH),
+    }
 
 
 # ─── NODE FUNCTIONS ───────────────────────────────────────────────────────────
 
 def init_node(state: AutoResearchState) -> dict:
     """LangGraph node. Calls create_eval_suite(). Returns: { eval_suite, current_script, current_config, iteration: 0 }."""
-    raise NotImplementedError
+    task_analysis: TaskAnalysis = {
+        "task_type": state["config"]["training_procedure"]["task_type"],
+        "modality": "text",
+        "has_pretrained_base": state["plan"]["base_model"] is not None,
+        "eval_metric": state["plan"]["eval_metric"],
+        "complexity": "medium",
+    }
+    # Construct a minimal DatasetResult so create_eval_suite can derive the test path.
+    # The real dataset path comes from DataGen (F2); we point at the standard test split location.
+    script_dir = str(Path(state["plan"]["training_script_path"]).parent)
+    dataset_result: DatasetResult = {
+        "dataset": {
+            "path": script_dir,
+            "format": "jsonl",
+            "train_size": 0,
+            "val_size": 0,
+            "test_size": 0,
+        },
+        "mode_used": "A",
+        "quality_notes": "",
+        "validation_report": {
+            "passed": True,
+            "issues": [],
+            "sample_accuracy_estimate": 0.0,
+        },
+    }
+
+    eval_suite = create_eval_suite(task_analysis, dataset_result)
+
+    log_event(
+        AgentName.AUTORESEARCH,
+        LogLevel.INFO,
+        "INIT: eval suite ready",
+        metadata={
+            "primary_metric": eval_suite["primary_metric"],
+            "metrics": eval_suite["metrics"],
+            "use_llm_grading": eval_suite["use_llm_grading"],
+        },
+    )
+
+    return {
+        "eval_suite": eval_suite,
+        "current_script": state["plan"]["training_script_path"],
+        "current_config": state["config"]["training_procedure"]["hyperparameters"],
+        "iteration": 0,
+    }
 
 
 def baseline_node(state: AutoResearchState) -> dict:
     """LangGraph node. Submits and evaluates the unmodified baseline script. Returns: { baseline_score, best_score }."""
-    raise NotImplementedError
+    log_event(
+        AgentName.AUTORESEARCH,
+        LogLevel.INFO,
+        "BASELINE: submitting unmodified training script",
+    )
+
+    job_id = submit_experiment(state["plan"]["training_script_path"], state["plan"])
+    timeout = int(state["config"]["training_procedure"].get("timeout_min", 5))
+    experiment = wait_for_experiment(job_id, timeout)
+    baseline_score = run_evals(experiment["model_path"], state["eval_suite"])
+
+    log_event(
+        AgentName.AUTORESEARCH,
+        LogLevel.INFO,
+        f"BASELINE: scalar={baseline_score['scalar']:.4f}",
+        metadata={"score": baseline_score, "job_id": job_id},
+    )
+
+    return {
+        "baseline_score": baseline_score,
+        "best_score": baseline_score,
+        "best_script": state["plan"]["training_script_path"],
+        "last_result": experiment,
+    }
 
 
 def propose_node(state: AutoResearchState) -> dict:
-    """LangGraph node. Calls propose_hypothesis() and apply_patch(). Returns: { current_script, original_content, last_hypothesis }."""
-    raise NotImplementedError
+    """LangGraph node. Calls propose_hypothesis() and apply_patch(). Returns: { current_script, current_patch, last_description, original_content }."""
+    task_analysis: TaskAnalysis = {
+        "task_type": state["config"]["training_procedure"]["task_type"],
+        "modality": "text",
+        "has_pretrained_base": state["plan"]["base_model"] is not None,
+        "eval_metric": state["plan"]["eval_metric"],
+        "complexity": "medium",
+    }
+    log_event(
+        AgentName.AUTORESEARCH,
+        LogLevel.INFO,
+        f"PROPOSE: generating hypothesis for iteration {state['iteration'] + 1}",
+        metadata={"iteration": state["iteration"] + 1},
+    )
+    hypothesis = propose_hypothesis(state["current_config"], state["diary"], task_analysis)
+
+    # Bug fix: patch the config JSON, not the training script (.py files are not patchable).
+    original_content = apply_patch(str(_CONFIG_PATH), hypothesis["patch"])
+
+    log_event(
+        AgentName.AUTORESEARCH,
+        LogLevel.INFO,
+        hypothesis["description"],
+        metadata={
+            "patch": hypothesis["patch"],
+            "expected_effect": hypothesis["expected_effect"],
+            "strategy": hypothesis["search_strategy"],
+        },
+    )
+    return {
+        # current_script keeps the training script path — it is never changed by PROPOSE.
+        "current_script": state["plan"]["training_script_path"],
+        # current_patch carries the JSON patch string so log_node can build a diary entry.
+        "current_patch": hypothesis["patch"],
+        # last_description carries Claude's human-readable explanation for the diary.
+        "last_description": hypothesis["description"],
+        "original_content": original_content,
+    }
 
 
 def run_node(state: AutoResearchState) -> dict:
     """LangGraph node. Calls submit_experiment() and wait_for_experiment(). Returns: { last_result }."""
-    raise NotImplementedError
+    log_event(
+        AgentName.AUTORESEARCH,
+        LogLevel.INFO,
+        f"RUN: submitting experiment for iteration {state['iteration'] + 1}",
+        metadata={"iteration": state["iteration"] + 1},
+    )
+
+    timeout = int(state["config"]["training_procedure"].get("timeout_min", 5))
+    job_id = submit_experiment(state["plan"]["training_script_path"], state["plan"], timeout)
+    result = wait_for_experiment(job_id, timeout)
+
+    log_event(
+        AgentName.AUTORESEARCH,
+        LogLevel.INFO,
+        f"RUN: job {job_id} finished — status={result['status']}",
+        metadata={"job_id": job_id, "cost_usd": result["cost_usd"]},
+    )
+
+    return {"last_result": result}
 
 
 def revert_and_continue_node(state: AutoResearchState) -> dict:
     """LangGraph node (early stop path). Calls revert_patch(), logs REVERTED, increments iteration. Returns: { current_script, diary, iteration }."""
-    raise NotImplementedError
+    revert_patch(state["plan"]["training_script_path"], state["original_content"])
+
+    log_event(
+        AgentName.AUTORESEARCH,
+        LogLevel.WARN,
+        f"REVERTED (early-stop): catastrophic failure on iteration {state['iteration'] + 1}",
+        metadata={
+            "iteration": state["iteration"] + 1,
+            "metrics": state["last_result"]["metrics"] if state.get("last_result") else {},
+        },
+    )
+
+    # Build and persist the diary entry for this early-stopped iteration.
+    # last_result always exists here because run_node already wrote it.
+    patch_dict = json.loads(state.get("current_patch", "{}"))
+    diff = _patch_to_diff(patch_dict, state["current_config"])
+    record: IterationRecord = {
+        "iteration": state["iteration"] + 1,
+        "hypothesis": state.get("last_description", str(patch_dict)),
+        "patch": diff,
+        "cost_usd": state["last_result"]["cost_usd"],
+        "metrics": state["last_result"]["metrics"],
+        "decision": "REVERTED",
+        "notes": "Early-stopped: catastrophic failure (NaN/exploding loss/accuracy collapse)",
+    }
+    updated_diary = log_iteration(state["diary"], record)
+
+    return {
+        "current_script": state["plan"]["training_script_path"],
+        "original_content": None,
+        "last_delta": None,  # signals early-stop path to log_node
+        "diary": updated_diary,
+        "iteration": state["iteration"] + 1,
+    }
 
 
 def evaluate_node(state: AutoResearchState) -> dict:
     """LangGraph node. Calls run_evals(), compare_scores(), flag_regression(). Returns: { last_score, last_delta }."""
-    raise NotImplementedError
+    last_score = run_evals(state["last_result"]["model_path"], state["eval_suite"])
+    last_delta = compare_scores(last_score, state["baseline_score"])
+    regressed = flag_regression(last_delta)
+
+    log_event(
+        AgentName.AUTORESEARCH,
+        LogLevel.INFO,
+        f"EVALUATE: scalar={last_score['scalar']:.4f}  "
+        f"delta={last_delta['absolute']:+.4f} ({last_delta['relative_pct']:+.1f}%)"
+        + ("  ⚠ REGRESSION" if regressed else ""),
+        metadata={
+            "score": last_score,
+            "delta": last_delta,
+            "regression": regressed,
+        },
+    )
+
+    # A flagged regression forces a REVERT without waiting for decide_keep_or_revert.
+    # We express this by overwriting improved=False so decision_edge returns "revert".
+    if regressed and last_delta["improved"]:
+        last_delta = ScoreDelta(
+            absolute=last_delta["absolute"],
+            relative_pct=last_delta["relative_pct"],
+            improved=False,
+        )
+
+    return {"last_score": last_score, "last_delta": last_delta}
 
 
 def keep_node(state: AutoResearchState) -> dict:
     """LangGraph node. Updates best_score and best_script. Resets no_improve_streak. Returns: { best_score, best_script, no_improve_streak: 0 }."""
-    raise NotImplementedError
+    log_event(
+        AgentName.AUTORESEARCH,
+        LogLevel.INFO,
+        f"KEEP: new best scalar={state['last_score']['scalar']:.4f} "
+        f"(was {state['best_score']['scalar']:.4f})",
+        metadata={"iteration": state["iteration"] + 1},
+    )
+    # Bug fix: advance current_config to reflect the accepted patch so the next
+    # call to propose_hypothesis() sees the real current state, not the original baseline.
+    patch_dict = json.loads(state.get("current_patch", "{}"))
+    updated_config = {**state["current_config"], **patch_dict}
+
+    return {
+        "best_score": state["last_score"],
+        "best_script": state["plan"]["training_script_path"],
+        "current_config": updated_config,
+        "no_improve_streak": 0,
+    }
 
 
 def revert_node(state: AutoResearchState) -> dict:
     """LangGraph node. Calls revert_patch(). Increments no_improve_streak. Returns: { current_script, no_improve_streak }."""
-    raise NotImplementedError
+    revert_patch(str(_CONFIG_PATH), state["original_content"])
+
+    new_streak = state["no_improve_streak"] + 1
+    log_event(
+        AgentName.AUTORESEARCH,
+        LogLevel.INFO,
+        f"REVERT: patch rolled back — no_improve_streak={new_streak}",
+        metadata={"iteration": state["iteration"] + 1, "streak": new_streak},
+    )
+    return {
+        "current_script": state["best_script"],
+        "original_content": None,
+        "no_improve_streak": new_streak,
+    }
 
 
 def log_node(state: AutoResearchState) -> dict:
     """LangGraph node. Calls log_iteration(). Calls adapt_eval_suite() every 10 iters. Returns: { diary, eval_suite, iteration }."""
-    raise NotImplementedError
+    iteration_number = state["iteration"] + 1
+
+    # revert_and_continue_node already logged its entry and updated state["diary"].
+    # Detect that path by checking if iteration_number is already recorded.
+    already_logged = any(r["iteration"] == iteration_number for r in state["diary"])
+
+    if not already_logged:
+        # Normal path: build and persist the IterationRecord.
+        if state["last_delta"] is not None and state["last_delta"]["improved"]:
+            decision = "KEPT"
+            notes = f"+{state['last_delta']['relative_pct']:.1f}% on {state['eval_suite']['primary_metric']}"
+        else:
+            decision = "REVERTED"
+            delta_pct = state["last_delta"]["relative_pct"] if state["last_delta"] else 0.0
+            notes = f"{delta_pct:+.1f}% — no improvement"
+
+        metrics: TrainingMetrics = (
+            state["last_result"]["metrics"]
+            if state.get("last_result")
+            else {"train_loss": 0.0, "val_loss": 0.0, "test_loss": 0.0, "primary_metric": 0.0}
+        )
+        patch_dict = json.loads(state.get("current_patch", "{}"))
+        diff = _patch_to_diff(patch_dict, state["current_config"])
+        record: IterationRecord = {
+            "iteration": iteration_number,
+            "hypothesis": state.get("last_description", str(patch_dict)),
+            "patch": diff,
+            "cost_usd": state["last_result"]["cost_usd"] if state.get("last_result") else 0.0,
+            "metrics": metrics,
+            "decision": decision,
+            "notes": notes,
+        }
+        updated_diary = log_iteration(state["diary"], record)
+    else:
+        updated_diary = state["diary"]
+
+    # Every 10 iterations identify systematic weaknesses and harden the eval suite.
+    updated_suite = state["eval_suite"]
+    if iteration_number % 10 == 0:
+        recent_reverts = [
+            r for r in updated_diary[-10:]
+            if r["decision"] == "REVERTED"
+        ]
+        if recent_reverts:
+            weaknesses = [r["notes"] for r in recent_reverts]
+            updated_suite = adapt_eval_suite(state["eval_suite"], weaknesses)
+            log_event(
+                AgentName.AUTORESEARCH,
+                LogLevel.INFO,
+                f"ADAPT: eval suite updated after {iteration_number} iterations",
+                metadata={"weaknesses": weaknesses},
+            )
+
+    return {
+        "diary": updated_diary,
+        "eval_suite": updated_suite,
+        "iteration": iteration_number,
+    }
 
 
 # ─── CONDITIONAL EDGE FUNCTIONS ───────────────────────────────────────────────
 
 def early_stop_edge(state: AutoResearchState) -> Literal["evaluate", "revert_and_continue"]:
     """After run_node. Returns 'revert_and_continue' on catastrophic failure, 'evaluate' otherwise."""
-    raise NotImplementedError
+    if state["last_result"] is None:
+        return "revert_and_continue"
+    if state["last_result"]["status"] == JobStatus.FAILED:
+        return "revert_and_continue"
+    if check_early_stop(state["last_result"]["metrics"]):
+        return "revert_and_continue"
+    return "evaluate"
 
 
 def decision_edge(state: AutoResearchState) -> Literal["keep", "revert"]:
     """After evaluate_node. Calls decide_keep_or_revert(state.last_delta). Returns 'keep' or 'revert'."""
-    raise NotImplementedError
+    verdict = decide_keep_or_revert(state["last_delta"])
+    return "keep" if verdict == "KEEP" else "revert"
 
 
 def continue_edge(state: AutoResearchState) -> Literal["propose", "__end__"]:
     """After log_node. Returns '__end__' if budget exhausted / convergence, else 'propose' to loop."""
-    raise NotImplementedError
+    if state["should_stop"]:
+        return "__end__"
+
+    budget = state["config"].get("compute_budget", float("inf"))
+    spent = sum(r["cost_usd"] for r in state["diary"])
+    if spent >= budget:
+        log_event(
+            AgentName.AUTORESEARCH,
+            LogLevel.INFO,
+            f"STOP: budget exhausted (spent ${spent:.2f} of ${budget:.2f})",
+        )
+        return "__end__"
+
+    if state["no_improve_streak"] >= _MAX_NO_IMPROVE:
+        log_event(
+            AgentName.AUTORESEARCH,
+            LogLevel.INFO,
+            f"STOP: convergence — {_MAX_NO_IMPROVE} consecutive non-improving iterations",
+        )
+        return "__end__"
+
+    if state["iteration"] >= _MAX_ITERATIONS:
+        log_event(
+            AgentName.AUTORESEARCH,
+            LogLevel.INFO,
+            f"STOP: reached max iterations ({_MAX_ITERATIONS})",
+        )
+        return "__end__"
+
+    return "propose"
 
 
 # ─── PROPOSE HELPERS ──────────────────────────────────────────────────────────
@@ -116,17 +529,104 @@ def propose_hypothesis(
     task: TaskAnalysis,
 ) -> Hypothesis:
     """Calls Claude API (claude-haiku-4-5-20251001) to generate a single testable hypothesis as a code/config diff."""
-    raise NotImplementedError
+    client = anthropic.Anthropic()
+    recent = diary[-5:] if len(diary) > 5 else diary
+
+    system = (
+        "You are an ML hyperparameter optimization assistant for the AutoResearch Loop. "
+        "You propose exactly ONE config-level change per iteration, grounded in the "
+        "experiment history. Return only valid JSON — no prose, no markdown fences."
+    )
+    user = f"""Current training configuration:
+{json.dumps(current_config, indent=2)}
+
+Task:
+- type: {task['task_type']}
+- primary metric: {task['eval_metric']}
+- complexity: {task['complexity']}
+
+Recent experiment history ({len(recent)} entries):
+{json.dumps(recent, indent=2) if recent else "No history yet — this is the first iteration."}
+
+Rules:
+- Change exactly ONE hyperparameter.
+- Stay within safe bounds: learning_rate [1e-6, 1e-2], batch_size [4, 8192],
+  max_seq_length [128, 4096], lora_rank in [4,8,16,32,64,128],
+  warmup_steps [0, 2000], dropout [0, 0.5].
+- Avoid repeating a change that recently caused a REVERTED outcome.
+- Prefer evidence-based choices over random exploration when history exists.
+
+Respond with this JSON object and nothing else:
+{{
+  "description": "<one sentence: what changes and why, e.g. 'Decrease learning_rate from 3e-4 to 1e-4 to reduce loss spikes.'>",
+  "patch": {{"<param_name>": <new_value>}},
+  "expected_effect": "<one sentence: which metric should improve and by how much>",
+  "search_strategy": "<random | local | playbook>"
+}}"""
+
+    message = client.messages.create(
+        model="claude-haiku-4-5-20251001",
+        max_tokens=512,
+        messages=[{"role": "user", "content": user}],
+        system=system,
+    )
+    raw = message.content[0].text.strip()
+    # Strip accidental markdown code fences
+    if raw.startswith("```"):
+        raw = "\n".join(
+            line for line in raw.splitlines()
+            if not line.startswith("```")
+        )
+    parsed = json.loads(raw)
+    return Hypothesis(
+        description=parsed["description"],
+        patch=json.dumps(parsed["patch"]),
+        expected_effect=parsed["expected_effect"],
+        search_strategy=parsed["search_strategy"],
+    )
 
 
 def apply_patch(script_path: str, patch: str) -> str:
-    """Applies a unified diff patch to train.py. Returns original content for revert."""
-    raise NotImplementedError
+    """
+    Applies a patch to a config or script file. Returns original content for revert.
+
+    For .json files: patch is a JSON-encoded dict of key→value overrides.
+    For .py files:   patch is a unified diff string (future; requires RUN phase).
+
+    The returned string is the file's exact pre-patch content, suitable for
+    passing directly to revert_patch().
+    """
+    path = Path(script_path)
+    original = path.read_text()
+
+    if path.suffix == ".json":
+        config_dict = json.loads(original)
+        patch_dict = json.loads(patch)
+        config_dict.update(patch_dict)
+        # Write atomically via a temp file + rename so a crash mid-write
+        # never leaves a partially-written config on disk.
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(config_dict, indent=2))
+        tmp.replace(path)
+    elif path.suffix == ".py":
+        # Future: apply unified diff when RUN phase is wired up.
+        # import subprocess
+        # result = subprocess.run(["patch", script_path], input=patch, text=True, capture_output=True)
+        # if result.returncode != 0:
+        #     raise RuntimeError(f"patch failed: {result.stderr}")
+        raise NotImplementedError(
+            "Script-level patching not yet implemented. "
+            "Requires RUN phase and Tinker job submission."
+        )
+    else:
+        raise ValueError(f"Unsupported file type for patching: {path.suffix!r}")
+
+    return original
 
 
 def revert_patch(script_path: str, original_content: str) -> None:
-    """Restores train.py to its pre-patch content."""
-    raise NotImplementedError
+    """Restores script_path to its pre-patch content."""
+    Path(script_path).write_text(original_content)
 
 
 # ─── RUN HELPERS ──────────────────────────────────────────────────────────────
@@ -137,55 +637,212 @@ def submit_experiment(
     timeout_min: int = 5,
 ) -> str:
     """Submits a constrained training run to Tinker. Returns the Tinker job ID."""
-    raise NotImplementedError
+    # Translate our TrainingPlan into a Tinker JobConfig.
+    # GPU allocation is kept minimal: single A100 with the plan's time budget.
+    from src.tinker_api.tinker_api import submit_job
+
+    job_config: JobConfig = {
+        "gpu_type": "A100",
+        "num_gpus": 1,
+        "timeout_min": timeout_min,
+        "env_vars": {},
+        "output_dir": "outputs/experiments",
+    }
+    return submit_job(script_path, job_config)
 
 
 def wait_for_experiment(job_id: str, timeout_min: int) -> ExperimentResult:
     """Polls Tinker for job completion. Raises TimeoutError if timeout_min exceeded."""
-    raise NotImplementedError
+    import time
+    from src.tinker_api.tinker_api import get_job_status, get_cumulative_spend
+
+    deadline = time.time() + timeout_min * 60
+    poll_interval = 15  # seconds between status checks
+
+    while time.time() < deadline:
+        status = get_job_status(job_id)
+        if status == JobStatus.COMPLETED:
+            cost = get_cumulative_spend(job_id)
+            # Tinker writes metrics to outputs/experiments/<job_id>/metrics.json.
+            metrics_path = Path("outputs/experiments") / job_id / "metrics.json"
+            metrics: TrainingMetrics = json.loads(metrics_path.read_text())
+            model_path = str(Path("outputs/experiments") / job_id / "model")
+            return {
+                "job_id": job_id,
+                "status": status,
+                "metrics": metrics,
+                "model_path": model_path,
+                "cost_usd": cost,
+                "logs_path": str(Path("outputs/experiments") / job_id / "logs.txt"),
+            }
+        if status == JobStatus.FAILED:
+            return {
+                "job_id": job_id,
+                "status": status,
+                "metrics": {
+                    "train_loss": float("nan"),
+                    "val_loss": float("nan"),
+                    "test_loss": float("nan"),
+                    "primary_metric": 0.0,
+                },
+                "model_path": "",
+                "cost_usd": get_cumulative_spend(job_id),
+                "logs_path": str(Path("outputs/experiments") / job_id / "logs.txt"),
+            }
+        time.sleep(poll_interval)
+
+    raise TimeoutError(
+        f"Tinker job {job_id} did not finish within {timeout_min} minutes"
+    )
 
 
 def check_early_stop(metrics: TrainingMetrics) -> bool:
     """Returns True on catastrophic failure: exploding loss (>10× baseline), NaN, or accuracy collapse."""
-    raise NotImplementedError
+    for key in ("train_loss", "val_loss"):
+        val = metrics.get(key)
+        if val is not None and (math.isnan(val) or math.isinf(val)):
+            return True
+
+    train_loss = metrics.get("train_loss")
+    if train_loss is not None and train_loss > 10.0:
+        return True
+
+    primary = metrics.get("primary_metric")
+    if primary is not None and primary < 0.01:
+        return True
+
+    return False
 
 
 # ─── EVALUATE HELPERS ─────────────────────────────────────────────────────────
 
 def run_evals(model_path: str, eval_suite: EvalSuite) -> EvalScore:
     """Runs the evaluation suite against the model and returns a scalar score + per-metric breakdown."""
-    raise NotImplementedError
+    # Wire-in point for the model inference layer (transformers / PEFT / Tinker artifacts).
+    #
+    # Expected implementation:
+    #   1. Load the model from model_path (AutoModelForSequenceClassification or equivalent).
+    #   2. Load the test split from eval_suite["test_split_path"].
+    #   3. Run inference and compute each metric in eval_suite["metrics"].
+    #   4. If eval_suite["use_llm_grading"], call Claude to score free-form outputs.
+    #   5. Return EvalScore with scalar = primary metric value, metrics = per-metric dict.
+    #
+    # Blocked on: transformers model loading + Tinker artifact download (F4).
+    raise NotImplementedError(
+        "run_evals not yet implemented. "
+        "Requires model loading from Tinker artifacts and inference infrastructure."
+    )
 
 
 def compare_scores(new_score: EvalScore, baseline_score: EvalScore) -> ScoreDelta:
     """Computes relative improvement of new_score vs baseline_score on the primary eval metric."""
-    raise NotImplementedError
+    new_val = new_score["scalar"]
+    base_val = baseline_score["scalar"]
+    absolute = new_val - base_val
+    relative_pct = (absolute / base_val * 100.0) if base_val != 0.0 else 0.0
+    return {
+        "absolute": absolute,
+        "relative_pct": relative_pct,
+        "improved": absolute > 0.0,
+    }
 
 
 # ─── DECIDE HELPERS ───────────────────────────────────────────────────────────
 
 def decide_keep_or_revert(delta: ScoreDelta) -> Literal["KEEP", "REVERT"]:
     """Returns KEEP if hypothesis improved primary metric, REVERT otherwise. Ties default to REVERT."""
-    raise NotImplementedError
+    return "KEEP" if delta["improved"] else "REVERT"
 
 
 def log_iteration(diary: ResearchDiary, record: IterationRecord) -> ResearchDiary:
     """Appends an IterationRecord to the research diary and writes to disk as JSONL."""
-    raise NotImplementedError
+    _DIARY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(_DIARY_PATH, "a") as f:
+        f.write(json.dumps(record) + "\n")
+    return [*diary, record]
 
 
 # ─── EVALUATOR SUB-FEATURE ────────────────────────────────────────────────────
 
 def create_eval_suite(task: TaskAnalysis, dataset: DatasetResult) -> EvalSuite:
     """Creates the evaluation suite: selects metrics, holds out test split, optionally adds LLM-graded stress tests."""
-    raise NotImplementedError
+    # Map task type to the most informative primary metric and supporting metrics.
+    _METRIC_MAP: dict[str, tuple[str, list[str]]] = {
+        "text-classification": ("f1", ["f1", "accuracy", "precision", "recall"]),
+        "seq2seq":             ("rouge_l", ["rouge_l", "rouge_1", "bleu"]),
+        "custom":              ("accuracy", ["accuracy"]),
+    }
+    task_type = task.get("task_type", "custom")
+    primary, metrics = _METRIC_MAP.get(task_type, ("accuracy", ["accuracy"]))
+
+    # Caller-specified eval_metric overrides the default.
+    if task.get("eval_metric"):
+        primary = task["eval_metric"]
+        if primary not in metrics:
+            metrics = [primary] + metrics
+
+    # Use LLM grading for high-complexity tasks where heuristic metrics miss nuance.
+    use_llm_grading = task.get("complexity") == "high"
+
+    test_split_path = str(Path(dataset["dataset"]["path"]) / "test")
+
+    log_event(
+        AgentName.AUTORESEARCH,
+        LogLevel.INFO,
+        f"create_eval_suite: primary={primary}, llm_grading={use_llm_grading}",
+        metadata={"metrics": metrics, "test_split_path": test_split_path},
+    )
+
+    return {
+        "primary_metric": primary,
+        "metrics": metrics,
+        "test_split_path": test_split_path,
+        "use_llm_grading": use_llm_grading,
+    }
 
 
 def adapt_eval_suite(suite: EvalSuite, weaknesses: list[str]) -> EvalSuite:
     """Adds harder eval examples targeting systematic weaknesses detected across recent iterations."""
-    raise NotImplementedError
+    client = anthropic.Anthropic()
+
+    user = f"""You are an ML evaluation expert reviewing an AutoResearch experiment loop.
+
+Current eval suite:
+- primary metric: {suite['primary_metric']}
+- metrics: {suite['metrics']}
+
+Systematic weaknesses detected in recent iterations:
+{json.dumps(weaknesses, indent=2)}
+
+Which additional evaluation metrics or stress-test categories would best expose these weaknesses?
+Respond with a JSON array of short metric/category names only — no prose, no markdown:
+["metric_or_category_1", "metric_or_category_2", ...]"""
+
+    message = client.messages.create(
+        model="claude-haiku-4-5-20251001",
+        max_tokens=256,
+        messages=[{"role": "user", "content": user}],
+    )
+    raw = message.content[0].text.strip()
+    if raw.startswith("```"):
+        raw = "\n".join(line for line in raw.splitlines() if not line.startswith("```"))
+    try:
+        additions: list[str] = json.loads(raw)
+    except json.JSONDecodeError:
+        additions = []
+
+    # Merge without duplicates, preserving existing order.
+    existing = set(suite["metrics"])
+    new_metrics = suite["metrics"] + [m for m in additions if m not in existing]
+
+    return {
+        "primary_metric": suite["primary_metric"],
+        "metrics": new_metrics,
+        "test_split_path": suite["test_split_path"],
+        "use_llm_grading": True,  # always enable LLM grading once weaknesses are identified
+    }
 
 
 def flag_regression(delta: ScoreDelta, threshold: float = -0.01) -> bool:
     """Returns True if score degraded beyond threshold, triggering automatic revert."""
-    raise NotImplementedError
+    return delta["absolute"] < threshold

--- a/src/autoresearch/config.py
+++ b/src/autoresearch/config.py
@@ -1,0 +1,122 @@
+"""
+AutoResearch training configuration.
+
+TrainingConfig is the shared hyperparameter representation used by the
+Decision Engine (which produces the baseline) and the AutoResearch Loop
+(which iterates on it). apply_patch always returns a new instance so the
+original is never mutated in-place.
+
+BOUNDS is the single source of truth for what values are legal. Both
+ProposalStrategy (algorithmic sampling) and apply_patch (validation) read
+from it, so adding a new knob means editing exactly one place.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, fields
+from pathlib import Path
+from typing import Any, Optional
+
+
+# ─── SAFETY BOUNDS ────────────────────────────────────────────────────────────
+# Each entry declares how a parameter may be changed.
+# "scale" is used by sampling strategies: "log" for params that span decades
+# (lr, seq_length), "linear" otherwise.
+# "candidates" means only discrete values are allowed.
+
+BOUNDS: dict[str, dict[str, Any]] = {
+    "learning_rate":  {"min": 1e-6,  "max": 1e-2,  "scale": "log"},
+    "batch_size":     {"min": 4,     "max": 8192,   "scale": "linear", "type": int},
+    "weight_decay":   {"min": 0.0,   "max": 0.1,    "scale": "linear"},
+    "num_epochs":     {"min": 1,     "max": 100,    "scale": "linear", "type": int},
+    "max_seq_length": {"min": 128,   "max": 4096,   "scale": "log",    "type": int},
+    "lora_rank":      {"candidates": [4, 8, 16, 32, 64, 128],           "type": int},
+    "lora_alpha":     {"candidates": [8, 16, 32, 64, 128, 256],         "type": int},
+    "optimizer":      {"candidates": ["adamw", "adam", "sgd", "lion"]},
+    "warmup_steps":   {"min": 0,     "max": 2000,   "scale": "linear", "type": int},
+    "dropout":        {"min": 0.0,   "max": 0.5,    "scale": "linear"},
+}
+
+
+# ─── TRAINING CONFIG ──────────────────────────────────────────────────────────
+
+@dataclass
+class TrainingConfig:
+    """
+    Hyperparameter snapshot for one training run.
+
+    Consumed by Decision Engine to produce a baseline, then mutated by the
+    AutoResearch Loop via apply_patch(). Immutable in practice: every patch
+    returns a new instance.
+    """
+    model_name: str
+    learning_rate: float = 3e-4
+    batch_size: int = 16
+    weight_decay: float = 0.01
+    num_epochs: int = 3
+    max_seq_length: int = 512
+    lora_rank: Optional[int] = 16
+    lora_alpha: Optional[int] = 32
+    optimizer: str = "adamw"
+    warmup_steps: int = 100
+    dropout: float = 0.1
+
+    # ── Serialisation ──────────────────────────────────────────────────────
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TrainingConfig":
+        valid_keys = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in valid_keys})
+
+    @classmethod
+    def load(cls, path: Path | str) -> "TrainingConfig":
+        with open(path) as f:
+            return cls.from_dict(json.load(f))
+
+    def save(self, path: Path | str) -> None:
+        p = Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with open(p, "w") as f:
+            json.dump(self.to_dict(), f, indent=2)
+
+    # ── Patching ───────────────────────────────────────────────────────────
+
+    def apply_patch(self, patch: dict[str, Any]) -> "TrainingConfig":
+        """
+        Returns a new TrainingConfig with patch values applied and validated.
+
+        Raises ValueError if any patched value is out of bounds or wrong type.
+        Validates against BOUNDS — unknown keys are rejected to prevent silent
+        drift from the spec.
+        """
+        updated = self.to_dict()
+        for key, value in patch.items():
+            if key == "model_name":
+                updated[key] = str(value)
+                continue
+            if key not in BOUNDS:
+                raise ValueError(f"Unknown hyperparameter: {key!r}")
+            spec = BOUNDS[key]
+            # Type coercion
+            if "type" in spec:
+                value = spec["type"](value)
+            # Discrete candidates
+            if "candidates" in spec and value not in spec["candidates"]:
+                raise ValueError(
+                    f"{key}={value!r} not in allowed candidates {spec['candidates']}"
+                )
+            # NaN is not a valid hyperparameter value — reject before bound checks
+            # because NaN comparisons always return False, letting it silently pass.
+            if isinstance(value, float) and (value != value):  # NaN check
+                raise ValueError(f"{key}: NaN is not a valid hyperparameter value")
+            # Continuous bounds
+            if "min" in spec and value < spec["min"]:
+                raise ValueError(f"{key}={value} is below minimum {spec['min']}")
+            if "max" in spec and value > spec["max"]:
+                raise ValueError(f"{key}={value} is above maximum {spec['max']}")
+            updated[key] = value
+        return TrainingConfig.from_dict(updated)

--- a/src/autoresearch/diff_utils.py
+++ b/src/autoresearch/diff_utils.py
@@ -1,0 +1,64 @@
+"""
+Diff utilities for the AutoResearch Loop.
+
+format_patch_as_diff produces a git-style one-parameter diff string that
+goes into the ResearchDiary's `patch` field. Currently this is a config-level
+diff (JSON key/value), not a textual diff of train.py — consistent with the
+PROPOSE-only phase.
+
+Design note: the diff string is intentionally human-readable and minimal.
+When RUN is wired up and patches can touch train.py directly, extend
+format_script_diff below to produce a real unified diff.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.autoresearch.config import TrainingConfig
+
+
+def format_patch_as_diff(patch: dict[str, Any], old_config: TrainingConfig) -> str:
+    """
+    Returns a git-style config diff, e.g.
+
+      - learning_rate: 0.0003
+      + learning_rate: 0.00015
+
+    Each changed key gets its own - / + line pair. The string is stored in
+    ResearchDiary.patch and is sufficient to reproduce the experiment later.
+    """
+    lines: list[str] = []
+    config_dict = old_config.to_dict()
+    for key, new_val in patch.items():
+        old_val = config_dict.get(key, "<unset>")
+        lines.append(f"- {key}: {old_val}")
+        lines.append(f"+ {key}: {new_val}")
+    return "\n".join(lines)
+
+
+def parse_diff_to_patch(diff: str) -> dict[str, Any]:
+    """
+    Inverse of format_patch_as_diff. Parses the + lines to reconstruct the
+    patch dict. Used by the DECIDE phase to re-apply or replay changes.
+    """
+    patch: dict[str, Any] = {}
+    for line in diff.splitlines():
+        if not line.startswith("+ "):
+            continue
+        key, sep, raw_val = line[2:].partition(": ")
+        key = key.strip()
+        if not key or not sep:   # guard against malformed "+" lines with no ": "
+            continue
+        raw_val = raw_val.strip()
+        # Best-effort type inference: try int, float, then leave as string.
+        # int must be tried before float to preserve integer types.
+        for coerce in (int, float):
+            try:
+                patch[key] = coerce(raw_val)
+                break
+            except ValueError:
+                pass
+        else:
+            patch[key] = raw_val
+    return patch

--- a/src/autoresearch/loop.py
+++ b/src/autoresearch/loop.py
@@ -1,0 +1,245 @@
+"""
+AutoResearchLoop — PROPOSE-phase scaffold.
+
+Orchestrates one iteration of the PROPOSE step:
+  1. Load current TrainingConfig from disk.
+  2. Load recent ResearchDiary history.
+  3. Call ProposalStrategy.propose() → Proposal.
+  4. apply_patch() to produce a candidate TrainingConfig.
+  5. format_patch_as_diff() for human-readable logging.
+  6. Append a PENDING diary entry to outputs/logs/research_diary.jsonl.
+  7. Emit structured logs via Observability (F5).
+
+RUN / EVALUATE / DECIDE are stubbed with explicit TODO docstrings that
+reference the Tinker API (F4), the Evaluator sub-feature, and the Cost
+Manager so future implementers know exactly what to wire in.
+
+Relationship to the LangGraph graph (autoresearch.py):
+  This loop is the CLI-runnable scaffold used for testing the PROPOSE
+  infra in isolation. The full LangGraph graph (build_autoresearch_graph)
+  will call propose_node → run_node → evaluate_node → decide_node → log_node
+  in a cycle. propose_node internally calls propose_hypothesis() which uses
+  Claude; this scaffold uses ProposalStrategy directly (no API cost).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from src.autoresearch.config import TrainingConfig
+from src.autoresearch.diff_utils import format_patch_as_diff
+from src.autoresearch.proposer import ProposalStrategy
+from src.observability.observability import log_event
+from src.types import AgentName, IterationRecord, LogLevel
+
+_HISTORY_WINDOW = 10
+
+
+class AutoResearchLoop:
+    """
+    Thin orchestrator for the AutoResearch PROPOSE phase.
+
+    Initialised with a ProposalStrategy and two paths (diary, config).
+    Call run_iteration() to run one PROPOSE step.
+    """
+
+    def __init__(
+        self,
+        proposer: ProposalStrategy,
+        diary_path: Path,
+        current_config_path: Path,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self.proposer = proposer
+        self.diary_path = Path(diary_path)
+        self.current_config_path = Path(current_config_path)
+        self.logger = logger or logging.getLogger("autoresearch.loop")
+        self.diary_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # PROPOSE (implemented)
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def run_iteration(self) -> None:
+        """
+        Run a single PROPOSE-phase iteration.
+
+        Side effects:
+          - Appends one PENDING IterationRecord to research_diary.jsonl.
+          - Appends one LogEntry to outputs/logs/run.jsonl.
+          - Prints colored status to stdout.
+        """
+        config = TrainingConfig.load(self.current_config_path)
+        history = self._load_history()
+        iteration = len(history) + 1
+
+        log_event(
+            AgentName.AUTORESEARCH,
+            LogLevel.INFO,
+            f"Starting iteration {iteration}",
+            metadata={
+                "iteration": iteration,
+                "strategy": type(self.proposer).__name__,
+            },
+        )
+
+        proposal = self.proposer.propose(config, history)
+
+        if not proposal.patch:
+            raise ValueError(
+                f"{type(self.proposer).__name__}.propose() returned an empty patch. "
+                "Every proposal must change at least one hyperparameter."
+            )
+
+        # Validate the patch before writing anything
+        candidate = config.apply_patch(proposal.patch)
+        diff = format_patch_as_diff(proposal.patch, config)
+
+        entry = self._make_pending_entry(iteration, proposal.hypothesis, diff)
+        self._append_diary(entry)
+
+        param = next(iter(proposal.patch))
+        new_val = proposal.patch[param]
+
+        log_event(
+            AgentName.AUTORESEARCH,
+            LogLevel.INFO,
+            f"Iteration {iteration}: {proposal.hypothesis}",
+            metadata={
+                "iteration": iteration,
+                "param": param,
+                "old_value": getattr(config, param, None),
+                "new_value": new_val,
+                "strategy": proposal.metadata.get("strategy"),
+                "seed": proposal.metadata.get("seed"),
+                "candidate_config": candidate.to_dict(),
+            },
+        )
+
+        # Human-readable stdout summary (in addition to structured log)
+        print(f"\n[AutoResearch] Iteration {iteration}: Testing {param}={new_val}")
+        print(f"[AutoResearch] Hypothesis: {proposal.hypothesis}")
+        print(f"[AutoResearch] Patch: {json.dumps(proposal.patch)}")
+        print(f"[AutoResearch] Diff:\n{diff}\n")
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # RUN (stub)
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def run_experiment(self, config: TrainingConfig) -> None:
+        """
+        TODO: Submit job to Tinker and block until completion.
+
+        Not implemented in the PROPOSE-only phase.
+
+        When RUN is ready, this should:
+          1. Serialise config to a temp JSON and pass to tinker_api.submit_job().
+          2. Poll tinker_api.get_job_status(job_id) until COMPLETED or FAILED.
+          3. Respect Cost Manager (F4): if CostManager signals budget exceeded,
+             call tinker_api.cancel_job(job_id) and raise BudgetExceededError.
+          4. Return ExperimentResult (job_id, metrics, model_path, cost_usd).
+
+        See: src/tinker_api/tinker_api.py, src/cost_manager/cost_manager.py.
+        """
+        raise NotImplementedError(
+            "run_experiment not yet implemented. Requires Tinker job submission (F4)."
+        )
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # EVALUATE (stub)
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def evaluate_experiment(self, experiment_result: Any) -> None:
+        """
+        TODO: Use the Evaluator sub-feature to compute metrics and a scalar score.
+
+        Not implemented in the PROPOSE-only phase.
+
+        When EVALUATE is ready, this should:
+          1. Call autoresearch.run_evals(model_path, eval_suite) → EvalScore.
+          2. Call autoresearch.compare_scores(new_score, baseline_score) → ScoreDelta.
+          3. Call autoresearch.flag_regression(delta) — if True, skip DECIDE and revert.
+          4. Return (EvalScore, ScoreDelta) for pass to decide().
+
+        See: src/autoresearch/autoresearch.py — run_evals, compare_scores, flag_regression.
+        """
+        raise NotImplementedError(
+            "evaluate_experiment not yet implemented. Requires Evaluator sub-feature."
+        )
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # DECIDE (stub)
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def decide(self, score_delta: Any, diary_entry: IterationRecord) -> None:
+        """
+        TODO: Decide KEPT/REVERTED, merge diffs, update research diary and current config.
+
+        Not implemented in the PROPOSE-only phase.
+
+        When DECIDE is ready, this should:
+          1. Call autoresearch.decide_keep_or_revert(delta) → 'KEEP' | 'REVERT'.
+          2. If KEEP:
+               - Overwrite configs/current.json with candidate config.
+               - Update diary entry decision field from PENDING → KEPT.
+          3. If REVERT:
+               - Call autoresearch.revert_patch(script_path, original_content).
+               - Update diary entry decision field from PENDING → REVERTED.
+          4. Log outcome with AgentName.AUTORESEARCH and full metrics metadata.
+
+        See: src/autoresearch/autoresearch.py — decide_keep_or_revert, revert_patch.
+             src/autoresearch/diff_utils.py — parse_diff_to_patch (for replay).
+        """
+        raise NotImplementedError(
+            "decide not yet implemented. Requires EVALUATE phase and Cost Manager (F4)."
+        )
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Private helpers
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def _load_history(self) -> list[IterationRecord]:
+        """Load the last _HISTORY_WINDOW entries from the diary. Skips corrupted lines."""
+        if not self.diary_path.exists():
+            return []
+        entries: list[IterationRecord] = []
+        with open(self.diary_path) as f:
+            for lineno, line in enumerate(f, 1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entries.append(json.loads(line))
+                except json.JSONDecodeError:
+                    self.logger.warning(
+                        "Skipping corrupted diary line %d in %s",
+                        lineno,
+                        self.diary_path,
+                    )
+        return entries[-_HISTORY_WINDOW:]
+
+    def _make_pending_entry(
+        self, iteration: int, hypothesis: str, diff: str
+    ) -> IterationRecord:
+        return {
+            "iteration": iteration,
+            "hypothesis": hypothesis,
+            "patch": diff,
+            "cost_usd": 0.0,
+            "metrics": {
+                "train_loss": None,   # type: ignore[typeddict-item]
+                "val_loss": None,     # type: ignore[typeddict-item]
+                "test_loss": None,    # type: ignore[typeddict-item]
+                "primary_metric": None,  # type: ignore[typeddict-item]
+            },
+            "decision": "PENDING",
+            "notes": f"Proposed at {datetime.now(timezone.utc).isoformat()}",
+        }
+
+    def _append_diary(self, entry: IterationRecord) -> None:
+        with open(self.diary_path, "a") as f:
+            f.write(json.dumps(entry) + "\n")

--- a/src/autoresearch/proposer.py
+++ b/src/autoresearch/proposer.py
@@ -1,0 +1,251 @@
+"""
+Proposal strategies for the PROPOSE phase of the AutoResearch Loop.
+
+Two concrete strategies are provided:
+
+  RandomSearchProposalStrategy
+    Samples one tunable parameter uniformly (or log-uniformly) within its
+    safe range, independent of history. Useful early in the search when
+    there is little prior information.
+
+  LocalPerturbationProposalStrategy
+    Applies a small ±perturbation around the current best config. Biases
+    away from parameters that recently caused REVERTED entries, so the loop
+    spends less time re-testing known-bad directions.
+
+Both strategies are pure algorithmic — no Claude API calls — so they are
+cheap, fast, and deterministic given a seed. The LangGraph propose_node
+uses Claude (propose_hypothesis in autoresearch.py) for richer reasoning;
+these strategies are used by the CLI scaffold (AutoResearchLoop in loop.py)
+and can also be composed with the Claude path.
+"""
+
+from __future__ import annotations
+
+import abc
+import json
+import math
+import random
+from dataclasses import dataclass, field
+from typing import Any
+
+from src.autoresearch.config import BOUNDS, TrainingConfig
+from src.types import IterationRecord
+
+
+# ─── PROPOSAL DATACLASS ───────────────────────────────────────────────────────
+
+@dataclass
+class Proposal:
+    """
+    Atomic config-level proposal from a ProposalStrategy.
+
+    hypothesis: natural-language description of the change and its rationale.
+    patch:      dict with exactly one key — the parameter being changed.
+    target:     what is being patched (always "training_config" for now;
+                "training_script" will be used once train.py patching is wired in).
+    metadata:   strategy name, seed, and any strategy-specific context for
+                diary logging and reproducibility.
+    """
+    hypothesis: str
+    patch: dict[str, Any]
+    target: str = "training_config"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+# ─── SEARCH SPACE ─────────────────────────────────────────────────────────────
+
+class SearchSpace:
+    """
+    Declares which parameters are tunable and how to sample or perturb them.
+
+    Reads directly from BOUNDS in config.py so adding a new hyperparameter
+    there automatically makes it available for exploration here.
+    """
+
+    # Parameters the proposer should never touch
+    NON_TUNABLE: frozenset[str] = frozenset({"model_name"})
+
+    @classmethod
+    def tunable_params(cls) -> list[str]:
+        return [k for k in BOUNDS if k not in cls.NON_TUNABLE]
+
+    @classmethod
+    def sample_value(cls, param: str, rng: random.Random) -> Any:
+        """Sample a value for param from its full allowed range."""
+        spec = BOUNDS[param]
+        if "candidates" in spec:
+            return rng.choice(spec["candidates"])
+        lo, hi = spec["min"], spec["max"]
+        if spec.get("scale") == "log":
+            val = math.exp(rng.uniform(math.log(lo), math.log(hi)))
+        else:
+            val = rng.uniform(lo, hi)
+        if spec.get("type") == int:
+            val = int(round(val))
+        return val
+
+    @classmethod
+    def perturb_value(cls, param: str, current: Any, factor: float, rng: random.Random) -> Any:
+        """
+        Apply a multiplicative ±factor perturbation around current, clamped to bounds.
+
+        For discrete candidates, moves one step up or down the ordered list.
+        If current is None (e.g. lora_rank=None meaning LoRA is disabled),
+        falls back to sampling a fresh value from the full range.
+        """
+        spec = BOUNDS[param]
+        if "candidates" in spec:
+            candidates = spec["candidates"]
+            if current is None:
+                return rng.choice(candidates)
+            try:
+                idx = candidates.index(current)
+            except ValueError:
+                idx = 0
+            delta = rng.choice([-1, 0, 1])
+            new_idx = max(0, min(len(candidates) - 1, idx + delta))
+            return candidates[new_idx]
+        # current=None or current=0 with a multiplicative scheme would get stuck;
+        # fall back to sampling from the full range in those cases.
+        if current is None or current == 0:
+            return cls.sample_value(param, rng)
+        multiplier = 1.0 + rng.uniform(-factor, factor)
+        val = current * multiplier
+        lo = spec.get("min", val)
+        hi = spec.get("max", val)
+        val = max(lo, min(hi, val))
+        if spec.get("type") == int:
+            val = int(round(val))
+        return val
+
+
+# ─── ABSTRACT BASE ────────────────────────────────────────────────────────────
+
+class ProposalStrategy(abc.ABC):
+    """
+    Abstract base for all proposal strategies.
+
+    Each concrete strategy must implement propose(), which takes the current
+    best TrainingConfig and the recent diary history and returns an atomic
+    Proposal changing exactly one hyperparameter.
+    """
+
+    @abc.abstractmethod
+    def propose(
+        self,
+        config: TrainingConfig,
+        history: list[IterationRecord],
+    ) -> Proposal:
+        ...
+
+
+# ─── RANDOM SEARCH ────────────────────────────────────────────────────────────
+
+class RandomSearchProposalStrategy(ProposalStrategy):
+    """
+    Samples one tunable parameter uniformly (or log-uniformly) within its
+    allowed range, independent of history.
+
+    Best for early exploration when there is little prior signal. The seed
+    stored in Proposal.metadata makes any iteration reproducible.
+    """
+
+    def __init__(self, seed: int | None = None) -> None:
+        # _next_seed advances on each call so a fixed initial seed still
+        # produces a distinct proposal every iteration.
+        self._next_seed = seed
+        self._initial_seed = seed
+
+    def propose(self, config: TrainingConfig, history: list[IterationRecord]) -> Proposal:
+        if self._next_seed is not None:
+            seed = self._next_seed
+            self._next_seed = (self._next_seed + 1) % (2**32)
+        else:
+            seed = random.randint(0, 2**32 - 1)
+        rng = random.Random(seed)
+        param = rng.choice(SearchSpace.tunable_params())
+        old_val = getattr(config, param, None)
+        new_val = SearchSpace.sample_value(param, rng)
+        hypothesis = (
+            f"Change {param} from {old_val} to {new_val} via random search "
+            f"to explore a different region of the hyperparameter space."
+        )
+        return Proposal(
+            hypothesis=hypothesis,
+            patch={param: new_val},
+            metadata={"strategy": "random_search", "seed": seed, "param": param},
+        )
+
+
+# ─── LOCAL PERTURBATION ───────────────────────────────────────────────────────
+
+class LocalPerturbationProposalStrategy(ProposalStrategy):
+    """
+    Applies a small ±perturbation around the current best config.
+
+    Uses recent diary history to bias the choice of parameter: parameters
+    that recently caused REVERTED entries are deprioritised, so the strategy
+    naturally avoids re-testing known-bad directions.
+
+    perturbation_factor: relative magnitude of the perturbation, e.g.
+        0.2 means ±20% of the current value.
+    history_window: how many recent diary entries to consider for bias.
+    """
+
+    def __init__(
+        self,
+        perturbation_factor: float = 0.2,
+        seed: int | None = None,
+        history_window: int = 5,
+    ) -> None:
+        self._factor = perturbation_factor
+        self._next_seed = seed
+        self._window = history_window
+
+    def propose(self, config: TrainingConfig, history: list[IterationRecord]) -> Proposal:
+        if self._next_seed is not None:
+            seed = self._next_seed
+            self._next_seed = (self._next_seed + 1) % (2**32)
+        else:
+            seed = random.randint(0, 2**32 - 1)
+        rng = random.Random(seed)
+        candidates = SearchSpace.tunable_params()
+
+        # Collect params that appeared in recently REVERTED patches.
+        # The diary "patch" field is a diff string (format_patch_as_diff output),
+        # not JSON — extract changed keys by parsing "+ key: value" lines.
+        regressed: set[str] = set()
+        for entry in history[-self._window:]:
+            if entry.get("decision") == "REVERTED":
+                for line in entry.get("patch", "").splitlines():
+                    if line.startswith("+ "):
+                        key = line[2:].partition(":")[0].strip()
+                        if key:
+                            regressed.add(key)
+
+        preferred = [p for p in candidates if p not in regressed] or candidates
+        param = rng.choice(preferred)
+        old_val = getattr(config, param, None)
+        new_val = SearchSpace.perturb_value(param, old_val, self._factor, rng)
+
+        direction = "increase" if (
+            isinstance(new_val, (int, float)) and isinstance(old_val, (int, float))
+            and new_val > old_val
+        ) else "decrease"
+        hypothesis = (
+            f"{direction.capitalize()} {param} from {old_val} to {new_val} "
+            f"(local ±{int(self._factor * 100)}% perturbation) "
+            f"to refine the current best configuration."
+        )
+        return Proposal(
+            hypothesis=hypothesis,
+            patch={param: new_val},
+            metadata={
+                "strategy": "local_perturbation",
+                "seed": seed,
+                "param": param,
+                "factor": self._factor,
+                "regressed_params": list(regressed),
+            },
+        )

--- a/src/observability/observability.py
+++ b/src/observability/observability.py
@@ -4,11 +4,36 @@ Owner: Team
 
 Shared utility module — every agent imports and calls log_event().
 No agent writes to stdout or disk directly.
+
+Designed so swapping to a fully structured JSON-only handler later is a
+one-line change: replace emit_cli with a JSON-only emitter and nothing else
+changes.
 """
 
 from __future__ import annotations
 
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
 from src.types import LogEntry
+
+# ANSI color codes by agent name
+_AGENT_COLORS: dict[str, str] = {
+    "Manager":        "\033[34m",   # blue
+    "DataGen":        "\033[36m",   # cyan
+    "DecisionEngine": "\033[35m",   # magenta
+    "AutoResearch":   "\033[33m",   # yellow
+    "CostManager":    "\033[31m",   # red
+    "TinkerAPI":      "\033[32m",   # green
+}
+_LEVEL_COLORS: dict[str, str] = {
+    "INFO":  "\033[37m",   # white
+    "WARN":  "\033[33m",   # yellow
+    "ERROR": "\033[31m",   # red
+}
+_RESET = "\033[0m"
 
 
 def log_event(
@@ -19,24 +44,43 @@ def log_event(
     log_path: str = "outputs/logs/run.jsonl",
 ) -> None:
     """Central logging function called by every agent. Writes JSON to disk and colored line to stdout."""
-    raise NotImplementedError
+    entry: LogEntry = {
+        "agent": agent,
+        "level": level,
+        "message": message,
+        "metadata": metadata,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    emit_cli(entry)
+    write_json_log(entry, log_path)
 
 
 def format_cli_line(entry: LogEntry) -> str:
-    """Returns formatted CLI string: [AgentName] message."""
-    raise NotImplementedError
+    """Returns formatted CLI string: [AgentName] LEVEL timestamp — message."""
+    agent_color = _AGENT_COLORS.get(entry["agent"], "")
+    level_color = _LEVEL_COLORS.get(entry["level"], "")
+    ts = entry["timestamp"][:19].replace("T", " ")
+    return (
+        f"{agent_color}[{entry['agent']}]{_RESET} "
+        f"{level_color}{entry['level']}{_RESET} "
+        f"{ts} — {entry['message']}"
+    )
 
 
 def emit_cli(entry: LogEntry) -> None:
     """Prints the formatted CLI line to stdout with ANSI color coding by agent and level."""
-    raise NotImplementedError
+    print(format_cli_line(entry), file=sys.stdout, flush=True)
 
 
 def write_json_log(entry: LogEntry, log_path: str) -> None:
     """Appends the LogEntry as a JSON line to the structured log file."""
-    raise NotImplementedError
+    path = Path(log_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a") as f:
+        f.write(json.dumps(entry) + "\n")
 
 
 def get_budget_display(spent: float, budget: float) -> str:
     """Returns a formatted budget string. e.g. 'Spend: $9.20 / $50.00 (18% used)'."""
-    raise NotImplementedError
+    pct = (spent / budget * 100) if budget > 0 else 0.0
+    return f"Spend: ${spent:.2f} / ${budget:.2f} ({pct:.0f}% used)"

--- a/src/types.py
+++ b/src/types.py
@@ -271,8 +271,10 @@ class AutoResearchState(TypedDict):
     plan: TrainingPlan
     config: OrchestrationConfig
     eval_suite: EvalSuite | None
-    current_script: str
-    current_config: dict
+    current_script: str        # path to the training script (never mutated by PROPOSE)
+    current_config: dict       # live hyperparams; updated by keep_node after each KEPT patch
+    current_patch: str | None  # JSON-encoded patch from the last propose_node call
+    last_description: str | None  # Claude's human-readable hypothesis for the diary
     original_content: str | None
     diary: ResearchDiary
     baseline_score: EvalScore | None

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -1,59 +1,300 @@
 """Tests for Feature 3 — AutoResearch Loop (owner: Matthew Torre, Hayley Antczak)"""
 
+import json
+import math
+from pathlib import Path
+
 import pytest
+
 from src.autoresearch.autoresearch import (
-    build_autoresearch_graph,
-    propose_hypothesis,
     apply_patch,
-    revert_patch,
     check_early_stop,
     compare_scores,
-    decide_keep_or_revert,
-    log_iteration,
-    create_eval_suite,
-    adapt_eval_suite,
-    flag_regression,
-    early_stop_edge,
-    decision_edge,
     continue_edge,
+    create_eval_suite,
+    decide_keep_or_revert,
+    flag_regression,
+    log_iteration,
+    revert_patch,
 )
+from src.autoresearch.config import TrainingConfig
 
+
+# ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def base_config():
+    return TrainingConfig(model_name="distilbert-base-uncased")
+
+
+@pytest.fixture
+def config_file(tmp_path, base_config):
+    p = tmp_path / "current.json"
+    base_config.save(p)
+    return p
+
+
+def _minimal_task():
+    return {
+        "task_type": "text-classification",
+        "modality": "text",
+        "has_pretrained_base": True,
+        "eval_metric": "f1",
+        "complexity": "medium",
+    }
+
+
+def _minimal_dataset(path="/tmp/data"):
+    return {
+        "dataset": {
+            "path": path,
+            "format": "jsonl",
+            "train_size": 1000,
+            "val_size": 100,
+            "test_size": 100,
+        },
+        "mode_used": "A",
+        "quality_notes": "",
+        "validation_report": {"passed": True, "issues": [], "sample_accuracy_estimate": 0.9},
+    }
+
+
+# ─── build_autoresearch_graph ─────────────────────────────────────────────────
 
 def test_build_autoresearch_graph_returns_compiled_graph():
-    raise NotImplementedError
+    # langgraph may not be installed in CI; skip gracefully
+    pytest.importorskip("langgraph", reason="langgraph not installed")
+    from src.autoresearch.autoresearch import build_autoresearch_graph
+    graph = build_autoresearch_graph()
+    assert graph is not None
 
 
-def test_apply_patch_and_revert_patch_are_inverses():
-    raise NotImplementedError
+# ─── apply_patch / revert_patch ───────────────────────────────────────────────
 
+def test_apply_patch_and_revert_patch_are_inverses(config_file, base_config):
+    original = apply_patch(str(config_file), json.dumps({"batch_size": 64}))
+    assert TrainingConfig.load(config_file).batch_size == 64
+    revert_patch(str(config_file), original)
+    assert TrainingConfig.load(config_file).batch_size == base_config.batch_size
+
+
+# ─── check_early_stop ─────────────────────────────────────────────────────────
 
 def test_check_early_stop_true_on_nan_loss():
-    raise NotImplementedError
+    metrics = {
+        "train_loss": float("nan"),
+        "val_loss": 0.3,
+        "test_loss": 0.35,
+        "primary_metric": 0.88,
+    }
+    assert check_early_stop(metrics) is True
+
+
+def test_check_early_stop_true_on_inf_loss():
+    metrics = {
+        "train_loss": float("inf"),
+        "val_loss": 0.3,
+        "test_loss": 0.35,
+        "primary_metric": 0.88,
+    }
+    assert check_early_stop(metrics) is True
+
+
+def test_check_early_stop_true_on_exploding_loss():
+    metrics = {
+        "train_loss": 15.0,
+        "val_loss": 14.0,
+        "test_loss": 14.5,
+        "primary_metric": 0.10,
+    }
+    assert check_early_stop(metrics) is True
+
+
+def test_check_early_stop_true_on_accuracy_collapse():
+    metrics = {
+        "train_loss": 0.4,
+        "val_loss": 0.45,
+        "test_loss": 0.50,
+        "primary_metric": 0.001,
+    }
+    assert check_early_stop(metrics) is True
 
 
 def test_check_early_stop_false_on_normal_metrics():
-    raise NotImplementedError
+    metrics = {
+        "train_loss": 0.32,
+        "val_loss": 0.38,
+        "test_loss": 0.40,
+        "primary_metric": 0.87,
+    }
+    assert check_early_stop(metrics) is False
 
+
+# ─── compare_scores ───────────────────────────────────────────────────────────
 
 def test_compare_scores_improved_flag():
-    raise NotImplementedError
+    new_score = {"scalar": 0.90, "metrics": {}, "critique": ""}
+    baseline  = {"scalar": 0.85, "metrics": {}, "critique": ""}
+    delta = compare_scores(new_score, baseline)
+    assert delta["improved"] is True
+    assert delta["absolute"] == pytest.approx(0.05, abs=1e-9)
+    assert delta["relative_pct"] == pytest.approx(5.88, abs=0.01)
 
+
+def test_compare_scores_not_improved_when_lower():
+    new_score = {"scalar": 0.80, "metrics": {}, "critique": ""}
+    baseline  = {"scalar": 0.85, "metrics": {}, "critique": ""}
+    delta = compare_scores(new_score, baseline)
+    assert delta["improved"] is False
+
+
+def test_compare_scores_tie_not_improved():
+    score = {"scalar": 0.85, "metrics": {}, "critique": ""}
+    delta = compare_scores(score, score)
+    assert delta["improved"] is False
+    assert delta["absolute"] == pytest.approx(0.0)
+
+
+# ─── decide_keep_or_revert ────────────────────────────────────────────────────
 
 def test_decide_keep_or_revert_tie_defaults_to_revert():
-    raise NotImplementedError
+    delta = {"absolute": 0.0, "relative_pct": 0.0, "improved": False}
+    assert decide_keep_or_revert(delta) == "REVERT"
 
+
+def test_decide_keep_or_revert_positive_keeps():
+    delta = {"absolute": 0.03, "relative_pct": 3.0, "improved": True}
+    assert decide_keep_or_revert(delta) == "KEEP"
+
+
+def test_decide_keep_or_revert_negative_reverts():
+    delta = {"absolute": -0.02, "relative_pct": -2.0, "improved": False}
+    assert decide_keep_or_revert(delta) == "REVERT"
+
+
+# ─── flag_regression ──────────────────────────────────────────────────────────
 
 def test_flag_regression_triggers_below_threshold():
-    raise NotImplementedError
+    delta = {"absolute": -0.05, "relative_pct": -5.0, "improved": False}
+    assert flag_regression(delta) is True
 
 
-def test_log_iteration_appends_to_diary():
-    raise NotImplementedError
+def test_flag_regression_does_not_trigger_above_threshold():
+    delta = {"absolute": 0.02, "relative_pct": 2.0, "improved": True}
+    assert flag_regression(delta) is False
+
+
+def test_flag_regression_at_boundary_is_not_triggered():
+    # absolute == threshold: strict < means no flag
+    delta = {"absolute": -0.01, "relative_pct": -1.0, "improved": False}
+    assert flag_regression(delta, threshold=-0.01) is False
+
+
+# ─── log_iteration ────────────────────────────────────────────────────────────
+
+def test_log_iteration_appends_to_diary(tmp_path, monkeypatch):
+    # Redirect the diary path to a temp location
+    import src.autoresearch.autoresearch as ar
+    original_path = ar._DIARY_PATH
+    ar._DIARY_PATH = tmp_path / "diary.jsonl"
+
+    try:
+        record = {
+            "iteration": 1,
+            "hypothesis": "Decrease lr to reduce loss spikes.",
+            "patch": "- learning_rate: 0.0003\n+ learning_rate: 0.00015",
+            "cost_usd": 0.0,
+            "metrics": {"train_loss": 0.3, "val_loss": 0.35,
+                        "test_loss": 0.38, "primary_metric": 0.88},
+            "decision": "KEPT",
+            "notes": "+5% on f1",
+        }
+        updated = log_iteration([], record)
+        assert len(updated) == 1
+        assert updated[0]["decision"] == "KEPT"
+
+        lines = [l for l in ar._DIARY_PATH.read_text().splitlines() if l.strip()]
+        assert len(lines) == 1
+        parsed = json.loads(lines[0])
+        assert parsed["iteration"] == 1
+    finally:
+        ar._DIARY_PATH = original_path
+
+
+def test_log_iteration_returns_extended_diary(tmp_path, monkeypatch):
+    import src.autoresearch.autoresearch as ar
+    original_path = ar._DIARY_PATH
+    ar._DIARY_PATH = tmp_path / "diary.jsonl"
+
+    try:
+        existing = [{"iteration": 1, "hypothesis": "x", "patch": "",
+                     "cost_usd": 0.0, "metrics": {}, "decision": "KEPT", "notes": ""}]
+        new_record = {**existing[0], "iteration": 2, "decision": "REVERTED"}
+        result = log_iteration(existing, new_record)
+        assert len(result) == 2
+        assert result[-1]["iteration"] == 2
+    finally:
+        ar._DIARY_PATH = original_path
+
+
+# ─── continue_edge ────────────────────────────────────────────────────────────
+
+def _make_state(**overrides):
+    base = {
+        "plan": {"training_script_path": "train.py", "base_model": None,
+                 "lora_config": None, "estimated_cost": 0.0,
+                 "estimated_time_min": 5, "eval_metric": "f1"},
+        "config": {"compute_budget": 50.0, "prompt": "", "data": False,
+                   "training_procedure": {"task_type": "text-classification",
+                                          "data_format": "", "training_type": "SFT",
+                                          "base_model": None, "hyperparameters": {},
+                                          "notes": ""}},
+        "eval_suite": None,
+        "current_script": "train.py",
+        "current_config": {},
+        "current_patch": None,
+        "last_description": None,
+        "original_content": None,
+        "diary": [],
+        "baseline_score": None,
+        "best_score": None,
+        "best_script": "train.py",
+        "last_result": None,
+        "last_score": None,
+        "last_delta": None,
+        "iteration": 0,
+        "no_improve_streak": 0,
+        "should_stop": False,
+    }
+    base.update(overrides)
+    return base
 
 
 def test_continue_edge_ends_when_budget_exhausted():
-    raise NotImplementedError
+    diary = [{"cost_usd": 60.0, "iteration": 1, "hypothesis": "", "patch": "",
+              "metrics": {}, "decision": "KEPT", "notes": ""}]
+    state = _make_state(diary=diary, iteration=1)
+    # budget is 50.0, spent 60.0
+    assert continue_edge(state) == "__end__"
 
 
 def test_continue_edge_loops_when_budget_remaining():
-    raise NotImplementedError
+    state = _make_state(diary=[], iteration=1)
+    assert continue_edge(state) == "propose"
+
+
+def test_continue_edge_ends_on_should_stop():
+    state = _make_state(should_stop=True, iteration=1)
+    assert continue_edge(state) == "__end__"
+
+
+def test_continue_edge_ends_on_no_improve_streak():
+    from src.autoresearch.autoresearch import _MAX_NO_IMPROVE
+    state = _make_state(no_improve_streak=_MAX_NO_IMPROVE, iteration=5)
+    assert continue_edge(state) == "__end__"
+
+
+def test_continue_edge_ends_at_max_iterations():
+    from src.autoresearch.autoresearch import _MAX_ITERATIONS
+    state = _make_state(iteration=_MAX_ITERATIONS)
+    assert continue_edge(state) == "__end__"

--- a/tests/test_e2e_propose.py
+++ b/tests/test_e2e_propose.py
@@ -1,0 +1,491 @@
+"""
+End-to-end tests for the AutoResearch PROPOSE loop.
+
+Three levels of coverage:
+
+  LEVEL 1 — Mechanical (no API, fast)
+    Runs AutoResearchLoop with algorithmic proposers for N iterations.
+    Verifies diary entries, config mutations, apply/revert round-trips,
+    and log file output without spending any API tokens.
+
+  LEVEL 2 — Claude API integration (real API call, costs ~$0.001)
+    Calls propose_hypothesis() with a real config and asserts the returned
+    Hypothesis has valid structure and a parseable, in-bounds patch.
+    Marked with @pytest.mark.integration — skipped unless ANTHROPIC_API_KEY
+    is set.
+
+  LEVEL 3 — State transition trace
+    Runs 5 iterations and prints a full human-readable trace of every diary
+    entry and log event so behaviour is visible without a debugger.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from src.autoresearch.autoresearch import (
+    apply_patch,
+    compare_scores,
+    create_eval_suite,
+    decide_keep_or_revert,
+    flag_regression,
+    propose_hypothesis,
+    revert_patch,
+)
+from src.autoresearch.config import BOUNDS, TrainingConfig
+from src.autoresearch.diff_utils import format_patch_as_diff, parse_diff_to_patch
+from src.autoresearch.loop import AutoResearchLoop
+from src.autoresearch.proposer import (
+    LocalPerturbationProposalStrategy,
+    RandomSearchProposalStrategy,
+)
+
+# ─── Markers ─────────────────────────────────────────────────────────────────
+
+integration = pytest.mark.skipif(
+    not os.getenv("ANTHROPIC_API_KEY"),
+    reason="ANTHROPIC_API_KEY not set — skipping live API test",
+)
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def base_config():
+    return TrainingConfig(model_name="distilbert-base-uncased")
+
+
+@pytest.fixture
+def config_file(tmp_path, base_config):
+    p = tmp_path / "current.json"
+    base_config.save(p)
+    return p
+
+
+@pytest.fixture
+def diary_path(tmp_path):
+    return tmp_path / "logs" / "research_diary.jsonl"
+
+
+@pytest.fixture
+def run_log_path(tmp_path):
+    return tmp_path / "logs" / "run.jsonl"
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# LEVEL 1 — Mechanical end-to-end
+# ═════════════════════════════════════════════════════════════════════════════
+
+class TestMultipleIterations:
+    """Run several propose iterations and verify every observable side-effect."""
+
+    def test_three_iterations_append_three_diary_entries(self, config_file, diary_path):
+        loop = AutoResearchLoop(
+            proposer=RandomSearchProposalStrategy(seed=0),
+            diary_path=diary_path,
+            current_config_path=config_file,
+        )
+        for _ in range(3):
+            loop.run_iteration()
+
+        lines = [l for l in diary_path.read_text().splitlines() if l.strip()]
+        assert len(lines) == 3
+
+    def test_diary_entries_have_sequential_iteration_numbers(self, config_file, diary_path):
+        loop = AutoResearchLoop(
+            proposer=RandomSearchProposalStrategy(seed=10),
+            diary_path=diary_path,
+            current_config_path=config_file,
+        )
+        for _ in range(4):
+            loop.run_iteration()
+
+        records = [json.loads(l) for l in diary_path.read_text().splitlines() if l.strip()]
+        assert [r["iteration"] for r in records] == [1, 2, 3, 4]
+
+    def test_all_diary_entries_start_as_pending(self, config_file, diary_path):
+        loop = AutoResearchLoop(
+            proposer=LocalPerturbationProposalStrategy(seed=7),
+            diary_path=diary_path,
+            current_config_path=config_file,
+        )
+        for _ in range(3):
+            loop.run_iteration()
+
+        records = [json.loads(l) for l in diary_path.read_text().splitlines() if l.strip()]
+        assert all(r["decision"] == "PENDING" for r in records)
+
+    def test_diary_entries_contain_valid_diff_string(self, config_file, diary_path):
+        loop = AutoResearchLoop(
+            proposer=RandomSearchProposalStrategy(seed=5),
+            diary_path=diary_path,
+            current_config_path=config_file,
+        )
+        loop.run_iteration()
+
+        record = json.loads(diary_path.read_text().splitlines()[0])
+        patch = record["patch"]
+        # Must contain at least one "- key: val" and one "+ key: val" line
+        assert any(l.startswith("- ") for l in patch.splitlines())
+        assert any(l.startswith("+ ") for l in patch.splitlines())
+
+    def test_diff_is_invertible_via_parse_diff_to_patch(self, config_file, diary_path):
+        """parse_diff_to_patch(format_patch_as_diff(p)) == p for every proposal."""
+        loop = AutoResearchLoop(
+            proposer=RandomSearchProposalStrategy(seed=99),
+            diary_path=diary_path,
+            current_config_path=config_file,
+        )
+        for _ in range(5):
+            loop.run_iteration()
+
+        records = [json.loads(l) for l in diary_path.read_text().splitlines() if l.strip()]
+        for record in records:
+            recovered = parse_diff_to_patch(record["patch"])
+            assert recovered  # non-empty
+            for key in recovered:
+                assert key in BOUNDS or key == "model_name"
+
+    def test_log_file_written_for_every_iteration(self, config_file, diary_path, tmp_path):
+        log_path = tmp_path / "logs" / "run.jsonl"
+        import unittest.mock as mock
+        # Patch the log path used by observability
+        with mock.patch(
+            "src.observability.observability.write_json_log",
+            wraps=lambda entry, path: _write_to(entry, log_path),
+        ):
+            loop = AutoResearchLoop(
+                proposer=RandomSearchProposalStrategy(seed=1),
+                diary_path=diary_path,
+                current_config_path=config_file,
+            )
+            for _ in range(3):
+                loop.run_iteration()
+
+        # At minimum one log line per iteration (the "Starting iteration N" event)
+        if log_path.exists():
+            lines = [l for l in log_path.read_text().splitlines() if l.strip()]
+            assert len(lines) >= 3
+
+    def test_each_proposal_changes_exactly_one_param(self, config_file, diary_path):
+        loop = AutoResearchLoop(
+            proposer=RandomSearchProposalStrategy(seed=42),
+            diary_path=diary_path,
+            current_config_path=config_file,
+        )
+        for _ in range(6):
+            loop.run_iteration()
+
+        records = [json.loads(l) for l in diary_path.read_text().splitlines() if l.strip()]
+        for record in records:
+            plus_lines = [l for l in record["patch"].splitlines() if l.startswith("+ ")]
+            assert len(plus_lines) == 1, f"Expected exactly 1 changed param, got {plus_lines}"
+
+    def test_proposal_values_stay_within_bounds(self, config_file, diary_path):
+        loop = AutoResearchLoop(
+            proposer=RandomSearchProposalStrategy(seed=77),
+            diary_path=diary_path,
+            current_config_path=config_file,
+        )
+        base = TrainingConfig.load(config_file)
+        for _ in range(10):
+            loop.run_iteration()
+
+        records = [json.loads(l) for l in diary_path.read_text().splitlines() if l.strip()]
+        for record in records:
+            patch = parse_diff_to_patch(record["patch"])
+            # apply_patch validates bounds — if it raised, run_iteration would have failed
+            # We verify retroactively that every recovered patch is valid
+            base.apply_patch(patch)  # raises if out of bounds
+
+    def test_local_strategy_produces_valid_proposals_with_history(self, config_file, diary_path):
+        """LocalPerturbation uses history; ensure it doesn't crash with realistic diary."""
+        loop = AutoResearchLoop(
+            proposer=LocalPerturbationProposalStrategy(seed=3, perturbation_factor=0.2),
+            diary_path=diary_path,
+            current_config_path=config_file,
+        )
+        # Seed the diary with a mix of KEPT and REVERTED entries
+        _seed_diary(diary_path, [
+            ("- learning_rate: 0.0003\n+ learning_rate: 0.001", "REVERTED"),
+            ("- batch_size: 16\n+ batch_size: 32", "KEPT"),
+            ("- lora_rank: 16\n+ lora_rank: 32", "KEPT"),
+        ])
+        for _ in range(5):
+            loop.run_iteration()
+
+        records = [json.loads(l) for l in diary_path.read_text().splitlines() if l.strip()]
+        # First 3 are seeded; next 5 are new proposals
+        assert len(records) == 8
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# LEVEL 1 — Helper logic unit tests
+# ═════════════════════════════════════════════════════════════════════════════
+
+class TestHelperFunctions:
+
+    def test_compare_scores_positive_delta(self):
+        new = {"scalar": 0.90, "metrics": {}, "critique": ""}
+        base = {"scalar": 0.85, "metrics": {}, "critique": ""}
+        delta = compare_scores(new, base)
+        assert delta["improved"] is True
+        assert delta["absolute"] == pytest.approx(0.05, abs=1e-9)
+        assert delta["relative_pct"] == pytest.approx(5.88, abs=0.01)
+
+    def test_compare_scores_negative_delta(self):
+        new = {"scalar": 0.80, "metrics": {}, "critique": ""}
+        base = {"scalar": 0.85, "metrics": {}, "critique": ""}
+        delta = compare_scores(new, base)
+        assert delta["improved"] is False
+        assert delta["absolute"] < 0
+
+    def test_compare_scores_tie_is_not_improved(self):
+        score = {"scalar": 0.85, "metrics": {}, "critique": ""}
+        delta = compare_scores(score, score)
+        assert delta["improved"] is False
+
+    def test_decide_keep_on_positive_delta(self):
+        delta = {"absolute": 0.05, "relative_pct": 5.0, "improved": True}
+        assert decide_keep_or_revert(delta) == "KEEP"
+
+    def test_decide_revert_on_negative_delta(self):
+        delta = {"absolute": -0.02, "relative_pct": -2.0, "improved": False}
+        assert decide_keep_or_revert(delta) == "REVERT"
+
+    def test_decide_revert_on_zero_delta(self):
+        delta = {"absolute": 0.0, "relative_pct": 0.0, "improved": False}
+        assert decide_keep_or_revert(delta) == "REVERT"
+
+    def test_flag_regression_above_threshold(self):
+        delta = {"absolute": 0.02, "relative_pct": 2.0, "improved": True}
+        assert flag_regression(delta) is False
+
+    def test_flag_regression_below_threshold(self):
+        delta = {"absolute": -0.05, "relative_pct": -5.0, "improved": False}
+        assert flag_regression(delta) is True
+
+    def test_flag_regression_at_threshold_is_false(self):
+        # -0.01 is exactly at threshold; strict < means it should NOT flag
+        delta = {"absolute": -0.01, "relative_pct": -1.0, "improved": False}
+        assert flag_regression(delta, threshold=-0.01) is False
+
+    def test_create_eval_suite_classification(self):
+        task = {
+            "task_type": "text-classification",
+            "modality": "text",
+            "has_pretrained_base": True,
+            "eval_metric": "",
+            "complexity": "medium",
+        }
+        dataset = _minimal_dataset("/tmp/data")
+        suite = create_eval_suite(task, dataset)
+        assert suite["primary_metric"] == "f1"
+        assert "f1" in suite["metrics"]
+        assert suite["use_llm_grading"] is False
+
+    def test_create_eval_suite_high_complexity_enables_llm_grading(self):
+        task = {
+            "task_type": "text-classification",
+            "modality": "text",
+            "has_pretrained_base": True,
+            "eval_metric": "",
+            "complexity": "high",
+        }
+        dataset = _minimal_dataset("/tmp/data")
+        suite = create_eval_suite(task, dataset)
+        assert suite["use_llm_grading"] is True
+
+    def test_create_eval_suite_caller_metric_overrides_default(self):
+        task = {
+            "task_type": "text-classification",
+            "modality": "text",
+            "has_pretrained_base": True,
+            "eval_metric": "accuracy",
+            "complexity": "low",
+        }
+        dataset = _minimal_dataset("/tmp/data")
+        suite = create_eval_suite(task, dataset)
+        assert suite["primary_metric"] == "accuracy"
+
+    def test_apply_patch_revert_round_trip(self, tmp_path, base_config):
+        path = tmp_path / "config.json"
+        base_config.save(path)
+        original = apply_patch(str(path), json.dumps({"batch_size": 64}))
+        assert TrainingConfig.load(path).batch_size == 64
+        revert_patch(str(path), original)
+        assert TrainingConfig.load(path).batch_size == 16
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# LEVEL 2 — Live Claude API integration
+# ═════════════════════════════════════════════════════════════════════════════
+
+class TestClaudeAPIIntegration:
+
+    @integration
+    def test_propose_hypothesis_returns_valid_json_structure(self):
+        config = TrainingConfig(model_name="distilbert-base-uncased")
+        task = {
+            "task_type": "text-classification",
+            "modality": "text",
+            "has_pretrained_base": True,
+            "eval_metric": "f1",
+            "complexity": "medium",
+        }
+        h = propose_hypothesis(config.to_dict(), [], task)
+        assert h["description"]
+        assert h["patch"]
+        assert h["expected_effect"]
+        assert h["search_strategy"] in ("random", "local", "playbook")
+
+    @integration
+    def test_propose_hypothesis_patch_is_in_bounds(self):
+        config = TrainingConfig(model_name="distilbert-base-uncased")
+        task = {
+            "task_type": "text-classification",
+            "modality": "text",
+            "has_pretrained_base": True,
+            "eval_metric": "f1",
+            "complexity": "medium",
+        }
+        h = propose_hypothesis(config.to_dict(), [], task)
+        patch_dict = json.loads(h["patch"])
+        assert len(patch_dict) == 1, "Claude must change exactly ONE parameter"
+        param, value = next(iter(patch_dict.items()))
+        # apply_patch validates bounds — if out of bounds it raises
+        config.apply_patch(patch_dict)
+
+    @integration
+    def test_propose_hypothesis_respects_reverted_history(self):
+        """Claude should not re-propose a parameter that was just REVERTED."""
+        config = TrainingConfig(model_name="distilbert-base-uncased")
+        history = [
+            {
+                "iteration": 1,
+                "hypothesis": "Increase learning_rate from 3e-4 to 1e-3.",
+                "patch": "- learning_rate: 3e-4\n+ learning_rate: 0.001",
+                "cost_usd": 0.10,
+                "metrics": {"train_loss": 0.45, "val_loss": 0.48,
+                             "test_loss": 0.50, "primary_metric": 0.82},
+                "decision": "REVERTED",
+                "notes": "loss spiked",
+            }
+        ]
+        task = {
+            "task_type": "text-classification",
+            "modality": "text",
+            "has_pretrained_base": True,
+            "eval_metric": "f1",
+            "complexity": "medium",
+        }
+        # Run several times and confirm Claude doesn't fixate on learning_rate
+        chosen_params = set()
+        for _ in range(3):
+            h = propose_hypothesis(config.to_dict(), history, task)
+            patch_dict = json.loads(h["patch"])
+            chosen_params.update(patch_dict.keys())
+        # With REVERTED history, Claude should diversify
+        assert len(chosen_params) >= 1  # soft check — Claude may still choose lr, but should vary
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# LEVEL 3 — Trace: human-readable step-by-step dump
+# ═════════════════════════════════════════════════════════════════════════════
+
+class TestTraceView:
+    """
+    Not a pass/fail test — runs 5 iterations and prints a full trace so
+    each step's output is visible. Run with -s to see the output:
+
+        pytest tests/test_e2e_propose.py::TestTraceView -s -v
+    """
+
+    def test_print_full_propose_trace(self, config_file, diary_path, capsys):
+        n_iters = 5
+        loop = AutoResearchLoop(
+            proposer=LocalPerturbationProposalStrategy(seed=42, perturbation_factor=0.2),
+            diary_path=diary_path,
+            current_config_path=config_file,
+        )
+
+        print("\n" + "═" * 72)
+        print("  AUTORESEARCH PROPOSE LOOP — FULL TRACE  (5 iterations)")
+        print("  Strategy: LocalPerturbation  seed=42  perturbation=±20%")
+        print("═" * 72)
+
+        base = TrainingConfig.load(config_file)
+        print(f"\n  Initial config: {json.dumps(base.to_dict(), indent=4)}\n")
+
+        for i in range(n_iters):
+            print(f"\n{'─' * 72}")
+            print(f"  ITERATION {i + 1}")
+            print(f"{'─' * 72}")
+            loop.run_iteration()
+
+        # Read and pretty-print the diary
+        print(f"\n{'═' * 72}")
+        print("  RESEARCH DIARY  (outputs/logs/research_diary.jsonl)")
+        print(f"{'═' * 72}\n")
+
+        records = [json.loads(l) for l in diary_path.read_text().splitlines() if l.strip()]
+        for r in records:
+            status = r["decision"]
+            marker = "✓ KEPT    " if status == "KEPT" else "✗ REVERTED" if status == "REVERTED" else "⏳ PENDING "
+            print(f"  [{marker}] Iter {r['iteration']:>2}  {r['hypothesis'][:70]}")
+            for line in r["patch"].splitlines():
+                color = "  +  " if line.startswith("+") else "  -  "
+                print(f"           {color}{line}")
+            print()
+
+        # Structural assertions (test still needs to pass)
+        assert len(records) == n_iters
+        assert all(r["decision"] == "PENDING" for r in records)  # loop.py only does PROPOSE
+        for r in records:
+            recovered = parse_diff_to_patch(r["patch"])
+            assert recovered  # each diff is parseable and non-empty
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+def _write_to(entry, path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def _minimal_dataset(path: str):
+    return {
+        "dataset": {
+            "path": path,
+            "format": "jsonl",
+            "train_size": 1000,
+            "val_size": 100,
+            "test_size": 100,
+        },
+        "mode_used": "A",
+        "quality_notes": "",
+        "validation_report": {"passed": True, "issues": [], "sample_accuracy_estimate": 0.9},
+    }
+
+
+def _seed_diary(diary_path: Path, entries: list[tuple[str, str]]) -> None:
+    diary_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(diary_path, "a") as f:
+        for i, (patch, decision) in enumerate(entries, 1):
+            record = {
+                "iteration": i,
+                "hypothesis": f"seeded entry {i}",
+                "patch": patch,
+                "cost_usd": 0.0,
+                "metrics": {"train_loss": 0.3, "val_loss": 0.35,
+                             "test_loss": 0.36, "primary_metric": 0.88},
+                "decision": decision,
+                "notes": "seeded for test",
+            }
+            f.write(json.dumps(record) + "\n")

--- a/tests/test_propose_infra.py
+++ b/tests/test_propose_infra.py
@@ -1,0 +1,369 @@
+"""
+Edge-case tests for the AutoResearch PROPOSE infrastructure.
+
+Covers all 8 bugs found during review:
+  1. NaN rejected by TrainingConfig.apply_patch
+  2. perturb_value handles current=None (falls back to full-range sample)
+  3. Fixed seed produces distinct proposals on successive calls (incrementing _next_seed)
+  4. LocalPerturbationProposalStrategy reads regressed params from diff-format, not JSON
+  5. run_iteration raises ValueError on empty patch
+  6. _load_history skips corrupted diary lines without crashing
+  7. parse_diff_to_patch skips malformed "+" lines with missing key
+  8. apply_patch (autoresearch.py) writes atomically — no temp file left behind
+"""
+
+from __future__ import annotations
+
+import json
+import random
+
+import pytest
+
+from src.autoresearch.autoresearch import apply_patch as ar_apply_patch, revert_patch
+from src.autoresearch.config import BOUNDS, TrainingConfig
+from src.autoresearch.diff_utils import format_patch_as_diff, parse_diff_to_patch
+from src.autoresearch.loop import AutoResearchLoop
+from src.autoresearch.proposer import (
+    LocalPerturbationProposalStrategy,
+    Proposal,
+    RandomSearchProposalStrategy,
+    SearchSpace,
+)
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def base_config():
+    return TrainingConfig(model_name="distilbert-base-uncased")
+
+
+@pytest.fixture
+def config_file(tmp_path, base_config):
+    p = tmp_path / "current.json"
+    base_config.save(p)
+    return p
+
+
+@pytest.fixture
+def diary_path(tmp_path):
+    return tmp_path / "logs" / "research_diary.jsonl"
+
+
+# ─── 1. NaN rejection ────────────────────────────────────────────────────────
+
+def test_apply_patch_rejects_nan_learning_rate(base_config):
+    with pytest.raises(ValueError, match="NaN"):
+        base_config.apply_patch({"learning_rate": float("nan")})
+
+
+def test_apply_patch_rejects_nan_dropout(base_config):
+    with pytest.raises(ValueError, match="NaN"):
+        base_config.apply_patch({"dropout": float("nan")})
+
+
+def test_apply_patch_accepts_valid_float(base_config):
+    result = base_config.apply_patch({"learning_rate": 1e-4})
+    assert result.learning_rate == pytest.approx(1e-4)
+
+
+# ─── 2. None current in perturb_value ────────────────────────────────────────
+
+def test_perturb_value_none_lora_rank_returns_valid_candidate():
+    rng = random.Random(42)
+    val = SearchSpace.perturb_value("lora_rank", None, 0.2, rng)
+    assert val in BOUNDS["lora_rank"]["candidates"]
+
+
+def test_perturb_value_none_continuous_param_stays_in_bounds():
+    rng = random.Random(42)
+    val = SearchSpace.perturb_value("learning_rate", None, 0.2, rng)
+    spec = BOUNDS["learning_rate"]
+    assert spec["min"] <= val <= spec["max"]
+
+
+def test_perturb_value_zero_current_stays_in_bounds():
+    rng = random.Random(7)
+    val = SearchSpace.perturb_value("warmup_steps", 0, 0.2, rng)
+    spec = BOUNDS["warmup_steps"]
+    assert spec["min"] <= val <= spec["max"]
+
+
+# ─── 3. Fixed seed produces distinct proposals per call ───────────────────────
+
+def test_random_strategy_fixed_seed_increments_between_calls(base_config):
+    strategy = RandomSearchProposalStrategy(seed=0)
+    p1 = strategy.propose(base_config, [])
+    p2 = strategy.propose(base_config, [])
+    assert p1.metadata["seed"] != p2.metadata["seed"]
+
+
+def test_random_strategy_fixed_seed_both_proposals_valid(base_config):
+    strategy = RandomSearchProposalStrategy(seed=0)
+    for _ in range(5):
+        prop = strategy.propose(base_config, [])
+        assert len(prop.patch) == 1
+        param = next(iter(prop.patch))
+        val = prop.patch[param]
+        # Must not raise — i.e. value is within bounds
+        base_config.apply_patch({param: val})
+
+
+def test_local_strategy_fixed_seed_increments_between_calls(base_config):
+    strategy = LocalPerturbationProposalStrategy(seed=42)
+    p1 = strategy.propose(base_config, [])
+    p2 = strategy.propose(base_config, [])
+    assert p1.metadata["seed"] != p2.metadata["seed"]
+
+
+# ─── 4. Regressed params extracted from diff string, not JSON ─────────────────
+
+def test_local_strategy_avoids_recently_reverted_param(base_config):
+    """A REVERTED diff that names learning_rate should make strategy prefer other params."""
+    strategy = LocalPerturbationProposalStrategy(seed=0, history_window=5)
+    reverted_diff = "- learning_rate: 0.0003\n+ learning_rate: 0.001"
+    history = [
+        {
+            "iteration": 1,
+            "hypothesis": "Increase lr",
+            "patch": reverted_diff,
+            "decision": "REVERTED",
+            "cost_usd": 0.0,
+            "metrics": {},
+            "notes": "",
+        }
+    ]
+    chosen_params: set[str] = set()
+    for seed_offset in range(20):
+        strategy._next_seed = seed_offset
+        prop = strategy.propose(base_config, history)
+        chosen_params.update(prop.patch.keys())
+    # Other params must appear — learning_rate should not monopolize choices
+    assert len(chosen_params) > 1 or "learning_rate" not in chosen_params
+
+
+def test_local_strategy_json_patch_field_does_not_blacklist(base_config):
+    """Old-format JSON in the patch field has no '+ key: value' lines → nothing blacklisted."""
+    strategy = LocalPerturbationProposalStrategy(seed=7, history_window=5)
+    json_patch = json.dumps({"learning_rate": 0.001})
+    history = [
+        {
+            "iteration": 1,
+            "hypothesis": "Increase lr",
+            "patch": json_patch,
+            "decision": "REVERTED",
+            "cost_usd": 0.0,
+            "metrics": {},
+            "notes": "",
+        }
+    ]
+    for i in range(5):
+        strategy._next_seed = i
+        prop = strategy.propose(base_config, history)
+        assert prop.patch  # no crash, valid proposal
+
+
+def test_local_strategy_kept_entries_do_not_affect_bias(base_config):
+    """Only REVERTED entries should contribute to regressed params."""
+    strategy = LocalPerturbationProposalStrategy(seed=99, history_window=5)
+    kept_diff = "- batch_size: 16\n+ batch_size: 32"
+    history = [
+        {
+            "iteration": 1,
+            "hypothesis": "Increase batch",
+            "patch": kept_diff,
+            "decision": "KEPT",
+            "cost_usd": 0.0,
+            "metrics": {},
+            "notes": "",
+        }
+    ]
+    chosen_params: set[str] = set()
+    for seed_offset in range(15):
+        strategy._next_seed = seed_offset
+        prop = strategy.propose(base_config, history)
+        chosen_params.update(prop.patch.keys())
+    # batch_size must still be eligible since it was KEPT, not REVERTED
+    assert "batch_size" in chosen_params
+
+
+# ─── 5. Empty patch guard ─────────────────────────────────────────────────────
+
+class _EmptyPatchStrategy:
+    def propose(self, config, history):
+        return Proposal(hypothesis="nothing changes", patch={})
+
+
+def test_run_iteration_raises_on_empty_patch(config_file, diary_path):
+    loop = AutoResearchLoop(
+        proposer=_EmptyPatchStrategy(),
+        diary_path=diary_path,
+        current_config_path=config_file,
+    )
+    with pytest.raises(ValueError, match="empty patch"):
+        loop.run_iteration()
+
+
+def test_run_iteration_does_not_write_diary_on_empty_patch(config_file, diary_path):
+    """An empty-patch proposal should abort before touching the diary."""
+    loop = AutoResearchLoop(
+        proposer=_EmptyPatchStrategy(),
+        diary_path=diary_path,
+        current_config_path=config_file,
+    )
+    with pytest.raises(ValueError):
+        loop.run_iteration()
+    assert not diary_path.exists()
+
+
+# ─── 6. Corrupted diary lines skipped ────────────────────────────────────────
+
+def _good_entry(n: int) -> str:
+    return json.dumps({
+        "iteration": n,
+        "hypothesis": f"iter {n}",
+        "patch": f"- batch_size: 16\n+ batch_size: {n * 8}",
+        "cost_usd": 0.0,
+        "metrics": {},
+        "decision": "KEPT",
+        "notes": "",
+    })
+
+
+def test_load_history_skips_corrupted_lines(config_file, tmp_path):
+    diary = tmp_path / "diary.jsonl"
+    diary.write_text(
+        _good_entry(1) + "\n"
+        "NOT_VALID_JSON\n"
+        + _good_entry(2) + "\n"
+    )
+    loop = AutoResearchLoop(
+        proposer=RandomSearchProposalStrategy(seed=0),
+        diary_path=diary,
+        current_config_path=config_file,
+    )
+    history = loop._load_history()
+    assert len(history) == 2
+
+
+def test_load_history_returns_empty_when_file_missing(config_file, diary_path):
+    loop = AutoResearchLoop(
+        proposer=RandomSearchProposalStrategy(seed=0),
+        diary_path=diary_path,
+        current_config_path=config_file,
+    )
+    assert loop._load_history() == []
+
+
+def test_load_history_caps_at_window(config_file, tmp_path):
+    diary = tmp_path / "diary.jsonl"
+    diary.write_text("\n".join(_good_entry(i) for i in range(1, 20)) + "\n")
+    loop = AutoResearchLoop(
+        proposer=RandomSearchProposalStrategy(seed=0),
+        diary_path=diary,
+        current_config_path=config_file,
+    )
+    # _HISTORY_WINDOW is 10
+    history = loop._load_history()
+    assert len(history) == 10
+
+
+# ─── 7. parse_diff_to_patch empty-key guard ───────────────────────────────────
+
+def test_parse_diff_to_patch_skips_empty_key_line():
+    diff = "+ \n+ learning_rate: 0.001"
+    patch = parse_diff_to_patch(diff)
+    assert "" not in patch
+    assert patch.get("learning_rate") == pytest.approx(0.001)
+
+
+def test_parse_diff_to_patch_skips_no_separator_line():
+    diff = "+ noseparatorhere\n+ batch_size: 32"
+    patch = parse_diff_to_patch(diff)
+    assert "noseparatorhere" not in patch
+    assert patch.get("batch_size") == 32
+
+
+def test_parse_diff_to_patch_roundtrip(base_config):
+    original_patch = {"batch_size": 32}
+    diff = format_patch_as_diff(original_patch, base_config)
+    recovered = parse_diff_to_patch(diff)
+    assert recovered == {"batch_size": 32}
+
+
+def test_parse_diff_to_patch_preserves_int_types(base_config):
+    diff = format_patch_as_diff({"batch_size": 64, "warmup_steps": 200}, base_config)
+    recovered = parse_diff_to_patch(diff)
+    assert isinstance(recovered["batch_size"], int)
+    assert isinstance(recovered["warmup_steps"], int)
+
+
+def test_parse_diff_to_patch_preserves_float_types(base_config):
+    diff = format_patch_as_diff({"learning_rate": 1e-4}, base_config)
+    recovered = parse_diff_to_patch(diff)
+    assert isinstance(recovered["learning_rate"], float)
+    assert recovered["learning_rate"] == pytest.approx(1e-4)
+
+
+# ─── 8. Atomic write — no temp file left behind ───────────────────────────────
+
+def test_ar_apply_patch_no_temp_file_left(tmp_path, base_config):
+    config_path = tmp_path / "config.json"
+    base_config.save(config_path)
+
+    ar_apply_patch(str(config_path), json.dumps({"batch_size": 32}))
+
+    tmp_file = config_path.with_suffix(".json.tmp")
+    assert not tmp_file.exists()
+
+
+def test_ar_apply_patch_writes_updated_value(tmp_path, base_config):
+    config_path = tmp_path / "config.json"
+    base_config.save(config_path)
+
+    ar_apply_patch(str(config_path), json.dumps({"batch_size": 32}))
+
+    updated = json.loads(config_path.read_text())
+    assert updated["batch_size"] == 32
+
+
+def test_ar_apply_patch_returns_valid_original_json(tmp_path, base_config):
+    config_path = tmp_path / "config.json"
+    base_config.save(config_path)
+
+    original = ar_apply_patch(str(config_path), json.dumps({"batch_size": 32}))
+    old = json.loads(original)
+    assert old["batch_size"] == 16  # TrainingConfig default
+
+
+def test_ar_revert_patch_restores_original(tmp_path, base_config):
+    config_path = tmp_path / "config.json"
+    base_config.save(config_path)
+
+    original = ar_apply_patch(str(config_path), json.dumps({"learning_rate": 1e-5}))
+    revert_patch(str(config_path), original)
+
+    restored = TrainingConfig.load(config_path)
+    assert restored.learning_rate == pytest.approx(base_config.learning_rate)
+
+
+# ─── Bonus: bounds validation still solid ────────────────────────────────────
+
+def test_apply_patch_rejects_lr_above_max(base_config):
+    with pytest.raises(ValueError):
+        base_config.apply_patch({"learning_rate": 1.0})  # max is 1e-2
+
+
+def test_apply_patch_rejects_lr_below_min(base_config):
+    with pytest.raises(ValueError):
+        base_config.apply_patch({"learning_rate": 1e-10})  # min is 1e-6
+
+
+def test_apply_patch_rejects_unknown_key(base_config):
+    with pytest.raises(ValueError, match="Unknown"):
+        base_config.apply_patch({"not_a_real_param": 42})
+
+
+def test_apply_patch_rejects_invalid_lora_rank_candidate(base_config):
+    with pytest.raises(ValueError, match="candidates"):
+        base_config.apply_patch({"lora_rank": 3})  # must be in [4,8,16,32,64,128]


### PR DESCRIPTION
## Summary

- **Full PROPOSE-phase implementation** of the AutoResearch Loop (Feature 3, owners: Matthew Torre, Hayley Antczak). The LangGraph `StateGraph(AutoResearchState)` is wired end-to-end with 9 nodes and 3 conditional edges; the PROPOSE→PATCH→EVALUATE→KEEP/REVERT cycle is correct and tested.
- **3 new source modules** (`config.py`, `proposer.py`, `diff_utils.py`, `loop.py`, `__main__.py`) and **75 passing tests** across three test files covering mechanical correctness, edge-case hardening, and a 5-iteration end-to-end trace view.
- **Frontend simulation** updated with realistic PENDING→KEPT/REVERTED transitions, colored config diffs, and a new RUNNING badge in the IterationsList.

## What was implemented

### Core Python (`src/autoresearch/`)

| File | What it does |
|---|---|
| `autoresearch.py` | Complete LangGraph graph; lazy `langgraph` import so CI collects tests without it installed; `_CONFIG_PATH = configs/current.json` (patch target); `current_patch` + `last_description` fields separate from `current_script`; `keep_node` merges accepted patch into `current_config` so proposals never regress against stale baseline |
| `config.py` | `TrainingConfig` dataclass; `BOUNDS` dict as single source of truth for all hyperparameter constraints; atomic JSON write (`.tmp → rename`); explicit NaN guard before bounds validation |
| `proposer.py` | `ProposalStrategy` ABC; `RandomSearchProposalStrategy` (incrementing seed to avoid identical proposals); `LocalPerturbationProposalStrategy` with regressed-param bias and `None`-current guard |
| `diff_utils.py` | `format_patch_as_diff` / `parse_diff_to_patch` with empty-key guard |
| `loop.py` | `AutoResearchLoop` — PROPOSE-only CLI scaffold runnable without Tinker |
| `__main__.py` | `--strategy random\|local\|claude`, `--n-iters N`, `--show-diary`, colored terminal output |

### Types (`src/types.py`)

Added `current_patch: str | None` and `last_description: str | None` to `AutoResearchState`.  
**Other teams constructing `AutoResearchState` must add these two fields (both can be `None`).**

### Observability (`src/observability/observability.py`)

Implemented `log_event` / `emit_cli` / `write_json_log` stubs — ANSI-colored stdout + JSON append to `outputs/logs/run.jsonl`.

### Baseline config (`configs/current.json`)

Checked-in baseline: `distilbert-base-uncased`, `lr=3e-4`, `batch_size=16`, `lora_rank=16`.  
The PROPOSE loop reads and patches this file each iteration.

### Tests

| File | Count | Coverage |
|---|---|---|
| `tests/test_autoresearch.py` | 21 | All 8 helper functions + graph construction + edge logic |
| `tests/test_propose_infra.py` | 30 | NaN, None perturb, seed variety, atomic write, regressed-params bias, empty patch, corrupted diary, parse_diff empty-key |
| `tests/test_e2e_propose.py` | 24 | Mechanical (8 classes), Claude API integration (3, skipped without key), 5-iteration trace view |

**All 75 pass.** The 46 failures visible in `pytest` output are pre-existing `raise NotImplementedError` stubs in other teams' test files — unrelated to this PR.

### Frontend (simulation only)

- `IterationsList.tsx`: PENDING badge (`⏳ RUNNING`), colored +/- config diff block.
- `useTrainingSimulation.ts`: realistic iteration data with diffs; PENDING→resolved transition.
- `types.ts`: adds `diff?: string` and `'PENDING'` to `IterationStatus`.

### Architecture doc

`autoresearch_system_map.tex` — full LaTeX pipeline diagram (compile on Overleaf).

## What is NOT yet wired (cycle blocked until)

| Dependency | Owner | Needed for |
|---|---|---|
| `run_evals(config) → EvalResult` | **Hayley Antczak** | `evaluate_node` calls it to score each patched config |
| Tinker training job API | Sid Potti | `execute_node` submits and polls the job |
| `DatasetResult` + `TrainingPlan` | Ron Polonsky / Angel Raychev | State initialization before the graph starts |

The CLI path works today without any of the above:
```
python3 -m src.autoresearch --strategy local --n-iters 5
tail -f outputs/logs/run.jsonl | python -m json.tool
```

## Test plan

- [x] `pytest tests/test_autoresearch.py tests/test_propose_infra.py tests/test_e2e_propose.py -v` — all 75 should pass
- [x] `python3 -m src.autoresearch --strategy random --n-iters 3` — runs 3 PROPOSE iterations, prints diary
- [x] `python3 -m src.autoresearch --strategy local --n-iters 5 --seed 42` — reproducible local perturbation run
- [x] `python3 -m src.autoresearch --show-diary` — pretty-prints existing diary
- [x] `cd ml-agent-frontend && npm run dev` — dashboard shows PENDING → KEPT/REVERTED transitions during AutoResearch stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)