### PR TITLE
[codex] curate DataGen handoffs

### DIFF
--- a/src/data_generator/__init__.py
+++ b/src/data_generator/__init__.py
@@ -1,3 +1,9 @@
+from .curation import curate_handoff_to_dataset_result, curate_record
 from .data_generator import build_data_generator_graph, invoke_data_generator_graph
 
-__all__ = ["build_data_generator_graph", "invoke_data_generator_graph"]
+__all__ = [
+    "build_data_generator_graph",
+    "invoke_data_generator_graph",
+    "curate_record",
+    "curate_handoff_to_dataset_result",
+]

--- a/src/data_generator/curation.py
+++ b/src/data_generator/curation.py
@@ -28,8 +28,8 @@ def curate_handoff_to_dataset_result(
     assistant target.
     """
     mode = str(handoff.get("mode_used") or "C")
-    raw_data = handoff.get("raw_data") or {}
-    records = raw_data.get("records", []) if isinstance(raw_data, Mapping) else []
+    config = handoff.get("config") if isinstance(handoff.get("config"), Mapping) else {}
+    records, record_source = _records_from_handoff(handoff)
 
     curated: list[dict[str, Any]] = []
     issues: list[str] = []
@@ -38,7 +38,14 @@ def curate_handoff_to_dataset_result(
             issues.append(f"row {index}: record must be an object")
             continue
         try:
-            curated.append(curate_record(record))
+            curated.append(
+                curate_record(
+                    record,
+                    mode=mode,
+                    config=config,
+                    record_source=record_source,
+                )
+            )
         except ValueError as exc:
             issues.append(f"row {index}: {exc}")
 
@@ -49,19 +56,36 @@ def curate_handoff_to_dataset_result(
             fh.write(json.dumps(record) + "\n")
 
     dropped = len(records) - len(curated)
-    validation_issues = _validation_issues(issues, dropped, len(curated))
+    validation_issues = _validation_issues(
+        issues,
+        dropped,
+        len(curated),
+        handoff.get("validation_report"),
+    )
+    upstream_validation = handoff.get("validation_report")
+    upstream_passed = (
+        bool(upstream_validation.get("passed", True))
+        if isinstance(upstream_validation, Mapping)
+        else True
+    )
+    sample_accuracy = (
+        float(upstream_validation.get("sample_accuracy_estimate", 0.9))
+        if isinstance(upstream_validation, Mapping)
+        else (0.9 if curated else 0.0)
+    )
     dataset: StandardDataset = {
         "path": os.path.abspath(output_path),
         "format": "jsonl",
         **_split_counts(len(curated)),
     }
     validation_report: ValidationReport = {
-        "passed": bool(curated),
+        "passed": bool(curated) and upstream_passed,
         "issues": validation_issues,
-        "sample_accuracy_estimate": 0.9 if curated else 0.0,
+        "sample_accuracy_estimate": sample_accuracy if curated else 0.0,
     }
     quality_notes = (
-        f"DataGen mode {mode}; curated {len(curated)} of {len(records)} raw records"
+        f"DataGen mode {mode}; curated {len(curated)} of {len(records)} "
+        f"{record_source} record(s)"
     )
     if dropped:
         quality_notes += f"; dropped {dropped} malformed record(s)"
@@ -74,7 +98,13 @@ def curate_handoff_to_dataset_result(
     }
 
 
-def curate_record(record: Mapping[str, Any]) -> dict[str, Any]:
+def curate_record(
+    record: Mapping[str, Any],
+    *,
+    mode: str | None = None,
+    config: Mapping[str, Any] | None = None,
+    record_source: str = "raw_data",
+) -> dict[str, Any]:
     """Curate one raw record into a Tinker chat/SFT-compatible JSON object."""
     messages = record.get("messages")
     if messages is not None:
@@ -90,8 +120,76 @@ def curate_record(record: Mapping[str, Any]) -> dict[str, Any]:
     if not user_text:
         raise ValueError(f"missing input field; expected one of {_INPUT_KEYS}")
     if not target_text:
+        if _is_mode_c_web_record(record, mode, record_source):
+            return _curate_web_source_record(record, user_text, config)
         raise ValueError(f"missing target field; expected one of {_TARGET_KEYS}")
     return {"input": user_text, "output": target_text}
+
+
+def _records_from_handoff(handoff: Mapping[str, Any]) -> tuple[list[Any], str]:
+    curation_payload = handoff.get("curation_payload")
+    if isinstance(curation_payload, Mapping):
+        records = curation_payload.get("records")
+        if isinstance(records, list):
+            return records, "curation_payload"
+
+    raw_data = handoff.get("raw_data") or {}
+    if isinstance(raw_data, Mapping) and isinstance(raw_data.get("records"), list):
+        return raw_data["records"], "raw_data"
+
+    return [], "raw_data"
+
+
+def _is_mode_c_web_record(
+    record: Mapping[str, Any],
+    mode: str | None,
+    record_source: str,
+) -> bool:
+    if mode != "C":
+        return False
+    source_kind = str(record.get("source_kind") or record.get("source_type") or "")
+    source = str(record.get("source") or "")
+    metadata = record.get("metadata") if isinstance(record.get("metadata"), Mapping) else {}
+    if record_source == "curation_payload" and source_kind in {
+        "web",
+        "web_page",
+        "web_asset",
+        "html",
+        "pdf",
+        "csv",
+        "json",
+        "image",
+    }:
+        return True
+    if source in {"web_page", "web_asset", "web_search", "mode_c_web_acquisition"}:
+        return True
+    if record.get("url") or record.get("source_locator"):
+        return True
+    return str(metadata.get("extraction_method") or "") != ""
+
+
+def _curate_web_source_record(
+    record: Mapping[str, Any],
+    input_text: str,
+    config: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    task = _task_prompt(config)
+    source = _first_text(record, ("source_locator", "url", "title", "domain"))
+    user_content = (
+        f"Task: {task}\n"
+        f"Source: {source or 'web acquisition'}\n"
+        f"Content: {input_text}"
+    )
+    assistant_content = (
+        "candidate_source: this acquired source contains material that can be "
+        "used by the data curation step for the requested task."
+    )
+    return {
+        "messages": [
+            {"role": "user", "content": user_content},
+            {"role": "assistant", "content": assistant_content},
+        ]
+    }
 
 
 def _normalize_messages(messages: Any) -> list[dict[str, str]]:
@@ -119,6 +217,12 @@ def _first_text(record: Mapping[str, Any], keys: Sequence[str]) -> str:
     return ""
 
 
+def _task_prompt(config: Mapping[str, Any] | None) -> str:
+    if not config:
+        return "the requested ML task"
+    return " ".join(str(config.get("prompt", "the requested ML task")).split())
+
+
 def _split_counts(n_records: int) -> dict[str, int]:
     if n_records <= 0:
         return {"train_size": 0, "val_size": 0, "test_size": 0}
@@ -136,8 +240,13 @@ def _validation_issues(
     row_issues: list[str],
     dropped: int,
     curated_count: int,
+    upstream_validation: Any = None,
 ) -> list[str]:
     issues: list[str] = []
+    if isinstance(upstream_validation, Mapping):
+        upstream_issues = upstream_validation.get("issues", [])
+        if isinstance(upstream_issues, list):
+            issues.extend(str(issue) for issue in upstream_issues if str(issue).strip())
     if dropped:
         preview = "; ".join(row_issues[:3])
         issues.append(f"Dropped {dropped} malformed record(s). {preview}")

--- a/src/data_generator/curation.py
+++ b/src/data_generator/curation.py
@@ -1,0 +1,146 @@
+"""Data curation helpers for turning DataGen handoffs into trainable JSONL."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from src.types import DatasetResult, StandardDataset, ValidationReport
+
+_INPUT_KEYS = ("input", "prompt", "question", "content", "text", "utterance")
+_TARGET_KEYS = ("output", "answer", "label", "target", "label_text", "intent")
+_ALLOWED_MESSAGE_ROLES = {"system", "user", "assistant"}
+
+
+def curate_handoff_to_dataset_result(
+    handoff: Mapping[str, Any],
+    *,
+    output_dir: str = "outputs/datasets",
+    filename: str = "train_data.jsonl",
+) -> DatasetResult:
+    """Normalize a DataGen handoff into a local JSONL DatasetResult.
+
+    The curator is deliberately deterministic for the MVP. It accepts either
+    chat records with ``messages`` or single-turn ``input``/``output``-style
+    records, and drops rows that cannot produce both a user input and an
+    assistant target.
+    """
+    mode = str(handoff.get("mode_used") or "C")
+    raw_data = handoff.get("raw_data") or {}
+    records = raw_data.get("records", []) if isinstance(raw_data, Mapping) else []
+
+    curated: list[dict[str, Any]] = []
+    issues: list[str] = []
+    for index, record in enumerate(records):
+        if not isinstance(record, Mapping):
+            issues.append(f"row {index}: record must be an object")
+            continue
+        try:
+            curated.append(curate_record(record))
+        except ValueError as exc:
+            issues.append(f"row {index}: {exc}")
+
+    output_path = Path(output_dir) / filename
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as fh:
+        for record in curated:
+            fh.write(json.dumps(record) + "\n")
+
+    dropped = len(records) - len(curated)
+    validation_issues = _validation_issues(issues, dropped, len(curated))
+    dataset: StandardDataset = {
+        "path": os.path.abspath(output_path),
+        "format": "jsonl",
+        **_split_counts(len(curated)),
+    }
+    validation_report: ValidationReport = {
+        "passed": bool(curated),
+        "issues": validation_issues,
+        "sample_accuracy_estimate": 0.9 if curated else 0.0,
+    }
+    quality_notes = (
+        f"DataGen mode {mode}; curated {len(curated)} of {len(records)} raw records"
+    )
+    if dropped:
+        quality_notes += f"; dropped {dropped} malformed record(s)"
+
+    return {
+        "dataset": dataset,
+        "mode_used": mode,
+        "quality_notes": quality_notes,
+        "validation_report": validation_report,
+    }
+
+
+def curate_record(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Curate one raw record into a Tinker chat/SFT-compatible JSON object."""
+    messages = record.get("messages")
+    if messages is not None:
+        normalized = _normalize_messages(messages)
+        if not any(message["role"] == "user" for message in normalized):
+            raise ValueError("messages must contain a user message")
+        if not any(message["role"] == "assistant" for message in normalized):
+            raise ValueError("messages must contain an assistant message")
+        return {"messages": normalized}
+
+    user_text = _first_text(record, _INPUT_KEYS)
+    target_text = _first_text(record, _TARGET_KEYS)
+    if not user_text:
+        raise ValueError(f"missing input field; expected one of {_INPUT_KEYS}")
+    if not target_text:
+        raise ValueError(f"missing target field; expected one of {_TARGET_KEYS}")
+    return {"input": user_text, "output": target_text}
+
+
+def _normalize_messages(messages: Any) -> list[dict[str, str]]:
+    if not isinstance(messages, list):
+        raise ValueError("messages must be a list")
+    normalized: list[dict[str, str]] = []
+    for message in messages:
+        if not isinstance(message, Mapping):
+            raise ValueError("message entries must be objects")
+        role = str(message.get("role", "")).strip()
+        content = message.get("content")
+        if role not in _ALLOWED_MESSAGE_ROLES:
+            raise ValueError(f"unsupported message role {role!r}")
+        if content is None or str(content).strip() == "":
+            raise ValueError("message content cannot be empty")
+        normalized.append({"role": role, "content": str(content).strip()})
+    return normalized
+
+
+def _first_text(record: Mapping[str, Any], keys: Sequence[str]) -> str:
+    for key in keys:
+        value = record.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return ""
+
+
+def _split_counts(n_records: int) -> dict[str, int]:
+    if n_records <= 0:
+        return {"train_size": 0, "val_size": 0, "test_size": 0}
+    train_size = max(1, int(n_records * 0.8))
+    val_size = int(n_records * 0.1) if n_records >= 3 else 0
+    test_size = max(0, n_records - train_size - val_size)
+    return {
+        "train_size": train_size,
+        "val_size": val_size,
+        "test_size": test_size,
+    }
+
+
+def _validation_issues(
+    row_issues: list[str],
+    dropped: int,
+    curated_count: int,
+) -> list[str]:
+    issues: list[str] = []
+    if dropped:
+        preview = "; ".join(row_issues[:3])
+        issues.append(f"Dropped {dropped} malformed record(s). {preview}")
+    if curated_count == 0:
+        issues.append("No valid chat/SFT records were produced")
+    return issues

--- a/src/data_generator/data_generator.py
+++ b/src/data_generator/data_generator.py
@@ -12,6 +12,7 @@ from src.data_generator.graph import build_data_generator_graph, invoke_data_gen
 from src.data_generator.mode_a import detect_format, load_raw_data
 from src.data_generator.mode_b import build_explicit_hf_candidates, fetch_hf_datasets, parse_explicit_hf_dataset_ids
 from src.data_generator.mode_c import acquire_web_data
+from src.data_generator.curation import curate_handoff_to_dataset_result, curate_record
 from src.data_generator.nodes import (
     acquire_hf_data_node,
     acquire_user_data_node,
@@ -38,4 +39,6 @@ __all__ = [
     "build_explicit_hf_candidates",
     "fetch_hf_datasets",
     "acquire_web_data",
+    "curate_record",
+    "curate_handoff_to_dataset_result",
 ]

--- a/src/manager/manager.py
+++ b/src/manager/manager.py
@@ -16,10 +16,8 @@ from src.types import (
     DatasetResult,
     ManagerState,
     OrchestrationConfig,
-    StandardDataset,
     TaskReasoning,
     TrainedModel,
-    ValidationReport,
 )
 
 LOG_PATH = os.environ.get("DECISIONS_LOG", "decisions.jsonl")
@@ -205,40 +203,9 @@ def _handoff_to_dataset_result(handoff: dict) -> DatasetResult:
 
     Persists records to outputs/datasets/train_data.jsonl and computes an 80/10/10 split.
     """
-    mode = handoff.get("mode_used", "C")
-    raw_data = handoff.get("raw_data") or {}
-    records: list = raw_data.get("records", []) if isinstance(raw_data, dict) else []
+    from src.data_generator.curation import curate_handoff_to_dataset_result
 
-    os.makedirs("outputs/datasets", exist_ok=True)
-    dataset_path = os.path.abspath("outputs/datasets/train_data.jsonl")
-    with open(dataset_path, "w") as fh:
-        for rec in records:
-            import json as _json
-            fh.write(_json.dumps(rec) + "\n")
-
-    n = len(records)
-    train_n = max(1, int(n * 0.8))
-    val_n   = max(1, int(n * 0.1))
-    test_n  = max(1, n - train_n - val_n)
-
-    dataset: StandardDataset = {
-        "path": dataset_path,
-        "format": "jsonl",
-        "train_size": train_n,
-        "val_size": val_n,
-        "test_size": test_n,
-    }
-    validation_report: ValidationReport = {
-        "passed": n > 0,
-        "issues": [] if n > 0 else ["DataGen returned 0 records"],
-        "sample_accuracy_estimate": 0.9 if n > 0 else 0.0,
-    }
-    return DatasetResult(
-        dataset=dataset,
-        mode_used=mode,
-        quality_notes=f"DataGen mode {mode}, {n} records",
-        validation_report=validation_report,
-    )
+    return curate_handoff_to_dataset_result(handoff)
 
 
 def build_orchestration_config(

--- a/tests/test_data_curation.py
+++ b/tests/test_data_curation.py
@@ -31,6 +31,26 @@ def test_curate_record_rejects_content_without_target():
         curate_record({"content": "Only source text"})
 
 
+def test_curate_record_adapts_mode_c_web_source_without_target():
+    curated = curate_record(
+        {
+            "source_kind": "web_page",
+            "source_locator": "https://example.com/support",
+            "input": "Urgent tickets include outages and security incidents.",
+            "output": "",
+        },
+        mode="C",
+        config={"prompt": "classify support tickets by urgency"},
+        record_source="curation_payload",
+    )
+
+    assert curated["messages"][0]["role"] == "user"
+    assert "classify support tickets by urgency" in curated["messages"][0]["content"]
+    assert "https://example.com/support" in curated["messages"][0]["content"]
+    assert curated["messages"][1]["role"] == "assistant"
+    assert "candidate_source" in curated["messages"][1]["content"]
+
+
 def test_curate_handoff_writes_only_valid_jsonl(tmp_path):
     handoff = {
         "mode_used": "B",
@@ -71,6 +91,65 @@ def test_curate_handoff_writes_only_valid_jsonl(tmp_path):
             ]
         },
     ]
+
+
+def test_curate_handoff_prefers_mode_c_curation_payload(tmp_path):
+    handoff = {
+        "mode_used": "C",
+        "config": {"prompt": "build a classifier for support ticket urgency"},
+        "raw_data": {
+            "records": [
+                {
+                    "content": "raw page should not be used when curation payload exists",
+                }
+            ]
+        },
+        "curation_payload": {
+            "records": [
+                {
+                    "record_id": "c_000001",
+                    "source_kind": "web_page",
+                    "source_locator": "https://example.com/urgency",
+                    "input": "Outages and active security incidents are urgent.",
+                    "output": "",
+                }
+            ]
+        },
+    }
+
+    result = curate_handoff_to_dataset_result(handoff, output_dir=str(tmp_path))
+
+    assert result["validation_report"]["passed"] is True
+    assert result["quality_notes"] == (
+        "DataGen mode C; curated 1 of 1 curation_payload record(s)"
+    )
+    rows = [
+        json.loads(line)
+        for line in open(result["dataset"]["path"]).read().splitlines()
+        if line.strip()
+    ]
+    assert rows[0]["messages"][0]["content"].startswith(
+        "Task: build a classifier for support ticket urgency"
+    )
+    assert "raw page should not be used" not in rows[0]["messages"][0]["content"]
+
+
+def test_curate_handoff_preserves_upstream_validation(tmp_path):
+    handoff = {
+        "mode_used": "C",
+        "raw_data": {"records": [{"input": "A", "output": "alpha"}]},
+        "validation_report": {
+            "passed": False,
+            "issues": ["synthetic quality warning"],
+            "sample_accuracy_estimate": 0.42,
+        },
+    }
+
+    result = curate_handoff_to_dataset_result(handoff, output_dir=str(tmp_path))
+
+    assert result["validation_report"]["passed"] is False
+    assert result["validation_report"]["issues"] == ["synthetic quality warning"]
+    assert result["validation_report"]["sample_accuracy_estimate"] == 0.42
 
 
 def test_curate_handoff_fails_validation_when_no_rows_survive(tmp_path):

--- a/tests/test_data_curation.py
+++ b/tests/test_data_curation.py
@@ -1,0 +1,86 @@
+import json
+import os
+
+import pytest
+
+from src.data_generator.curation import (
+    curate_handoff_to_dataset_result,
+    curate_record,
+)
+
+
+def test_curate_record_preserves_valid_messages():
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "Say hi"},
+        {"role": "assistant", "content": "hi"},
+    ]
+
+    assert curate_record({"messages": messages}) == {"messages": messages}
+
+
+def test_curate_record_converts_input_label_to_output():
+    assert curate_record({"input": "Classify this", "label": 0}) == {
+        "input": "Classify this",
+        "output": "0",
+    }
+
+
+def test_curate_record_rejects_content_without_target():
+    with pytest.raises(ValueError, match="missing target"):
+        curate_record({"content": "Only source text"})
+
+
+def test_curate_handoff_writes_only_valid_jsonl(tmp_path):
+    handoff = {
+        "mode_used": "B",
+        "raw_data": {
+            "records": [
+                {"input": "A", "label": "alpha"},
+                {"content": "missing target"},
+                {
+                    "messages": [
+                        {"role": "user", "content": "B"},
+                        {"role": "assistant", "content": "beta"},
+                    ]
+                },
+            ]
+        },
+    }
+
+    result = curate_handoff_to_dataset_result(handoff, output_dir=str(tmp_path))
+
+    assert result["mode_used"] == "B"
+    assert result["validation_report"]["passed"] is True
+    assert result["validation_report"]["issues"]
+    assert result["dataset"]["train_size"] == 1
+    assert result["dataset"]["test_size"] == 1
+    assert os.path.exists(result["dataset"]["path"])
+
+    rows = [
+        json.loads(line)
+        for line in open(result["dataset"]["path"]).read().splitlines()
+        if line.strip()
+    ]
+    assert rows == [
+        {"input": "A", "output": "alpha"},
+        {
+            "messages": [
+                {"role": "user", "content": "B"},
+                {"role": "assistant", "content": "beta"},
+            ]
+        },
+    ]
+
+
+def test_curate_handoff_fails_validation_when_no_rows_survive(tmp_path):
+    handoff = {
+        "mode_used": "C",
+        "raw_data": {"records": [{"content": "TODO with no target"}]},
+    }
+
+    result = curate_handoff_to_dataset_result(handoff, output_dir=str(tmp_path))
+
+    assert result["validation_report"]["passed"] is False
+    assert result["dataset"]["train_size"] == 0
+    assert "No valid chat/SFT records" in result["validation_report"]["issues"][-1]


