### PR TITLE
[codex] guard Tinker runs with Cost Manager

### DIFF
--- a/src/autoresearch/autoresearch.py
+++ b/src/autoresearch/autoresearch.py
@@ -29,6 +29,7 @@ from src.tinker_api.sft_runner import (
 from src.types import (
     AgentName,
     AutoResearchState,
+    BudgetStatus,
     CostBreakdown,
     DatasetResult,
     EvalScore,
@@ -85,7 +86,11 @@ def build_autoresearch_graph():
     # Linear entry path
     graph.set_entry_point("init")
     graph.add_edge("init", "baseline")
-    graph.add_edge("baseline", "propose")
+    graph.add_conditional_edges(
+        "baseline",
+        continue_edge,
+        {"propose": "propose", "__end__": END},
+    )
 
     # Cyclic core: propose → run → (early-stop check) → evaluate → (keep/revert) → log → ...
     graph.add_edge("propose", "run")
@@ -131,6 +136,7 @@ def invoke_autoresearch_graph(
         "original_content": None,
         "diary": [],
         "baseline_score": None,
+        "baseline_result": None,
         "best_score": None,
         "best_script": plan["training_script_path"],
         "last_result": None,
@@ -143,15 +149,8 @@ def invoke_autoresearch_graph(
 
     final_state = graph.invoke(initial_state)
 
-    total_cost = sum(r["cost_usd"] for r in final_state["diary"])
-    termination = "budget_limit" if final_state["should_stop"] else "training_complete"
-    cost_breakdown: CostBreakdown = {
-        "data_gen_usd": 0.0,
-        "training_usd": total_cost,
-        "llm_calls_usd": 0.0,
-        "total_usd": total_cost,
-        "termination_reason": termination,
-    }
+    termination = "budget_limit" if _budget_exhausted(final_state) else "training_complete"
+    cost_breakdown = _cost_breakdown_from_state(final_state, termination)
 
     return {
         "weights_path": final_state["best_script"],
@@ -226,6 +225,7 @@ def baseline_node(state: AutoResearchState) -> dict:
     )
 
     experiment = _run_tinker_experiment_for_state(state, phase="baseline")
+    budget_status = _record_experiment_cost(state, experiment)
     baseline_score = run_evals(experiment["model_path"], state["eval_suite"])
 
     log_event(
@@ -237,9 +237,11 @@ def baseline_node(state: AutoResearchState) -> dict:
 
     return {
         "baseline_score": baseline_score,
+        "baseline_result": experiment,
         "best_score": baseline_score,
         "best_script": experiment["model_path"],
         "last_result": experiment,
+        "should_stop": budget_status == BudgetStatus.EXCEEDED,
     }
 
 
@@ -304,6 +306,7 @@ def run_node(state: AutoResearchState) -> dict:
     )
 
     result = _run_tinker_experiment_for_state(state, phase="iteration")
+    budget_status = _record_experiment_cost(state, result)
 
     log_event(
         AgentName.AUTORESEARCH,
@@ -312,7 +315,10 @@ def run_node(state: AutoResearchState) -> dict:
         metadata={"job_id": result["job_id"], "cost_usd": result["cost_usd"]},
     )
 
-    return {"last_result": result}
+    return {
+        "last_result": result,
+        "should_stop": budget_status == BudgetStatus.EXCEEDED,
+    }
 
 
 def revert_and_continue_node(state: AutoResearchState) -> dict:
@@ -511,8 +517,8 @@ def continue_edge(state: AutoResearchState) -> Literal["propose", "__end__"]:
         return "__end__"
 
     budget = state["config"].get("compute_budget", float("inf"))
-    spent = sum(r["cost_usd"] for r in state["diary"])
-    if spent >= budget:
+    spent = _spent_usd_from_state(state)
+    if _budget_exhausted(state):
         log_event(
             AgentName.AUTORESEARCH,
             LogLevel.INFO,
@@ -537,6 +543,46 @@ def continue_edge(state: AutoResearchState) -> Literal["propose", "__end__"]:
         return "__end__"
 
     return "propose"
+
+
+def _spent_usd_from_state(state: AutoResearchState) -> float:
+    cost_manager = state.get("cost_manager")
+    if cost_manager is not None and hasattr(cost_manager, "spent_usd"):
+        return float(cost_manager.spent_usd)
+    baseline_cost = (
+        state.get("baseline_result", {}).get("cost_usd", 0.0)
+        if state.get("baseline_result")
+        else 0.0
+    )
+    return baseline_cost + sum(r["cost_usd"] for r in state["diary"])
+
+
+def _budget_exhausted(state: AutoResearchState) -> bool:
+    if state.get("should_stop"):
+        return True
+    cost_manager = state.get("cost_manager")
+    if cost_manager is not None and getattr(cost_manager, "status", None) == BudgetStatus.EXCEEDED:
+        return True
+    budget = state["config"].get("compute_budget", float("inf"))
+    return _spent_usd_from_state(state) >= budget
+
+
+def _cost_breakdown_from_state(
+    state: AutoResearchState,
+    termination_reason: str,
+) -> CostBreakdown:
+    cost_manager = state.get("cost_manager")
+    if cost_manager is not None and hasattr(cost_manager, "cost_breakdown"):
+        return cost_manager.cost_breakdown(termination_reason=termination_reason)
+
+    total_cost = _spent_usd_from_state(state)
+    return {
+        "data_gen_usd": 0.0,
+        "training_usd": total_cost,
+        "llm_calls_usd": 0.0,
+        "total_usd": total_cost,
+        "termination_reason": termination_reason,
+    }
 
 
 # ─── PROPOSE HELPERS ──────────────────────────────────────────────────────────
@@ -738,7 +784,7 @@ def _run_tinker_experiment_for_state(
 ) -> ExperimentResult:
     run_id = f"autoresearch-{phase}-{state['iteration']}-{uuid4().hex[:8]}"
     cost_manager = state.get("cost_manager")
-    if cost_manager is not None:
+    if cost_manager is not None and hasattr(cost_manager, "start"):
         cost_manager.start(run_id)
     try:
         return run_tinker_sft_experiment(
@@ -748,8 +794,19 @@ def _run_tinker_experiment_for_state(
             max_steps=_max_steps_from_state(state),
         )
     finally:
-        if cost_manager is not None:
+        if cost_manager is not None and hasattr(cost_manager, "stop"):
             cost_manager.stop()
+
+
+def _record_experiment_cost(
+    state: AutoResearchState,
+    result: ExperimentResult,
+    category: str = "training",
+) -> str | None:
+    cost_manager = state.get("cost_manager")
+    if cost_manager is None or not hasattr(cost_manager, "record_spend"):
+        return None
+    return cost_manager.record_spend(float(result.get("cost_usd", 0.0)), category=category)
 
 
 def submit_experiment(

--- a/src/autoresearch/autoresearch.py
+++ b/src/autoresearch/autoresearch.py
@@ -14,6 +14,7 @@ import json
 import math
 from pathlib import Path
 from typing import Any, Literal
+from uuid import uuid4
 
 import anthropic
 
@@ -121,6 +122,7 @@ def invoke_autoresearch_graph(
     initial_state: AutoResearchState = {
         "plan": plan,
         "config": config,
+        "cost_manager": cost_manager,
         "eval_suite": None,
         "current_script": plan["training_script_path"],
         "current_config": config["training_procedure"]["hyperparameters"],
@@ -223,11 +225,7 @@ def baseline_node(state: AutoResearchState) -> dict:
         "BASELINE: submitting unmodified training script",
     )
 
-    experiment = run_tinker_sft_experiment(
-        _training_config_from_state(state),
-        _dataset_result_from_plan(state["plan"]),
-        max_steps=_max_steps_from_state(state),
-    )
+    experiment = _run_tinker_experiment_for_state(state, phase="baseline")
     baseline_score = run_evals(experiment["model_path"], state["eval_suite"])
 
     log_event(
@@ -305,11 +303,7 @@ def run_node(state: AutoResearchState) -> dict:
         metadata={"iteration": state["iteration"] + 1},
     )
 
-    result = run_tinker_sft_experiment(
-        _training_config_from_state(state),
-        _dataset_result_from_plan(state["plan"]),
-        max_steps=_max_steps_from_state(state),
-    )
+    result = _run_tinker_experiment_for_state(state, phase="iteration")
 
     log_event(
         AgentName.AUTORESEARCH,
@@ -735,6 +729,27 @@ def _max_steps_from_state(state: AutoResearchState) -> int:
         if value is not None:
             return max(1, int(value))
     return DEFAULT_LIVE_SMOKE_STEPS
+
+
+def _run_tinker_experiment_for_state(
+    state: AutoResearchState,
+    *,
+    phase: str,
+) -> ExperimentResult:
+    run_id = f"autoresearch-{phase}-{state['iteration']}-{uuid4().hex[:8]}"
+    cost_manager = state.get("cost_manager")
+    if cost_manager is not None:
+        cost_manager.start(run_id)
+    try:
+        return run_tinker_sft_experiment(
+            _training_config_from_state(state),
+            _dataset_result_from_plan(state["plan"]),
+            run_id=run_id,
+            max_steps=_max_steps_from_state(state),
+        )
+    finally:
+        if cost_manager is not None:
+            cost_manager.stop()
 
 
 def submit_experiment(

--- a/src/cost_manager/__init__.py
+++ b/src/cost_manager/__init__.py
@@ -1,3 +1,3 @@
-from .cost_manager import start_cost_monitor, generate_cost_report
+from .cost_manager import CostManager, generate_cost_report, start_cost_monitor
 
-__all__ = ["start_cost_monitor", "generate_cost_report"]
+__all__ = ["CostManager", "start_cost_monitor", "generate_cost_report"]

--- a/src/cost_manager/cost_manager.py
+++ b/src/cost_manager/cost_manager.py
@@ -57,6 +57,8 @@ def poll_spend(job_id: str) -> float:
 
 def check_budget_status(spent: float, budget: float) -> str:
     """Returns BudgetStatus: OK (< 90%), WARNING (90–99%), EXCEEDED (>= 100%)."""
+    if budget <= 0:
+        return BudgetStatus.EXCEEDED if spent > 0 else BudgetStatus.OK
     ratio = spent / budget if budget > 0 else 0.0
     if ratio >= 1.0:
         return BudgetStatus.EXCEEDED
@@ -103,10 +105,66 @@ class CostManager:
     def __init__(self, budget: float):
         self.budget = budget
         self._thread: threading.Thread | None = None
+        self._lock = threading.Lock()
+        self._category_totals: dict[str, float] = {}
+
+    @property
+    def category_totals(self) -> dict[str, float]:
+        """Returns a snapshot of in-process spend by category."""
+        with self._lock:
+            return dict(self._category_totals)
+
+    @property
+    def spent_usd(self) -> float:
+        """Returns total in-process spend recorded through this manager."""
+        with self._lock:
+            return round(sum(self._category_totals.values()), 6)
+
+    @property
+    def remaining_budget(self) -> float:
+        """Returns the remaining budget after in-process spend."""
+        return max(0.0, round(self.budget - self.spent_usd, 6))
+
+    @property
+    def status(self) -> str:
+        """Returns the current in-process budget status."""
+        return check_budget_status(self.spent_usd, self.budget)
+
+    def record_spend(self, amount: float, category: str = "training") -> str:
+        """Records completed in-process spend and returns the updated budget status."""
+        amount = float(amount)
+        if amount < 0:
+            raise ValueError("CostManager.record_spend amount must be non-negative")
+        with self._lock:
+            self._category_totals[category] = (
+                self._category_totals.get(category, 0.0) + amount
+            )
+        return self.status
+
+    def cost_breakdown(self, termination_reason: str | None = None) -> CostBreakdown:
+        """Returns a CostBreakdown from in-process spend totals."""
+        totals = self.category_totals
+        data_gen = totals.get("data_gen", 0.0) + totals.get("data_generation", 0.0)
+        training = totals.get("training", 0.0)
+        llm_calls = totals.get("llm_calls", 0.0) + totals.get("llm", 0.0)
+        total = self.spent_usd
+        other = max(0.0, total - data_gen - training - llm_calls)
+        training += other
+        reason = termination_reason or (
+            "budget_limit" if self.status == BudgetStatus.EXCEEDED else "training_complete"
+        )
+        return {
+            "data_gen_usd": round(data_gen, 6),
+            "training_usd": round(training, 6),
+            "llm_calls_usd": round(llm_calls, 6),
+            "total_usd": total,
+            "termination_reason": reason,
+        }
 
     def start(self, job_id: str) -> None:
         self.stop()
-        self._thread = start_cost_monitor(job_id, self.budget)
+        monitor_budget = self.remaining_budget if self.spent_usd > 0 else self.budget
+        self._thread = start_cost_monitor(job_id, monitor_budget)
 
     def stop(self) -> None:
         if self._thread:

--- a/src/cost_manager/cost_manager.py
+++ b/src/cost_manager/cost_manager.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import os
 import threading
-import time
 
 from src.types import BudgetStatus, CostBreakdown
 
@@ -41,7 +40,8 @@ def start_cost_monitor(
                     return
             except Exception:
                 pass  # don't crash the monitor on transient errors
-            time.sleep(poll_interval_sec)
+            if stop_event.wait(poll_interval_sec):
+                return
 
     thread = threading.Thread(target=_monitor, daemon=True, name=f"cost-monitor-{job_id}")
     thread.stop_event = stop_event  # type: ignore[attr-defined]
@@ -105,8 +105,13 @@ class CostManager:
         self._thread: threading.Thread | None = None
 
     def start(self, job_id: str) -> None:
+        self.stop()
         self._thread = start_cost_monitor(job_id, self.budget)
 
     def stop(self) -> None:
         if self._thread:
+            stop_event = getattr(self._thread, "stop_event", None)
+            if stop_event is not None:
+                stop_event.set()
             self._thread.join(timeout=5)
+            self._thread = None

--- a/src/types.py
+++ b/src/types.py
@@ -6,7 +6,7 @@ See spec-site/content/spec.ts for the canonical definitions.
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Any, TypedDict
 
 
 # ENUMS
@@ -276,6 +276,7 @@ class DataGenState(TypedDict):
 class AutoResearchState(TypedDict):
     plan: TrainingPlan
     config: OrchestrationConfig
+    cost_manager: Any
     eval_suite: EvalSuite | None
     current_script: str        # path to the training script (never mutated by PROPOSE)
     current_config: dict       # live hyperparams; updated by keep_node after each KEPT patch

--- a/src/types.py
+++ b/src/types.py
@@ -285,6 +285,7 @@ class AutoResearchState(TypedDict):
     original_content: str | None
     diary: ResearchDiary
     baseline_score: EvalScore | None
+    baseline_result: ExperimentResult | None
     best_score: EvalScore | None
     best_script: str
     last_result: ExperimentResult | None

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -257,6 +257,7 @@ def _make_state(**overrides):
         "original_content": None,
         "diary": [],
         "baseline_score": None,
+        "baseline_result": None,
         "best_score": None,
         "best_script": "train.py",
         "last_result": None,
@@ -265,6 +266,7 @@ def _make_state(**overrides):
         "iteration": 0,
         "no_improve_streak": 0,
         "should_stop": False,
+        "cost_manager": None,
     }
     base.update(overrides)
     return base
@@ -298,3 +300,57 @@ def test_continue_edge_ends_at_max_iterations():
     from src.autoresearch.autoresearch import _MAX_ITERATIONS
     state = _make_state(iteration=_MAX_ITERATIONS)
     assert continue_edge(state) == "__end__"
+
+
+def test_invoke_autoresearch_graph_cost_breakdown_includes_baseline_cost(monkeypatch):
+    import src.autoresearch.autoresearch as ar
+    from src.cost_manager.cost_manager import CostManager
+
+    class FakeGraph:
+        def invoke(self, initial_state):
+            cost_manager = initial_state["cost_manager"]
+            cost_manager.record_spend(0.20, category="training")
+            cost_manager.record_spend(0.30, category="training")
+            baseline_result = {
+                "job_id": "baseline",
+                "status": "COMPLETED",
+                "metrics": {"train_loss": 0.5, "val_loss": 0.5,
+                            "test_loss": 0.5, "primary_metric": 0.5},
+                "model_path": "baseline-model",
+                "cost_usd": 0.20,
+                "logs_path": "baseline.jsonl",
+            }
+            return {
+                **initial_state,
+                "baseline_result": baseline_result,
+                "baseline_score": {"scalar": 0.5, "metrics": {}, "critique": ""},
+                "best_score": {"scalar": 0.6, "metrics": {}, "critique": ""},
+                "best_script": "iteration-model",
+                "diary": [
+                    {
+                        "iteration": 1,
+                        "hypothesis": "x",
+                        "patch": "",
+                        "cost_usd": 0.30,
+                        "metrics": {},
+                        "decision": "KEPT",
+                        "notes": "",
+                    }
+                ],
+                "iteration": 1,
+            }
+
+    monkeypatch.setattr(ar, "build_autoresearch_graph", lambda: FakeGraph())
+    state = _make_state()
+    plan = {
+        **state["plan"],
+        "strategy": "fine-tune",
+        "training_script_path": "train.py",
+    }
+    cost_manager = CostManager(10.0)
+
+    result = ar.invoke_autoresearch_graph(plan, state["config"], cost_manager)
+
+    assert result["cost"]["training_usd"] == pytest.approx(0.50)
+    assert result["cost"]["total_usd"] == pytest.approx(0.50)
+    assert result["cost"]["termination_reason"] == "training_complete"

--- a/tests/test_cost_manager.py
+++ b/tests/test_cost_manager.py
@@ -28,6 +28,7 @@ def test_check_budget_status_warning_at_90_percent():
 def test_check_budget_status_exceeded_at_100_percent():
     assert check_budget_status(100.0, 100.0) == BudgetStatus.EXCEEDED
     assert check_budget_status(110.0, 100.0) == BudgetStatus.EXCEEDED
+    assert check_budget_status(0.01, 0.0) == BudgetStatus.EXCEEDED
 
 
 def test_start_cost_monitor_returns_thread():
@@ -51,6 +52,42 @@ def test_cost_manager_stop_signals_monitor_thread():
 
     assert manager._thread is None
     assert not thread.is_alive()
+
+
+def test_cost_manager_records_in_process_spend_by_category():
+    manager = CostManager(1.0)
+
+    assert manager.spent_usd == 0.0
+    assert manager.remaining_budget == 1.0
+    assert manager.record_spend(0.25) == BudgetStatus.OK
+    assert manager.record_spend(0.05, category="llm_calls") == BudgetStatus.OK
+    assert manager.record_spend(0.70) == BudgetStatus.EXCEEDED
+
+    assert manager.category_totals == {"training": 0.95, "llm_calls": 0.05}
+    assert manager.spent_usd == 1.0
+    assert manager.remaining_budget == 0.0
+    assert manager.status == BudgetStatus.EXCEEDED
+
+
+def test_cost_manager_cost_breakdown_uses_recorded_totals():
+    manager = CostManager(10.0)
+    manager.record_spend(1.25, category="training")
+    manager.record_spend(0.50, category="data_gen")
+    manager.record_spend(0.10, category="llm")
+
+    assert manager.cost_breakdown("training_complete") == {
+        "data_gen_usd": 0.5,
+        "training_usd": 1.25,
+        "llm_calls_usd": 0.1,
+        "total_usd": 1.85,
+        "termination_reason": "training_complete",
+    }
+
+
+def test_cost_manager_rejects_negative_spend():
+    manager = CostManager(10.0)
+    with pytest.raises(ValueError, match="non-negative"):
+        manager.record_spend(-0.01)
 
 
 def test_save_checkpoint_returns_path(tmp_path):

--- a/tests/test_cost_manager.py
+++ b/tests/test_cost_manager.py
@@ -4,6 +4,7 @@ import threading
 import pytest
 from unittest.mock import patch
 from src.cost_manager.cost_manager import (
+    CostManager,
     check_budget_status,
     generate_cost_report,
     save_checkpoint,
@@ -35,6 +36,21 @@ def test_start_cost_monitor_returns_thread():
     assert isinstance(thread, threading.Thread)
     assert thread.is_alive()
     thread.stop_event.set()  # type: ignore[attr-defined]
+    thread.join(timeout=1)
+
+
+def test_cost_manager_stop_signals_monitor_thread():
+    with patch("src.cost_manager.cost_manager.poll_spend", return_value=0.0):
+        manager = CostManager(50.0)
+        manager.start("job-456")
+        thread = manager._thread
+        assert isinstance(thread, threading.Thread)
+        assert thread.is_alive()
+
+        manager.stop()
+
+    assert manager._thread is None
+    assert not thread.is_alive()
 
 
 def test_save_checkpoint_returns_path(tmp_path):

--- a/tests/test_tinker_runner.py
+++ b/tests/test_tinker_runner.py
@@ -246,6 +246,46 @@ def test_autoresearch_run_node_wraps_tinker_runner_with_cost_manager(monkeypatch
     assert result["last_result"]["job_id"] == captured["run_id"]
     assert cost_manager.started == [captured["run_id"]]
     assert cost_manager.stopped == 1
+    assert cost_manager.recorded == [(0.01, "training")]
+
+
+def test_autoresearch_baseline_node_records_cost_and_budget_stop(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+    from src.cost_manager.cost_manager import CostManager
+
+    data_path = _write_jsonl(tmp_path / "train.jsonl", [{"input": "x", "output": "y"}])
+
+    def fake_runner(config, dataset, *, run_id=None, max_steps=None, **kwargs):
+        run_dir = tmp_path / "baseline-cost"
+        run_dir.mkdir()
+        (run_dir / "metrics.json").write_text(
+            json.dumps({"train_loss": 0.3, "val_loss": 0.3, "test_loss": 0.3})
+        )
+        return {
+            "job_id": run_id,
+            "status": "COMPLETED",
+            "metrics": {
+                "train_loss": 0.3,
+                "val_loss": 0.3,
+                "test_loss": 0.3,
+                "primary_metric": 1 / 1.3,
+            },
+            "model_path": str(run_dir),
+            "cost_usd": 0.02,
+            "logs_path": str(run_dir / "metrics.jsonl"),
+        }
+
+    monkeypatch.setattr(ar, "run_tinker_sft_experiment", fake_runner)
+    state = _autoresearch_state(str(data_path))
+    state["config"]["compute_budget"] = 0.01
+    state["cost_manager"] = CostManager(0.01)
+
+    result = ar.baseline_node(state)
+
+    assert result["baseline_result"]["cost_usd"] == 0.02
+    assert result["should_stop"] is True
+    assert state["cost_manager"].spent_usd == 0.02
+    assert ar.continue_edge({**state, **result}) == "__end__"
 
 
 def _write_jsonl(path: Path, rows: list[dict]) -> Path:
@@ -308,12 +348,17 @@ class _FakeCostManager:
     def __init__(self):
         self.started = []
         self.stopped = 0
+        self.recorded = []
 
     def start(self, job_id):
         self.started.append(job_id)
 
     def stop(self):
         self.stopped += 1
+
+    def record_spend(self, amount, category="training"):
+        self.recorded.append((amount, category))
+        return "OK"
 
 
 class _FakeFuture:

--- a/tests/test_tinker_runner.py
+++ b/tests/test_tinker_runner.py
@@ -177,6 +177,7 @@ def test_autoresearch_run_node_calls_tinker_runner(monkeypatch, tmp_path):
         captured["config"] = config
         captured["dataset"] = dataset
         captured["max_steps"] = max_steps
+        captured["run_id"] = kwargs.get("run_id")
         run_dir = tmp_path / "run"
         run_dir.mkdir()
         (run_dir / "metrics.json").write_text(
@@ -203,8 +204,48 @@ def test_autoresearch_run_node_calls_tinker_runner(monkeypatch, tmp_path):
 
     assert result["last_result"]["job_id"] == "fake-run"
     assert captured["max_steps"] == 5
+    assert captured["run_id"].startswith("autoresearch-iteration-")
     assert captured["dataset"]["dataset"]["path"] == str(data_path)
     assert captured["config"].model_name == "Qwen/Qwen3.5-9B"
+
+
+def test_autoresearch_run_node_wraps_tinker_runner_with_cost_manager(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    data_path = _write_jsonl(tmp_path / "train.jsonl", [{"input": "x", "output": "y"}])
+    cost_manager = _FakeCostManager()
+    captured = {}
+
+    def fake_runner(config, dataset, *, run_id=None, max_steps=None, **kwargs):
+        captured["run_id"] = run_id
+        run_dir = tmp_path / "run-cost"
+        run_dir.mkdir()
+        (run_dir / "metrics.json").write_text(
+            json.dumps({"train_loss": 0.4, "val_loss": 0.4, "test_loss": 0.4})
+        )
+        return {
+            "job_id": run_id,
+            "status": "COMPLETED",
+            "metrics": {
+                "train_loss": 0.4,
+                "val_loss": 0.4,
+                "test_loss": 0.4,
+                "primary_metric": 1 / 1.4,
+            },
+            "model_path": str(run_dir),
+            "cost_usd": 0.01,
+            "logs_path": str(run_dir / "metrics.jsonl"),
+        }
+
+    monkeypatch.setattr(ar, "run_tinker_sft_experiment", fake_runner)
+    state = _autoresearch_state(str(data_path))
+    state["cost_manager"] = cost_manager
+
+    result = ar.run_node(state)
+
+    assert result["last_result"]["job_id"] == captured["run_id"]
+    assert cost_manager.started == [captured["run_id"]]
+    assert cost_manager.stopped == 1
 
 
 def _write_jsonl(path: Path, rows: list[dict]) -> Path:
@@ -259,7 +300,20 @@ def _autoresearch_state(dataset_path: str) -> dict:
         "iteration": 0,
         "no_improve_streak": 0,
         "should_stop": False,
+        "cost_manager": None,
     }
+
+
+class _FakeCostManager:
+    def __init__(self):
+        self.started = []
+        self.stopped = 0
+
+    def start(self, job_id):
+        self.started.append(job_id)
+
+    def stop(self):
+        self.stopped += 1
 
 
 class _FakeFuture:


### PR DESCRIPTION
## Summary
- Store the Cost Manager in AutoResearch state and wrap each SDK-native Tinker baseline/iteration run with `cost_manager.start(run_id)` and `cost_manager.stop()`.
- Add in-process cumulative spend accounting to `CostManager` with `record_spend(...)`, category totals, `spent_usd`, `remaining_budget`, budget status, and `cost_breakdown(...)`.
- Record each AutoResearch Tinker `ExperimentResult["cost_usd"]` into the manager for both baseline and iteration runs.
- Include baseline spend in final AutoResearch cost reporting via the CostManager total, with a fallback that includes `baseline_result` plus diary spend.
- Stop the graph deterministically after baseline when recorded spend exhausts the budget, before launching proposed iteration runs.
- Generate explicit AutoResearch run IDs before calling the Tinker runner so token ledger/cancellation and the monitor share the same ID.
- Make `CostManager.stop()` actually signal the monitor thread and wake it promptly.
- Export `CostManager` from the cost manager package.

## Why
The spec calls for a hard budget guardrail during AutoResearch mini-runs. Manager already constructed a `CostManager`, but AutoResearch was not using it. This PR connects the monitor to Tinker run IDs and now also tracks completed SDK-native training costs in-process, so baseline cost is not lost and budget exhaustion does not rely only on the old REST-job polling path.

## Validation
- `python3 -m compileall src tests/test_cost_manager.py tests/test_tinker_runner.py tests/test_autoresearch.py` -> passed
- `uvx --with anthropic --with tinker --with tinker-cookbook pytest tests/test_cost_manager.py tests/test_tinker_runner.py tests/test_autoresearch.py -q` -> `46 passed, 1 skipped`
- `git diff --check` -> passed

Stacked on #35.
