### PR TITLE
[codex] add Tinker SFT runner

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ transformers>=4.40.0
 peft>=0.10.0
 torch>=2.2.0
 pytest>=8.0.0
+tinker
+tinker-cookbook

--- a/src/autoresearch/autoresearch.py
+++ b/src/autoresearch/autoresearch.py
@@ -13,11 +13,18 @@ from __future__ import annotations
 import json
 import math
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 import anthropic
 
+from src.autoresearch.config import TrainingConfig
 from src.observability.observability import log_event
+from src.tinker_api.sft_runner import (
+    DEFAULT_LIVE_SMOKE_STEPS,
+    DEFAULT_TINKER_MODEL,
+    SUPPORTED_TINKER_TUNABLES,
+    run_tinker_sft_experiment,
+)
 from src.types import (
     AgentName,
     AutoResearchState,
@@ -28,7 +35,6 @@ from src.types import (
     ExperimentResult,
     Hypothesis,
     IterationRecord,
-    JobConfig,
     JobStatus,
     LogLevel,
     OrchestrationConfig,
@@ -44,6 +50,7 @@ _DIARY_PATH = Path("outputs/logs/research_diary.jsonl")
 _CONFIG_PATH = Path("configs/current.json")  # the JSON file apply_patch/revert_patch target
 _MAX_NO_IMPROVE = 3   # halt after this many consecutive non-improving iterations
 _MAX_ITERATIONS = 20  # hard cap on total iterations regardless of improvement
+_EXPERIMENT_CACHE: dict[str, ExperimentResult] = {}
 
 
 def _patch_to_diff(patch_dict: dict, current_config: dict) -> str:
@@ -166,10 +173,13 @@ def init_node(state: AutoResearchState) -> dict:
     }
     # Construct a minimal DatasetResult so create_eval_suite can derive the test path.
     # The real dataset path comes from DataGen (F2); we point at the standard test split location.
-    script_dir = str(Path(state["plan"]["training_script_path"]).parent)
+    dataset_path = state["plan"].get(
+        "dataset_path",
+        str(Path(state["plan"]["training_script_path"]).parent),
+    )
     dataset_result: DatasetResult = {
         "dataset": {
-            "path": script_dir,
+            "path": dataset_path,
             "format": "jsonl",
             "train_size": 0,
             "val_size": 0,
@@ -213,22 +223,24 @@ def baseline_node(state: AutoResearchState) -> dict:
         "BASELINE: submitting unmodified training script",
     )
 
-    job_id = submit_experiment(state["plan"]["training_script_path"], state["plan"])
-    timeout = int(state["config"]["training_procedure"].get("timeout_min", 5))
-    experiment = wait_for_experiment(job_id, timeout)
+    experiment = run_tinker_sft_experiment(
+        _training_config_from_state(state),
+        _dataset_result_from_plan(state["plan"]),
+        max_steps=_max_steps_from_state(state),
+    )
     baseline_score = run_evals(experiment["model_path"], state["eval_suite"])
 
     log_event(
         AgentName.AUTORESEARCH,
         LogLevel.INFO,
         f"BASELINE: scalar={baseline_score['scalar']:.4f}",
-        metadata={"score": baseline_score, "job_id": job_id},
+        metadata={"score": baseline_score, "job_id": experiment["job_id"]},
     )
 
     return {
         "baseline_score": baseline_score,
         "best_score": baseline_score,
-        "best_script": state["plan"]["training_script_path"],
+        "best_script": experiment["model_path"],
         "last_result": experiment,
     }
 
@@ -248,7 +260,17 @@ def propose_node(state: AutoResearchState) -> dict:
         f"PROPOSE: generating hypothesis for iteration {state['iteration'] + 1}",
         metadata={"iteration": state["iteration"] + 1},
     )
-    hypothesis = propose_hypothesis(state["current_config"], state["diary"], task_analysis)
+    allowed_params = (
+        sorted(SUPPORTED_TINKER_TUNABLES)
+        if state["plan"].get("backend") == "tinker_sft"
+        else None
+    )
+    hypothesis = propose_hypothesis(
+        state["current_config"],
+        state["diary"],
+        task_analysis,
+        allowed_params=allowed_params,
+    )
 
     # Bug fix: patch the config JSON, not the training script (.py files are not patchable).
     original_content = apply_patch(str(_CONFIG_PATH), hypothesis["patch"])
@@ -275,7 +297,7 @@ def propose_node(state: AutoResearchState) -> dict:
 
 
 def run_node(state: AutoResearchState) -> dict:
-    """LangGraph node. Calls submit_experiment() and wait_for_experiment(). Returns: { last_result }."""
+    """LangGraph node. Runs a bounded SDK-native Tinker experiment. Returns: { last_result }."""
     log_event(
         AgentName.AUTORESEARCH,
         LogLevel.INFO,
@@ -283,15 +305,17 @@ def run_node(state: AutoResearchState) -> dict:
         metadata={"iteration": state["iteration"] + 1},
     )
 
-    timeout = int(state["config"]["training_procedure"].get("timeout_min", 5))
-    job_id = submit_experiment(state["plan"]["training_script_path"], state["plan"], timeout)
-    result = wait_for_experiment(job_id, timeout)
+    result = run_tinker_sft_experiment(
+        _training_config_from_state(state),
+        _dataset_result_from_plan(state["plan"]),
+        max_steps=_max_steps_from_state(state),
+    )
 
     log_event(
         AgentName.AUTORESEARCH,
         LogLevel.INFO,
-        f"RUN: job {job_id} finished — status={result['status']}",
-        metadata={"job_id": job_id, "cost_usd": result["cost_usd"]},
+        f"RUN: job {result['job_id']} finished — status={result['status']}",
+        metadata={"job_id": result["job_id"], "cost_usd": result["cost_usd"]},
     )
 
     return {"last_result": result}
@@ -299,7 +323,7 @@ def run_node(state: AutoResearchState) -> dict:
 
 def revert_and_continue_node(state: AutoResearchState) -> dict:
     """LangGraph node (early stop path). Calls revert_patch(), logs REVERTED, increments iteration. Returns: { current_script, diary, iteration }."""
-    revert_patch(state["plan"]["training_script_path"], state["original_content"])
+    revert_patch(str(_CONFIG_PATH), state["original_content"])
 
     log_event(
         AgentName.AUTORESEARCH,
@@ -382,7 +406,7 @@ def keep_node(state: AutoResearchState) -> dict:
 
     return {
         "best_score": state["last_score"],
-        "best_script": state["plan"]["training_script_path"],
+        "best_script": state["last_result"]["model_path"],
         "current_config": updated_config,
         "no_improve_streak": 0,
     }
@@ -400,7 +424,7 @@ def revert_node(state: AutoResearchState) -> dict:
         metadata={"iteration": state["iteration"] + 1, "streak": new_streak},
     )
     return {
-        "current_script": state["best_script"],
+        "current_script": state["plan"]["training_script_path"],
         "original_content": None,
         "no_improve_streak": new_streak,
     }
@@ -474,7 +498,7 @@ def early_stop_edge(state: AutoResearchState) -> Literal["evaluate", "revert_and
     """After run_node. Returns 'revert_and_continue' on catastrophic failure, 'evaluate' otherwise."""
     if state["last_result"] is None:
         return "revert_and_continue"
-    if state["last_result"]["status"] == JobStatus.FAILED:
+    if state["last_result"]["status"] in {JobStatus.FAILED, JobStatus.CANCELLED}:
         return "revert_and_continue"
     if check_early_stop(state["last_result"]["metrics"]):
         return "revert_and_continue"
@@ -527,6 +551,7 @@ def propose_hypothesis(
     current_config: dict,
     diary: ResearchDiary,
     task: TaskAnalysis,
+    allowed_params: list[str] | None = None,
 ) -> Hypothesis:
     """Calls Claude API (claude-haiku-4-5-20251001) to generate a single testable hypothesis as a code/config diff."""
     client = anthropic.Anthropic()
@@ -537,6 +562,23 @@ def propose_hypothesis(
         "You propose exactly ONE config-level change per iteration, grounded in the "
         "experiment history. Return only valid JSON — no prose, no markdown fences."
     )
+    change_rule = (
+        f"Change exactly ONE of these supported hyperparameters: {', '.join(allowed_params)}."
+        if allowed_params
+        else "Change exactly ONE hyperparameter."
+    )
+    if allowed_params:
+        bounds_rule = (
+            "Stay within safe bounds: learning_rate [1e-6, 1e-2], batch_size [4, 8192], "
+            "max_seq_length [128, 4096], lora_rank in [4,8,16,32,64,128], "
+            "num_epochs [1, 100]."
+        )
+    else:
+        bounds_rule = (
+            "Stay within safe bounds: learning_rate [1e-6, 1e-2], batch_size [4, 8192], "
+            "max_seq_length [128, 4096], lora_rank in [4,8,16,32,64,128], "
+            "warmup_steps [0, 2000], dropout [0, 0.5]."
+        )
     user = f"""Current training configuration:
 {json.dumps(current_config, indent=2)}
 
@@ -549,10 +591,8 @@ Recent experiment history ({len(recent)} entries):
 {json.dumps(recent, indent=2) if recent else "No history yet — this is the first iteration."}
 
 Rules:
-- Change exactly ONE hyperparameter.
-- Stay within safe bounds: learning_rate [1e-6, 1e-2], batch_size [4, 8192],
-  max_seq_length [128, 4096], lora_rank in [4,8,16,32,64,128],
-  warmup_steps [0, 2000], dropout [0, 0.5].
+- {change_rule}
+- {bounds_rule}
 - Avoid repeating a change that recently caused a REVERTED outcome.
 - Prefer evidence-based choices over random exploration when history exists.
 
@@ -578,9 +618,17 @@ Respond with this JSON object and nothing else:
             if not line.startswith("```")
         )
     parsed = json.loads(raw)
+    patch = parsed["patch"]
+    if allowed_params:
+        unsupported = [key for key in patch if key not in set(allowed_params)]
+        if unsupported:
+            raise ValueError(
+                f"Unsupported Tinker SFT hyperparameter(s): {unsupported}. "
+                f"Allowed: {allowed_params}"
+            )
     return Hypothesis(
         description=parsed["description"],
-        patch=json.dumps(parsed["patch"]),
+        patch=json.dumps(patch),
         expected_effect=parsed["expected_effect"],
         search_strategy=parsed["search_strategy"],
     )
@@ -616,7 +664,7 @@ def apply_patch(script_path: str, patch: str) -> str:
         #     raise RuntimeError(f"patch failed: {result.stderr}")
         raise NotImplementedError(
             "Script-level patching not yet implemented. "
-            "Requires RUN phase and Tinker job submission."
+            "The Tinker SFT v1 path patches JSON config only."
         )
     else:
         raise ValueError(f"Unsupported file type for patching: {path.suffix!r}")
@@ -631,69 +679,108 @@ def revert_patch(script_path: str, original_content: str) -> None:
 
 # ─── RUN HELPERS ──────────────────────────────────────────────────────────────
 
+def _dataset_result_from_plan(plan: TrainingPlan) -> DatasetResult:
+    dataset_path = plan.get("dataset_path") or str(Path(plan["training_script_path"]).parent)
+    return {
+        "dataset": {
+            "path": dataset_path,
+            "format": "jsonl",
+            "train_size": 0,
+            "val_size": 0,
+            "test_size": 0,
+        },
+        "mode_used": "A",
+        "quality_notes": "AutoResearch Tinker SFT dataset",
+        "validation_report": {
+            "passed": True,
+            "issues": [],
+            "sample_accuracy_estimate": 0.0,
+        },
+    }
+
+
+def _training_config_from_state(state: AutoResearchState) -> TrainingConfig:
+    data: dict[str, Any] = dict(state["current_config"])
+    data.setdefault("model_name", state["plan"].get("base_model") or DEFAULT_TINKER_MODEL)
+    if "max_seq_len" in data and "max_seq_length" not in data:
+        data["max_seq_length"] = data["max_seq_len"]
+    if "epochs" in data and "num_epochs" not in data:
+        data["num_epochs"] = data["epochs"]
+    lora = state["plan"].get("lora_config")
+    if lora and "lora_rank" not in data:
+        data["lora_rank"] = lora["rank"]
+    if lora and "lora_alpha" not in data:
+        data["lora_alpha"] = lora["alpha"]
+    return TrainingConfig.from_dict(data)
+
+
+def _training_config_from_plan(plan: TrainingPlan) -> TrainingConfig:
+    if _CONFIG_PATH.exists():
+        data = TrainingConfig.load(_CONFIG_PATH).to_dict()
+    else:
+        data = {"model_name": plan.get("base_model") or DEFAULT_TINKER_MODEL}
+    data["model_name"] = plan.get("base_model") or data.get("model_name") or DEFAULT_TINKER_MODEL
+    lora = plan.get("lora_config")
+    if lora:
+        data.setdefault("lora_rank", lora["rank"])
+        data.setdefault("lora_alpha", lora["alpha"])
+    return TrainingConfig.from_dict(data)
+
+
+def _max_steps_from_state(state: AutoResearchState) -> int:
+    procedure = state["config"].get("training_procedure", {})
+    hyperparameters = procedure.get("hyperparameters", {})
+    for source in (state["current_config"], hyperparameters, procedure):
+        value = source.get("max_steps") if isinstance(source, dict) else None
+        if value is not None:
+            return max(1, int(value))
+    return DEFAULT_LIVE_SMOKE_STEPS
+
+
 def submit_experiment(
     script_path: str,
     plan: TrainingPlan,
     timeout_min: int = 5,
 ) -> str:
-    """Submits a constrained training run to Tinker. Returns the Tinker job ID."""
-    # Translate our TrainingPlan into a Tinker JobConfig.
-    # GPU allocation is kept minimal: single A100 with the plan's time budget.
-    from src.tinker_api.tinker_api import submit_job
+    """Run a constrained SDK-native Tinker experiment and return its run ID.
 
-    job_config: JobConfig = {
-        "gpu_type": "A100",
-        "num_gpus": 1,
-        "timeout_min": timeout_min,
-        "env_vars": {},
-        "output_dir": "outputs/experiments",
-    }
-    return submit_job(script_path, job_config)
+    Kept as a compatibility wrapper for older call sites; it no longer submits
+    a REST job.
+    """
+    _ = script_path, timeout_min
+    result = run_tinker_sft_experiment(
+        _training_config_from_plan(plan),
+        _dataset_result_from_plan(plan),
+        max_steps=DEFAULT_LIVE_SMOKE_STEPS,
+    )
+    _EXPERIMENT_CACHE[result["job_id"]] = result
+    return result["job_id"]
 
 
 def wait_for_experiment(job_id: str, timeout_min: int) -> ExperimentResult:
-    """Polls Tinker for job completion. Raises TimeoutError if timeout_min exceeded."""
-    import time
-    from src.tinker_api.tinker_api import get_job_status, get_cumulative_spend
+    """Return a completed SDK-native Tinker experiment result."""
+    _ = timeout_min
+    if job_id in _EXPERIMENT_CACHE:
+        return _EXPERIMENT_CACHE[job_id]
 
-    deadline = time.time() + timeout_min * 60
-    poll_interval = 15  # seconds between status checks
-
-    while time.time() < deadline:
-        status = get_job_status(job_id)
-        if status == JobStatus.COMPLETED:
-            cost = get_cumulative_spend(job_id)
-            # Tinker writes metrics to outputs/experiments/<job_id>/metrics.json.
-            metrics_path = Path("outputs/experiments") / job_id / "metrics.json"
-            metrics: TrainingMetrics = json.loads(metrics_path.read_text())
-            model_path = str(Path("outputs/experiments") / job_id / "model")
-            return {
-                "job_id": job_id,
-                "status": status,
-                "metrics": metrics,
-                "model_path": model_path,
-                "cost_usd": cost,
-                "logs_path": str(Path("outputs/experiments") / job_id / "logs.txt"),
-            }
-        if status == JobStatus.FAILED:
-            return {
-                "job_id": job_id,
-                "status": status,
-                "metrics": {
-                    "train_loss": float("nan"),
-                    "val_loss": float("nan"),
-                    "test_loss": float("nan"),
-                    "primary_metric": 0.0,
-                },
-                "model_path": "",
-                "cost_usd": get_cumulative_spend(job_id),
-                "logs_path": str(Path("outputs/experiments") / job_id / "logs.txt"),
-            }
-        time.sleep(poll_interval)
-
-    raise TimeoutError(
-        f"Tinker job {job_id} did not finish within {timeout_min} minutes"
-    )
+    run_dir = Path("outputs/experiments") / job_id
+    metrics_path = run_dir / "metrics.json"
+    if not metrics_path.exists():
+        raise TimeoutError(f"Tinker run {job_id} has no metrics artifact")
+    metrics: TrainingMetrics = json.loads(metrics_path.read_text())
+    manifest_path = run_dir / "manifest.json"
+    status = JobStatus.COMPLETED
+    if manifest_path.exists():
+        manifest = json.loads(manifest_path.read_text())
+        status = manifest.get("status", status)
+    return {
+        "job_id": job_id,
+        "status": status,
+        "metrics": metrics,
+        "model_path": str(run_dir),
+        "cost_usd": 0.0,
+        "logs_path": str(run_dir / "metrics.jsonl"),
+    }
 
 
 def check_early_stop(metrics: TrainingMetrics) -> bool:
@@ -717,21 +804,25 @@ def check_early_stop(metrics: TrainingMetrics) -> bool:
 # ─── EVALUATE HELPERS ─────────────────────────────────────────────────────────
 
 def run_evals(model_path: str, eval_suite: EvalSuite) -> EvalScore:
-    """Runs the evaluation suite against the model and returns a scalar score + per-metric breakdown."""
-    # Wire-in point for the model inference layer (transformers / PEFT / Tinker artifacts).
-    #
-    # Expected implementation:
-    #   1. Load the model from model_path (AutoModelForSequenceClassification or equivalent).
-    #   2. Load the test split from eval_suite["test_split_path"].
-    #   3. Run inference and compute each metric in eval_suite["metrics"].
-    #   4. If eval_suite["use_llm_grading"], call Claude to score free-form outputs.
-    #   5. Return EvalScore with scalar = primary metric value, metrics = per-metric dict.
-    #
-    # Blocked on: transformers model loading + Tinker artifact download (F4).
-    raise NotImplementedError(
-        "run_evals not yet implemented. "
-        "Requires model loading from Tinker artifacts and inference infrastructure."
-    )
+    """Score Tinker SFT artifacts using val loss as the v1 proxy metric."""
+    _ = eval_suite
+    metrics_path = Path(model_path) / "metrics.json"
+    if not metrics_path.exists():
+        raise FileNotFoundError(f"Missing Tinker metrics artifact: {metrics_path}")
+    raw_metrics = json.loads(metrics_path.read_text())
+    val_loss = float(raw_metrics.get("val_loss", raw_metrics.get("train_loss", float("nan"))))
+    scalar = 0.0 if not math.isfinite(val_loss) or val_loss < 0 else 1.0 / (1.0 + val_loss)
+    metrics = {
+        "train_loss": float(raw_metrics.get("train_loss", val_loss)),
+        "val_loss": val_loss,
+        "test_loss": float(raw_metrics.get("test_loss", val_loss)),
+        "primary_metric": scalar,
+    }
+    return {
+        "scalar": scalar,
+        "metrics": metrics,
+        "critique": "Tinker SFT v1 score uses primary_metric = 1 / (1 + val_loss).",
+    }
 
 
 def compare_scores(new_score: EvalScore, baseline_score: EvalScore) -> ScoreDelta:

--- a/src/autoresearch/loop.py
+++ b/src/autoresearch/loop.py
@@ -132,21 +132,21 @@ class AutoResearchLoop:
 
     def run_experiment(self, config: TrainingConfig) -> None:
         """
-        TODO: Submit job to Tinker and block until completion.
+        TODO: Run a bounded SDK-native Tinker experiment and block until completion.
 
         Not implemented in the PROPOSE-only phase.
 
         When RUN is ready, this should:
-          1. Serialise config to a temp JSON and pass to tinker_api.submit_job().
-          2. Poll tinker_api.get_job_status(job_id) until COMPLETED or FAILED.
+          1. Build a TrainingConfig from the candidate config.
+          2. Call run_tinker_sft_experiment() and collect ExperimentResult artifacts.
           3. Respect Cost Manager (F4): if CostManager signals budget exceeded,
-             call tinker_api.cancel_job(job_id) and raise BudgetExceededError.
+             call tinker_api.cancel_job(run_id) and raise BudgetExceededError.
           4. Return ExperimentResult (job_id, metrics, model_path, cost_usd).
 
         See: src/tinker_api/tinker_api.py, src/cost_manager/cost_manager.py.
         """
         raise NotImplementedError(
-            "run_experiment not yet implemented. Requires Tinker job submission (F4)."
+            "run_experiment not yet implemented. Requires the Tinker SFT runner (F4)."
         )
 
     # ──────────────────────────────────────────────────────────────────────────

--- a/src/autoresearch/proposer.py
+++ b/src/autoresearch/proposer.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from src.autoresearch.config import BOUNDS, TrainingConfig
+from src.tinker_api.sft_runner import SUPPORTED_TINKER_TUNABLES
 from src.types import IterationRecord
 
 
@@ -67,8 +68,11 @@ class SearchSpace:
     NON_TUNABLE: frozenset[str] = frozenset({"model_name"})
 
     @classmethod
-    def tunable_params(cls) -> list[str]:
-        return [k for k in BOUNDS if k not in cls.NON_TUNABLE]
+    def tunable_params(cls, backend: str | None = None) -> list[str]:
+        params = [k for k in BOUNDS if k not in cls.NON_TUNABLE]
+        if backend == "tinker_sft":
+            return [k for k in params if k in SUPPORTED_TINKER_TUNABLES]
+        return params
 
     @classmethod
     def sample_value(cls, param: str, rng: random.Random) -> Any:
@@ -151,11 +155,12 @@ class RandomSearchProposalStrategy(ProposalStrategy):
     stored in Proposal.metadata makes any iteration reproducible.
     """
 
-    def __init__(self, seed: int | None = None) -> None:
+    def __init__(self, seed: int | None = None, backend: str | None = None) -> None:
         # _next_seed advances on each call so a fixed initial seed still
         # produces a distinct proposal every iteration.
         self._next_seed = seed
         self._initial_seed = seed
+        self._backend = backend
 
     def propose(self, config: TrainingConfig, history: list[IterationRecord]) -> Proposal:
         if self._next_seed is not None:
@@ -164,7 +169,7 @@ class RandomSearchProposalStrategy(ProposalStrategy):
         else:
             seed = random.randint(0, 2**32 - 1)
         rng = random.Random(seed)
-        param = rng.choice(SearchSpace.tunable_params())
+        param = rng.choice(SearchSpace.tunable_params(self._backend))
         old_val = getattr(config, param, None)
         new_val = SearchSpace.sample_value(param, rng)
         hypothesis = (
@@ -198,10 +203,12 @@ class LocalPerturbationProposalStrategy(ProposalStrategy):
         perturbation_factor: float = 0.2,
         seed: int | None = None,
         history_window: int = 5,
+        backend: str | None = None,
     ) -> None:
         self._factor = perturbation_factor
         self._next_seed = seed
         self._window = history_window
+        self._backend = backend
 
     def propose(self, config: TrainingConfig, history: list[IterationRecord]) -> Proposal:
         if self._next_seed is not None:
@@ -210,7 +217,7 @@ class LocalPerturbationProposalStrategy(ProposalStrategy):
         else:
             seed = random.randint(0, 2**32 - 1)
         rng = random.Random(seed)
-        candidates = SearchSpace.tunable_params()
+        candidates = SearchSpace.tunable_params(self._backend)
 
         # Collect params that appeared in recently REVERTED patches.
         # The diary "patch" field is a diff string (format_patch_as_diff output),

--- a/src/decision_engine/decision_engine.py
+++ b/src/decision_engine/decision_engine.py
@@ -19,12 +19,14 @@ from src.types import (
     TaskAnalysis,
     TrainingPlan,
 )
+from src.tinker_api.sft_runner import DEFAULT_TINKER_MODEL
 
 # Cost per GPU-hour on Tinker (USD) — update when Tinker docs confirm pricing
 _TINKER_GPU_COST_PER_HOUR = 2.50
 
 # Rough model-size → GPU-hours-per-epoch lookup (for cost estimation)
 _MODEL_COST_PROFILE = {
+    DEFAULT_TINKER_MODEL:           {"gpu_hours_per_epoch": 0.15, "strategy": "fine-tune"},
     "bert-base-uncased":        {"gpu_hours_per_epoch": 0.1,  "strategy": "fine-tune"},
     "bert-large-uncased":       {"gpu_hours_per_epoch": 0.3,  "strategy": "fine-tune"},
     "distilbert-base-uncased":  {"gpu_hours_per_epoch": 0.05, "strategy": "fine-tune"},
@@ -34,12 +36,13 @@ _MODEL_COST_PROFILE = {
 }
 
 _TASK_TO_BASE_MODEL = {
-    "text-classification":       "distilbert-base-uncased",
-    "token-classification":      "bert-base-uncased",
-    "seq2seq":                   "t5-small",
-    "question-answering":        "bert-base-uncased",
-    "summarization":             "t5-base",
-    "translation":               "t5-small",
+    "text-classification":       DEFAULT_TINKER_MODEL,
+    "token-classification":      DEFAULT_TINKER_MODEL,
+    "seq2seq":                   DEFAULT_TINKER_MODEL,
+    "question-answering":        DEFAULT_TINKER_MODEL,
+    "summarization":             DEFAULT_TINKER_MODEL,
+    "translation":               DEFAULT_TINKER_MODEL,
+    "custom":                    DEFAULT_TINKER_MODEL,
 }
 
 _TASK_TO_METRIC = {
@@ -78,6 +81,8 @@ def run_decision_engine(
         estimated_time_min=cost["estimated_time_min"],
         training_script_path=script_path,
         eval_metric=task["eval_metric"],
+        backend="tinker_sft",
+        dataset_path=dataset["dataset"]["path"],
     )
 
 

--- a/src/tinker_api/__init__.py
+++ b/src/tinker_api/__init__.py
@@ -14,6 +14,15 @@ from .tinker_api import (
     cancel_job,
     is_cancelled,
 )
+from .sft_runner import (
+    DEFAULT_LIVE_SMOKE_STEPS,
+    DEFAULT_TINKER_MODEL,
+    SUPPORTED_TINKER_TUNABLES,
+    load_conversations,
+    record_to_conversation,
+    resolve_renderer_name,
+    run_tinker_sft_experiment,
+)
 
 __all__ = [
     "TinkerAPIError",
@@ -30,4 +39,11 @@ __all__ = [
     "get_cumulative_spend",
     "cancel_job",
     "is_cancelled",
+    "DEFAULT_LIVE_SMOKE_STEPS",
+    "DEFAULT_TINKER_MODEL",
+    "SUPPORTED_TINKER_TUNABLES",
+    "load_conversations",
+    "record_to_conversation",
+    "resolve_renderer_name",
+    "run_tinker_sft_experiment",
 ]

--- a/src/tinker_api/sft_runner.py
+++ b/src/tinker_api/sft_runner.py
@@ -1,0 +1,495 @@
+"""
+SDK-native Tinker supervised fine-tuning runner.
+
+This module is intentionally lazy about importing ``tinker`` and
+``tinker_cookbook`` so the regular unit suite can run without live SDK
+dependencies installed.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Mapping, Sequence
+from uuid import uuid4
+
+from src.tinker_api.tinker_api import (
+    TinkerAPIError,
+    get_cumulative_spend,
+    is_cancelled,
+    record_tokens,
+)
+from src.types import DatasetResult, ExperimentResult, TrainingMetrics
+
+if TYPE_CHECKING:
+    from src.autoresearch.config import TrainingConfig
+
+DEFAULT_TINKER_MODEL = "Qwen/Qwen3.5-9B"
+DEFAULT_LIVE_SMOKE_STEPS = 5
+QWEN35_9B_RENDERER = "qwen3_5_disable_thinking"
+SUPPORTED_TINKER_TUNABLES: frozenset[str] = frozenset(
+    {"learning_rate", "batch_size", "max_seq_length", "lora_rank", "num_epochs"}
+)
+
+_INPUT_KEYS = ("input", "prompt", "question", "content")
+_TARGET_KEYS = ("output", "answer", "label", "target")
+
+
+def run_tinker_sft_experiment(
+    config: TrainingConfig | Mapping[str, Any],
+    dataset: DatasetResult | str | os.PathLike[str] | Sequence[Mapping[str, Any]],
+    *,
+    run_id: str | None = None,
+    max_steps: int | None = None,
+    output_dir: str = "outputs/experiments",
+    service_client: Any = None,
+) -> ExperimentResult:
+    """Run a short chat/SFT LoRA experiment through the Tinker SDK.
+
+    ``dataset`` may be a repo ``DatasetResult``, a JSONL path, or an in-memory
+    sequence of JSON-like records. Metrics and manifest artifacts are written
+    under ``output_dir/run_id``.
+    """
+    cfg = _coerce_training_config(config)
+    run_name = run_id or f"tinker-sft-{int(time.time())}-{uuid4().hex[:8]}"
+    run_dir = Path(output_dir) / run_name
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    conversations = load_conversations(dataset)
+    if not conversations:
+        raise ValueError("No valid chat/SFT examples found for Tinker training.")
+
+    try:
+        tinker, tinker_types, model_info, renderers, supervised_data, tokenizer_utils = (
+            _load_tinker_deps()
+        )
+        model_name = cfg.model_name or DEFAULT_TINKER_MODEL
+        renderer_name = resolve_renderer_name(model_name, model_info)
+        tokenizer = tokenizer_utils.get_tokenizer(model_name)
+        renderer = renderers.get_renderer(renderer_name, tokenizer)
+
+        svc = service_client if service_client is not None else tinker.ServiceClient()
+        training_client = svc.create_lora_training_client(
+            base_model=model_name,
+            rank=int(cfg.lora_rank or 32),
+        )
+
+        train_on_what = renderers.TrainOnWhat.ALL_ASSISTANT_MESSAGES
+        target_steps = _resolve_target_steps(
+            num_examples=len(conversations),
+            batch_size=cfg.batch_size,
+            num_epochs=cfg.num_epochs,
+            max_steps=max_steps,
+        )
+        metrics_history: list[dict[str, Any]] = []
+        metrics_path = run_dir / "metrics.jsonl"
+        status = "COMPLETED"
+
+        for step in range(target_steps):
+            if is_cancelled(run_name):
+                status = "CANCELLED"
+                break
+
+            batch_conversations = _conversation_batch(conversations, cfg.batch_size, step)
+            batch = [
+                supervised_data.conversation_to_datum(
+                    conversation,
+                    renderer,
+                    cfg.max_seq_length,
+                    train_on_what,
+                )
+                for conversation in batch_conversations
+            ]
+
+            adam_params = tinker_types.AdamParams(learning_rate=cfg.learning_rate)
+            fwd_future = training_client.forward_backward(batch, loss_fn="cross_entropy")
+            optim_future = training_client.optim_step(adam_params)
+            fwd_result = _future_result(fwd_future)
+            optim_result = _future_result(optim_future)
+
+            tokens = sum(_datum_token_count(datum) for datum in batch)
+            record_tokens(run_name, tokens)
+            loss = _extract_loss(fwd_result, optim_result)
+            step_metrics = {
+                "step": step + 1,
+                "train_loss": loss,
+                "val_loss": loss,
+                "test_loss": loss,
+                "primary_metric": _score_from_loss(loss),
+                "tokens": tokens,
+            }
+            metrics_history.append(step_metrics)
+            with open(metrics_path, "a") as fh:
+                fh.write(json.dumps(step_metrics) + "\n")
+
+        checkpoints, sampling_client = _save_final_artifacts(training_client, run_name)
+        sample_payload = _sample_once(
+            sampling_client=sampling_client,
+            renderer=renderer,
+            tinker_types=tinker_types,
+            conversations=conversations,
+        )
+        _write_json(run_dir / "sample.json", sample_payload)
+
+        final_metrics = _final_metrics(metrics_history, status)
+        manifest = {
+            "run_id": run_name,
+            "status": status,
+            "backend": "tinker_sft",
+            "model_name": model_name,
+            "renderer_name": renderer_name,
+            "dataset_path": _dataset_path_for_manifest(dataset),
+            "max_steps": max_steps,
+            "completed_steps": len(metrics_history),
+            "checkpoints": checkpoints,
+        }
+        _write_json(run_dir / "manifest.json", manifest)
+        _write_json(run_dir / "metrics.json", final_metrics)
+
+        return {
+            "job_id": run_name,
+            "status": status,
+            "metrics": final_metrics,
+            "model_path": str(run_dir),
+            "cost_usd": get_cumulative_spend(run_name),
+            "logs_path": str(metrics_path),
+        }
+    except Exception as exc:
+        if isinstance(exc, (TinkerAPIError, ValueError)):
+            raise
+        raise TinkerAPIError(str(exc)) from exc
+
+
+def load_conversations(
+    dataset: DatasetResult | str | os.PathLike[str] | Sequence[Mapping[str, Any]],
+) -> list[list[dict[str, str]]]:
+    """Load and normalize chat/SFT examples into message conversations."""
+    records = _load_records(dataset)
+    conversations: list[list[dict[str, str]]] = []
+    errors: list[str] = []
+    for index, record in enumerate(records):
+        try:
+            conversations.append(record_to_conversation(record))
+        except ValueError as exc:
+            errors.append(f"row {index}: {exc}")
+
+    if records and not conversations:
+        preview = "; ".join(errors[:3])
+        raise ValueError(f"No valid chat/SFT examples found. {preview}")
+    return conversations
+
+
+def record_to_conversation(record: Mapping[str, Any]) -> list[dict[str, str]]:
+    """Convert one JSON-like record into a user/assistant conversation."""
+    messages = record.get("messages")
+    if messages is not None:
+        if not isinstance(messages, list):
+            raise ValueError("messages must be a list")
+        normalized = [_normalize_message(message) for message in messages]
+        if not any(message["role"] == "user" for message in normalized):
+            raise ValueError("messages must contain at least one user message")
+        if not any(message["role"] == "assistant" for message in normalized):
+            raise ValueError("messages must contain at least one assistant message")
+        return normalized
+
+    user_text = _first_text(record, _INPUT_KEYS)
+    assistant_text = _first_text(record, _TARGET_KEYS)
+    if not user_text:
+        raise ValueError(f"missing input field; expected one of {_INPUT_KEYS}")
+    if not assistant_text:
+        raise ValueError(f"missing target field; expected one of {_TARGET_KEYS}")
+    return [
+        {"role": "user", "content": user_text},
+        {"role": "assistant", "content": assistant_text},
+    ]
+
+
+def resolve_renderer_name(model_name: str, model_info_module: Any | None = None) -> str:
+    """Resolve cookbook renderer name, with an explicit Qwen3.5-9B fallback."""
+    if model_info_module is None:
+        _tinker, _types, model_info_module, _renderers, _supervised, _tokenizers = (
+            _load_tinker_deps()
+        )
+    try:
+        return model_info_module.get_recommended_renderer_name(model_name)
+    except Exception:
+        if model_name == DEFAULT_TINKER_MODEL:
+            return QWEN35_9B_RENDERER
+        raise
+
+
+def _coerce_training_config(config: TrainingConfig | Mapping[str, Any]) -> TrainingConfig:
+    from src.autoresearch.config import TrainingConfig
+
+    if isinstance(config, TrainingConfig):
+        data = config.to_dict()
+    else:
+        data = dict(config)
+
+    if not data.get("model_name"):
+        data["model_name"] = DEFAULT_TINKER_MODEL
+    if "max_seq_len" in data and "max_seq_length" not in data:
+        data["max_seq_length"] = data["max_seq_len"]
+    if "epochs" in data and "num_epochs" not in data:
+        data["num_epochs"] = data["epochs"]
+    return TrainingConfig.from_dict(data)
+
+
+def _load_records(
+    dataset: DatasetResult | str | os.PathLike[str] | Sequence[Mapping[str, Any]],
+) -> list[Mapping[str, Any]]:
+    if isinstance(dataset, (str, os.PathLike)):
+        return _read_jsonl_records(_resolve_jsonl_path(Path(dataset)))
+    if isinstance(dataset, Mapping):
+        dataset_meta = dataset.get("dataset")
+        if isinstance(dataset_meta, Mapping) and dataset_meta.get("path"):
+            return _read_jsonl_records(_resolve_jsonl_path(Path(str(dataset_meta["path"]))))
+        if dataset.get("path"):
+            return _read_jsonl_records(_resolve_jsonl_path(Path(str(dataset["path"]))))
+    return [record for record in dataset if isinstance(record, Mapping)]  # type: ignore[arg-type]
+
+
+def _resolve_jsonl_path(path: Path) -> Path:
+    if path.is_file():
+        return path
+    if path.is_dir():
+        for name in ("train.jsonl", "train_data.jsonl", "data.jsonl"):
+            candidate = path / name
+            if candidate.exists():
+                return candidate
+    raise ValueError(f"Could not find JSONL dataset at {path}")
+
+
+def _read_jsonl_records(path: Path) -> list[Mapping[str, Any]]:
+    records: list[Mapping[str, Any]] = []
+    with open(path) as fh:
+        for lineno, line in enumerate(fh, 1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                parsed = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}:{lineno}: invalid JSONL row") from exc
+            if not isinstance(parsed, Mapping):
+                raise ValueError(f"{path}:{lineno}: JSONL row must be an object")
+            records.append(parsed)
+    return records
+
+
+def _normalize_message(message: Any) -> dict[str, str]:
+    if not isinstance(message, Mapping):
+        raise ValueError("message entries must be objects")
+    role = str(message.get("role", "")).strip()
+    content = message.get("content")
+    if role not in {"system", "user", "assistant"}:
+        raise ValueError(f"unsupported message role {role!r}")
+    if content is None or str(content).strip() == "":
+        raise ValueError("message content cannot be empty")
+    return {"role": role, "content": str(content)}
+
+
+def _first_text(record: Mapping[str, Any], keys: Sequence[str]) -> str:
+    for key in keys:
+        value = record.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return ""
+
+
+def _load_tinker_deps() -> tuple[Any, Any, Any, Any, Any, Any]:
+    try:
+        import tinker
+        from tinker import types as tinker_types
+        from tinker_cookbook import model_info, renderers
+        from tinker_cookbook.supervised import data as supervised_data
+        from tinker_cookbook import tokenizer_utils
+    except ImportError as exc:
+        raise TinkerAPIError(
+            "tinker and tinker-cookbook are required for live Tinker SFT runs"
+        ) from exc
+    return tinker, tinker_types, model_info, renderers, supervised_data, tokenizer_utils
+
+
+def _resolve_target_steps(
+    *,
+    num_examples: int,
+    batch_size: int,
+    num_epochs: int,
+    max_steps: int | None,
+) -> int:
+    if max_steps is not None:
+        return max(0, int(max_steps))
+    batches_per_epoch = max(1, math.ceil(num_examples / max(1, batch_size)))
+    return max(1, batches_per_epoch * max(1, int(num_epochs)))
+
+
+def _conversation_batch(
+    conversations: list[list[dict[str, str]]],
+    batch_size: int,
+    step: int,
+) -> list[list[dict[str, str]]]:
+    size = max(1, int(batch_size))
+    start = step * size
+    return [conversations[(start + offset) % len(conversations)] for offset in range(size)]
+
+
+def _future_result(value: Any) -> Any:
+    result = getattr(value, "result", None)
+    if callable(result):
+        return result()
+    return value
+
+
+def _datum_token_count(datum: Any) -> int:
+    model_input = getattr(datum, "model_input", None)
+    if model_input is None:
+        return 0
+    length = getattr(model_input, "length", None)
+    if isinstance(length, int):
+        return length
+    tokens = getattr(model_input, "tokens", None)
+    if tokens is not None:
+        return len(tokens)
+    to_ints = getattr(model_input, "to_ints", None)
+    if callable(to_ints):
+        return len(to_ints())
+    return 0
+
+
+def _extract_loss(*results: Any) -> float:
+    for result in results:
+        if result is None:
+            continue
+        loss = getattr(result, "loss", None)
+        if isinstance(loss, (int, float)):
+            return float(loss)
+        metrics = getattr(result, "metrics", None)
+        if isinstance(metrics, Mapping):
+            for key in ("loss", "train_loss", "mean_loss", "nll"):
+                value = metrics.get(key)
+                if isinstance(value, (int, float)):
+                    return float(value)
+    return 0.0
+
+
+def _score_from_loss(loss: float | None) -> float:
+    if loss is None or not math.isfinite(loss) or loss < 0:
+        return 0.0
+    return 1.0 / (1.0 + loss)
+
+
+def _save_final_artifacts(training_client: Any, run_id: str) -> tuple[dict[str, str], Any]:
+    checkpoints: dict[str, str] = {}
+    state_result = _call_optional_checkpoint(training_client, "save_state", f"{run_id}-final-state")
+    if state_result:
+        checkpoints["state_path"] = state_result
+    sampler_result = _call_optional_checkpoint(
+        training_client,
+        "save_weights_for_sampler",
+        f"{run_id}-final-sampler",
+    )
+    if sampler_result:
+        checkpoints["sampler_path"] = sampler_result
+
+    get_sampling = getattr(training_client, "save_weights_and_get_sampling_client", None)
+    if not callable(get_sampling):
+        return checkpoints, None
+    try:
+        sampling_client = _future_result(get_sampling())
+    except TypeError:
+        sampling_client = _future_result(get_sampling(name=f"{run_id}-final-sampling-client"))
+    return checkpoints, sampling_client
+
+
+def _call_optional_checkpoint(training_client: Any, method_name: str, name: str) -> str | None:
+    method = getattr(training_client, method_name, None)
+    if not callable(method):
+        return None
+    result = _future_result(method(name=name))
+    path = getattr(result, "path", None)
+    if path is not None:
+        return str(path)
+    if isinstance(result, str):
+        return result
+    return None
+
+
+def _sample_once(
+    *,
+    sampling_client: Any,
+    renderer: Any,
+    tinker_types: Any,
+    conversations: list[list[dict[str, str]]],
+) -> dict[str, Any]:
+    prompt_messages = [message for message in conversations[0] if message["role"] != "assistant"]
+    if not prompt_messages:
+        prompt_messages = [{"role": "user", "content": conversations[0][0]["content"]}]
+
+    if sampling_client is None:
+        return {"prompt": prompt_messages, "text": "", "tokens": [], "error": "no sampling client"}
+
+    model_input = renderer.build_generation_prompt(prompt_messages)
+    sampling_params = tinker_types.SamplingParams(
+        max_tokens=64,
+        stop=renderer.get_stop_sequences(),
+    )
+    response = _future_result(
+        sampling_client.sample(
+            prompt=model_input,
+            num_samples=1,
+            sampling_params=sampling_params,
+        )
+    )
+    sequences = getattr(response, "sequences", None) or getattr(response, "samples", None) or []
+    if not sequences:
+        return {"prompt": prompt_messages, "text": "", "tokens": []}
+    tokens = list(getattr(sequences[0], "tokens", []))
+    try:
+        parsed, _termination = renderer.parse_response(tokens)
+        content = parsed.get("content", "") if isinstance(parsed, Mapping) else str(parsed)
+    except Exception:
+        content = ""
+    return {"prompt": prompt_messages, "text": content, "tokens": tokens}
+
+
+def _final_metrics(metrics_history: list[dict[str, Any]], status: str) -> TrainingMetrics:
+    if not metrics_history:
+        loss = float("nan") if status == "FAILED" else 0.0
+        return {
+            "train_loss": loss,
+            "val_loss": loss,
+            "test_loss": loss,
+            "primary_metric": _score_from_loss(loss),
+        }
+    last = metrics_history[-1]
+    loss = float(last["train_loss"])
+    return {
+        "train_loss": loss,
+        "val_loss": float(last["val_loss"]),
+        "test_loss": float(last["test_loss"]),
+        "primary_metric": float(last["primary_metric"]),
+    }
+
+
+def _dataset_path_for_manifest(
+    dataset: DatasetResult | str | os.PathLike[str] | Sequence[Mapping[str, Any]],
+) -> str | None:
+    if isinstance(dataset, (str, os.PathLike)):
+        return str(dataset)
+    if isinstance(dataset, Mapping):
+        dataset_meta = dataset.get("dataset")
+        if isinstance(dataset_meta, Mapping) and dataset_meta.get("path"):
+            return str(dataset_meta["path"])
+        if dataset.get("path"):
+            return str(dataset["path"])
+    return None
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as fh:
+        json.dump(payload, fh, indent=2, allow_nan=True)

--- a/src/types.py
+++ b/src/types.py
@@ -138,7 +138,7 @@ class CostEstimate(TypedDict):
     confidence: str  # 'low' | 'medium' | 'high'
 
 
-class TrainingPlan(TypedDict):
+class _TrainingPlanRequired(TypedDict):
     strategy: str           # 'fine-tune' | 'pre-train'
     base_model: str | None
     lora_config: LoRAConfig | None
@@ -146,6 +146,11 @@ class TrainingPlan(TypedDict):
     estimated_time_min: int
     training_script_path: str
     eval_metric: str
+
+
+class TrainingPlan(_TrainingPlanRequired, total=False):
+    backend: str            # 'tinker_sft' for the SDK-native Tinker v1 path
+    dataset_path: str       # Local JSONL path consumed by the Tinker SFT runner
 
 
 class EvalScore(TypedDict):

--- a/tests/integration/test_tinker_live_smoke.py
+++ b/tests/integration/test_tinker_live_smoke.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.autoresearch.config import TrainingConfig
+from src.tinker_api.sft_runner import (
+    DEFAULT_LIVE_SMOKE_STEPS,
+    DEFAULT_TINKER_MODEL,
+    run_tinker_sft_experiment,
+)
+
+
+def test_live_tinker_chat_sft_smoke(tmp_path):
+    if os.getenv("RUN_LIVE_TINKER") != "1":
+        pytest.skip("set RUN_LIVE_TINKER=1 to run the live Tinker smoke test")
+    if not os.getenv("TINKER_API_KEY"):
+        pytest.skip("TINKER_API_KEY is required for the live Tinker smoke test")
+
+    model = os.getenv("TINKER_SMOKE_MODEL", DEFAULT_TINKER_MODEL)
+    steps = int(os.getenv("TINKER_SMOKE_STEPS", str(DEFAULT_LIVE_SMOKE_STEPS)))
+    data_path = tmp_path / "train.jsonl"
+    rows = [
+        {"input": "Reply with the word alpha.", "output": "alpha"},
+        {"input": "Reply with the word beta.", "output": "beta"},
+        {"input": "Reply with the word gamma.", "output": "gamma"},
+        {"input": "Reply with the word delta.", "output": "delta"},
+        {"input": "Reply with the word epsilon.", "output": "epsilon"},
+    ]
+    data_path.write_text("".join(json.dumps(row) + "\n" for row in rows))
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(
+            model_name=model,
+            learning_rate=1e-4,
+            batch_size=1,
+            num_epochs=1,
+            max_seq_length=512,
+            lora_rank=8,
+        ),
+        str(data_path),
+        run_id="live-tinker-smoke",
+        max_steps=steps,
+        output_dir=str(tmp_path / "experiments"),
+    )
+
+    run_dir = tmp_path / "experiments" / "live-tinker-smoke"
+    assert result["status"] == "COMPLETED"
+    assert result["model_path"] == str(run_dir)
+    assert (run_dir / "metrics.json").exists()
+    assert (run_dir / "metrics.jsonl").exists()
+    assert (run_dir / "manifest.json").exists()
+    assert (run_dir / "sample.json").exists()
+    manifest = json.loads((run_dir / "manifest.json").read_text())
+    assert manifest["completed_steps"] == steps
+    assert manifest["checkpoints"]

--- a/tests/test_tinker_runner.py
+++ b/tests/test_tinker_runner.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.autoresearch.config import TrainingConfig
+
+
+def test_record_to_conversation_accepts_messages():
+    from src.tinker_api.sft_runner import record_to_conversation
+
+    messages = [
+        {"role": "system", "content": "Be brief."},
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi"},
+    ]
+    assert record_to_conversation({"messages": messages}) == messages
+
+
+def test_record_to_conversation_converts_input_output():
+    from src.tinker_api.sft_runner import record_to_conversation
+
+    assert record_to_conversation({"input": "Classify this", "output": "positive"}) == [
+        {"role": "user", "content": "Classify this"},
+        {"role": "assistant", "content": "positive"},
+    ]
+
+
+def test_record_to_conversation_converts_input_label():
+    from src.tinker_api.sft_runner import record_to_conversation
+
+    assert record_to_conversation({"input": "Classify this", "label": 1})[-1] == {
+        "role": "assistant",
+        "content": "1",
+    }
+
+
+def test_record_to_conversation_rejects_malformed_record():
+    from src.tinker_api.sft_runner import record_to_conversation
+
+    with pytest.raises(ValueError, match="missing target"):
+        record_to_conversation({"input": "No answer"})
+
+
+def test_load_conversations_returns_empty_for_empty_jsonl(tmp_path):
+    from src.tinker_api.sft_runner import load_conversations
+
+    path = tmp_path / "train.jsonl"
+    path.write_text("")
+    assert load_conversations(path) == []
+
+
+def test_resolve_renderer_fallback_for_qwen35_9b():
+    from src.tinker_api.sft_runner import DEFAULT_TINKER_MODEL, resolve_renderer_name
+
+    model_info = MagicMock()
+    model_info.get_recommended_renderer_name.side_effect = KeyError(DEFAULT_TINKER_MODEL)
+
+    assert resolve_renderer_name(DEFAULT_TINKER_MODEL, model_info) == "qwen3_5_disable_thinking"
+
+
+def test_tinker_search_space_can_be_restricted_to_supported_tunables():
+    from src.autoresearch.proposer import SearchSpace
+    from src.tinker_api.sft_runner import SUPPORTED_TINKER_TUNABLES
+
+    assert set(SearchSpace.tunable_params("tinker_sft")) == set(SUPPORTED_TINKER_TUNABLES)
+    assert "dropout" not in SearchSpace.tunable_params("tinker_sft")
+    assert "warmup_steps" not in SearchSpace.tunable_params("tinker_sft")
+
+
+def test_run_tinker_sft_experiment_writes_artifacts(tmp_path, monkeypatch):
+    state = _install_fake_tinker_stack(monkeypatch, losses=[0.5, 0.25])
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [
+            {"input": "Say hello", "output": "hello"},
+            {
+                "messages": [
+                    {"role": "user", "content": "2+2"},
+                    {"role": "assistant", "content": "4"},
+                ]
+            },
+        ],
+    )
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=1),
+        str(data_path),
+        run_id="unit-run",
+        max_steps=2,
+        output_dir=str(tmp_path / "experiments"),
+    )
+
+    run_dir = tmp_path / "experiments" / "unit-run"
+    assert result["status"] == "COMPLETED"
+    assert result["model_path"] == str(run_dir)
+    assert json.loads((run_dir / "metrics.json").read_text())["val_loss"] == pytest.approx(0.25)
+    assert (run_dir / "metrics.jsonl").read_text().count("\n") == 2
+    manifest = json.loads((run_dir / "manifest.json").read_text())
+    assert manifest["checkpoints"]["state_path"].startswith("tinker://state/")
+    assert manifest["checkpoints"]["sampler_path"].startswith("tinker://sampler/")
+    assert json.loads((run_dir / "sample.json").read_text())["text"] == "sample text"
+    assert state.training_client.forward_backward_calls == 2
+    assert state.training_client.optim_step_calls == 2
+
+
+def test_run_tinker_sft_experiment_stops_on_cancel_and_writes_artifacts(tmp_path, monkeypatch):
+    _install_fake_tinker_stack(monkeypatch, losses=[0.5, 0.25, 0.1])
+    from src.tinker_api import tinker_api
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    original_record_tokens = tinker_api.record_tokens
+
+    def cancel_after_first_step(job_id: str, n_tokens: int) -> None:
+        original_record_tokens(job_id, n_tokens)
+        tinker_api.cancel_job(job_id)
+
+    monkeypatch.setattr("src.tinker_api.sft_runner.record_tokens", cancel_after_first_step)
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [{"input": "Question", "output": "Answer"}],
+    )
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=1),
+        data_path,
+        run_id="cancel-run",
+        max_steps=3,
+        output_dir=str(tmp_path / "experiments"),
+    )
+
+    run_dir = tmp_path / "experiments" / "cancel-run"
+    assert result["status"] == "CANCELLED"
+    assert (run_dir / "manifest.json").exists()
+    assert (run_dir / "sample.json").exists()
+    assert (run_dir / "metrics.jsonl").read_text().count("\n") == 1
+
+
+def test_run_evals_scores_tinker_metrics(tmp_path):
+    from src.autoresearch.autoresearch import run_evals
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "metrics.json").write_text(
+        json.dumps({"train_loss": 0.5, "val_loss": 1.0, "test_loss": 1.2})
+    )
+
+    score = run_evals(
+        str(run_dir),
+        {
+            "primary_metric": "primary_metric",
+            "metrics": [],
+            "test_split_path": "",
+            "use_llm_grading": False,
+        },
+    )
+
+    assert score["scalar"] == pytest.approx(0.5)
+    assert score["metrics"]["primary_metric"] == pytest.approx(0.5)
+
+
+def test_autoresearch_run_node_calls_tinker_runner(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    data_path = _write_jsonl(tmp_path / "train.jsonl", [{"input": "x", "output": "y"}])
+    captured = {}
+
+    def fake_runner(config, dataset, *, max_steps=None, **kwargs):
+        captured["config"] = config
+        captured["dataset"] = dataset
+        captured["max_steps"] = max_steps
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        (run_dir / "metrics.json").write_text(
+            json.dumps({"train_loss": 0.5, "val_loss": 0.5, "test_loss": 0.5})
+        )
+        return {
+            "job_id": "fake-run",
+            "status": "COMPLETED",
+            "metrics": {
+                "train_loss": 0.5,
+                "val_loss": 0.5,
+                "test_loss": 0.5,
+                "primary_metric": 2 / 3,
+            },
+            "model_path": str(run_dir),
+            "cost_usd": 0.01,
+            "logs_path": str(run_dir / "metrics.jsonl"),
+        }
+
+    monkeypatch.setattr(ar, "run_tinker_sft_experiment", fake_runner)
+    state = _autoresearch_state(str(data_path))
+
+    result = ar.run_node(state)
+
+    assert result["last_result"]["job_id"] == "fake-run"
+    assert captured["max_steps"] == 5
+    assert captured["dataset"]["dataset"]["path"] == str(data_path)
+    assert captured["config"].model_name == "Qwen/Qwen3.5-9B"
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> Path:
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows))
+    return path
+
+
+def _autoresearch_state(dataset_path: str) -> dict:
+    return {
+        "plan": {
+            "strategy": "fine-tune",
+            "base_model": "Qwen/Qwen3.5-9B",
+            "lora_config": {"rank": 8, "alpha": 16, "dropout": 0.05, "target_modules": []},
+            "estimated_cost": 1.0,
+            "estimated_time_min": 5,
+            "training_script_path": "outputs/scripts/train.py",
+            "eval_metric": "primary_metric",
+            "backend": "tinker_sft",
+            "dataset_path": dataset_path,
+        },
+        "config": {
+            "data": False,
+            "prompt": "test",
+            "compute_budget": 10.0,
+            "training_procedure": {
+                "task_type": "text-classification",
+                "data_format": "jsonl",
+                "training_type": "SFT",
+                "base_model": "Qwen/Qwen3.5-9B",
+                "hyperparameters": {"learning_rate": 1e-4, "batch_size": 1},
+                "notes": "",
+            },
+        },
+        "eval_suite": {
+            "primary_metric": "primary_metric",
+            "metrics": ["primary_metric"],
+            "test_split_path": "",
+            "use_llm_grading": False,
+        },
+        "current_script": "outputs/scripts/train.py",
+        "current_config": {"learning_rate": 1e-4, "batch_size": 1},
+        "current_patch": None,
+        "last_description": None,
+        "original_content": None,
+        "diary": [],
+        "baseline_score": None,
+        "best_score": None,
+        "best_script": "outputs/scripts/train.py",
+        "last_result": None,
+        "last_score": None,
+        "last_delta": None,
+        "iteration": 0,
+        "no_improve_streak": 0,
+        "should_stop": False,
+    }
+
+
+class _FakeFuture:
+    def __init__(self, value):
+        self._value = value
+
+    def result(self):
+        return self._value
+
+
+class _FakeModelInput:
+    def __init__(self, length: int):
+        self.length = length
+
+
+class _FakeDatum:
+    def __init__(self, length: int):
+        self.model_input = _FakeModelInput(length)
+
+
+class _FakeRenderer:
+    def build_generation_prompt(self, messages):
+        return _FakeModelInput(len(messages) + 1)
+
+    def get_stop_sequences(self):
+        return [0]
+
+    def parse_response(self, tokens):
+        return {"role": "assistant", "content": "sample text"}, "stop"
+
+
+class _FakeTrainingClient:
+    def __init__(self, losses):
+        self.losses = list(losses)
+        self.forward_backward_calls = 0
+        self.optim_step_calls = 0
+        self.sampling_client = _FakeSamplingClient()
+
+    def forward_backward(self, batch, loss_fn):
+        self.forward_backward_calls += 1
+        loss = self.losses[min(self.forward_backward_calls - 1, len(self.losses) - 1)]
+        return _FakeFuture(types.SimpleNamespace(loss=loss))
+
+    def optim_step(self, adam_params):
+        self.optim_step_calls += 1
+        return _FakeFuture(types.SimpleNamespace(metrics={}))
+
+    def save_state(self, name):
+        return _FakeFuture(types.SimpleNamespace(path=f"tinker://state/{name}"))
+
+    def save_weights_for_sampler(self, name):
+        return _FakeFuture(types.SimpleNamespace(path=f"tinker://sampler/{name}"))
+
+    def save_weights_and_get_sampling_client(self, name=None):
+        return self.sampling_client
+
+
+class _FakeSamplingClient:
+    def sample(self, prompt, num_samples, sampling_params):
+        sequence = types.SimpleNamespace(tokens=[10, 11, 12])
+        return _FakeFuture(types.SimpleNamespace(sequences=[sequence]))
+
+
+class _FakeServiceClient:
+    def __init__(self, training_client):
+        self.training_client = training_client
+
+    def create_lora_training_client(self, base_model, rank):
+        self.base_model = base_model
+        self.rank = rank
+        return self.training_client
+
+
+def _install_fake_tinker_stack(monkeypatch, losses):
+    training_client = _FakeTrainingClient(losses)
+    service_client = _FakeServiceClient(training_client)
+
+    tinker_mod = types.ModuleType("tinker")
+    tinker_types_mod = types.ModuleType("tinker.types")
+
+    class AdamParams:
+        def __init__(self, learning_rate):
+            self.learning_rate = learning_rate
+
+    class SamplingParams:
+        def __init__(self, max_tokens, stop):
+            self.max_tokens = max_tokens
+            self.stop = stop
+
+    tinker_types_mod.AdamParams = AdamParams
+    tinker_types_mod.SamplingParams = SamplingParams
+    tinker_mod.types = tinker_types_mod
+    tinker_mod.ServiceClient = lambda: service_client
+
+    cookbook = types.ModuleType("tinker_cookbook")
+    model_info = types.ModuleType("tinker_cookbook.model_info")
+    model_info.get_recommended_renderer_name = MagicMock(side_effect=KeyError("missing"))
+    renderers = types.ModuleType("tinker_cookbook.renderers")
+    renderers.TrainOnWhat = types.SimpleNamespace(ALL_ASSISTANT_MESSAGES="assistant")
+    renderers.get_renderer = MagicMock(return_value=_FakeRenderer())
+    tokenizer_utils = types.ModuleType("tinker_cookbook.tokenizer_utils")
+    tokenizer_utils.get_tokenizer = MagicMock(return_value=object())
+    supervised_pkg = types.ModuleType("tinker_cookbook.supervised")
+    supervised_data = types.ModuleType("tinker_cookbook.supervised.data")
+
+    def conversation_to_datum(conversation, renderer, max_length, train_on_what):
+        return _FakeDatum(length=len(json.dumps(conversation)))
+
+    supervised_data.conversation_to_datum = conversation_to_datum
+    supervised_pkg.data = supervised_data
+    cookbook.model_info = model_info
+    cookbook.renderers = renderers
+    cookbook.tokenizer_utils = tokenizer_utils
+
+    for name in [
+        "tinker",
+        "tinker.types",
+        "tinker_cookbook",
+        "tinker_cookbook.model_info",
+        "tinker_cookbook.renderers",
+        "tinker_cookbook.tokenizer_utils",
+        "tinker_cookbook.supervised",
+        "tinker_cookbook.supervised.data",
+    ]:
+        sys.modules.pop(name, None)
+
+    monkeypatch.setitem(sys.modules, "tinker", tinker_mod)
+    monkeypatch.setitem(sys.modules, "tinker.types", tinker_types_mod)
+    monkeypatch.setitem(sys.modules, "tinker_cookbook", cookbook)
+    monkeypatch.setitem(sys.modules, "tinker_cookbook.model_info", model_info)
+    monkeypatch.setitem(sys.modules, "tinker_cookbook.renderers", renderers)
+    monkeypatch.setitem(sys.modules, "tinker_cookbook.tokenizer_utils", tokenizer_utils)
+    monkeypatch.setitem(sys.modules, "tinker_cookbook.supervised", supervised_pkg)
+    monkeypatch.setitem(sys.modules, "tinker_cookbook.supervised.data", supervised_data)
+
+    importlib.reload(importlib.import_module("src.tinker_api.sft_runner"))
+    return types.SimpleNamespace(training_client=training_client, service_client=service_client)


### PR DESCRIPTION
## Summary
- Add an SDK-native Tinker chat/SFT runner for JSONL data, LoRA training, metrics, checkpoint metadata, and sample artifacts.
- Wire the full AutoResearch graph to call the runner directly and score runs with `primary_metric = 1 / (1 + val_loss)`.
- Extend the training plan/search-space path for `backend="tinker_sft"` and restrict Tinker proposals to supported v1 tunables.
- Add focused fake-client tests plus a gated live Tinker smoke test.

## Dependency surface
- Added `tinker` and `tinker-cookbook` to the root `requirements.txt` used by the main `src/` package.
- Left `autoresearch/pyproject.toml` unchanged because that folder is a standalone Karpathy-style example project, not the install surface for this integration.

## Related Issues
Refs #23
Refs #2

## Coordination Notes
- This may conflict with PR #33, which touches `src/autoresearch/autoresearch.py`, `requirements.txt`, and `tests/test_autoresearch.py`.
- This may conflict lightly with PR #31, which touches `src/types.py`.

## Validation
- `python3 -m compileall src`
- `uvx --with anthropic --with tinker --with tinker-cookbook pytest tests/test_tinker_api.py tests/test_autoresearch.py tests/test_e2e_propose.py tests/test_tinker_runner.py tests/test_decision_engine.py tests/test_manager.py tests/test_cost_manager.py tests/integration/test_tinker_live_smoke.py -q` -> `94 passed, 7 skipped`
- Live smoke with `RUN_LIVE_TINKER=1`, `TINKER_SMOKE_MODEL="Qwen/Qwen3.5-9B"`, `TINKER_SMOKE_STEPS=5` -> `1 passed in 55.78s`
- `git diff --check`

The live smoke sourced `TINKER_API_KEY` from the local environment only; the key was not printed, committed, or included in artifacts.