### PR DESCRIPTION
## Summary
- Add deterministic DataGen curation helpers that normalize raw handoff records into Tinker-compatible JSONL.
- Accept valid `messages` conversations and `input`/`output`-style single-turn records, including `input` + `label` rows from Hugging Face datasets.
- Prefer #27-style `curation_payload.records` when present, while still supporting legacy `raw_data.records` handoffs.
- Adapt Mode C web acquisition records without explicit labels into chat examples instead of dropping every content-only crawled page.
- Preserve upstream DataGen validation warnings and sample-quality estimates in the final `DatasetResult`.
- Route Manager's handoff conversion through the curation helper.

## Relationship To #27, #38, and #40
This PR is the downstream trainable-JSONL gate. It is meant to consume:
- Mode A local raw records
- Mode B Hugging Face raw records
- #27 web acquisition `curation_payload` / crawled web records
- #38 synthetic chat/SFT records

It does not replace #27's acquisition pipeline or #38's synthetic generation. It normalizes their outputs into the format the Tinker SFT runner can consume.

For merge/review, prefer the integration branch in #40, which combines #27 + #38 + #37 and validates the merged behavior.

## Why
The spec says Data Generator should standardize/validate discovered or generated data before training. Previously Manager wrote raw handoff records directly, which meant content-only or malformed rows could reach AutoResearch and fail at Tinker SFT time.

## Validation
- `python3 -m compileall src tests/test_data_curation.py tests/test_manager.py`
- `uvx --with pytest --with anthropic --with langgraph --with requests --with tinker --with tinker-cookbook python -m pytest tests/test_data_curation.py tests/test_manager.py -q` -> `15 passed, 1 skipped`
- `git diff --check`

Stacked on #35.
