### PR TITLE
[codex] use single assistant targets for Tinker SFT

### DIFF
--- a/src/tinker_api/sft_runner.py
+++ b/src/tinker_api/sft_runner.py
@@ -70,6 +70,9 @@ def run_tinker_sft_experiment(
         renderer_name = resolve_renderer_name(model_name, model_info)
         tokenizer = tokenizer_utils.get_tokenizer(model_name)
         renderer = renderers.get_renderer(renderer_name, tokenizer)
+        training_conversations = _expand_assistant_training_targets(conversations)
+        if not training_conversations:
+            raise ValueError("No assistant targets found after a user message.")
 
         svc = service_client if service_client is not None else tinker.ServiceClient()
         training_client = svc.create_lora_training_client(
@@ -77,9 +80,9 @@ def run_tinker_sft_experiment(
             rank=int(cfg.lora_rank or 32),
         )
 
-        train_on_what = renderers.TrainOnWhat.ALL_ASSISTANT_MESSAGES
+        train_on_what = renderers.TrainOnWhat.LAST_ASSISTANT_MESSAGE
         target_steps = _resolve_target_steps(
-            num_examples=len(conversations),
+            num_examples=len(training_conversations),
             batch_size=cfg.batch_size,
             num_epochs=cfg.num_epochs,
             max_steps=max_steps,
@@ -93,7 +96,11 @@ def run_tinker_sft_experiment(
                 status = "CANCELLED"
                 break
 
-            batch_conversations = _conversation_batch(conversations, cfg.batch_size, step)
+            batch_conversations = _conversation_batch(
+                training_conversations,
+                cfg.batch_size,
+                step,
+            )
             batch = [
                 supervised_data.conversation_to_datum(
                     conversation,
@@ -141,7 +148,9 @@ def run_tinker_sft_experiment(
             "backend": "tinker_sft",
             "model_name": model_name,
             "renderer_name": renderer_name,
+            "train_on_what": str(train_on_what),
             "dataset_path": _dataset_path_for_manifest(dataset),
+            "training_examples": len(training_conversations),
             "max_steps": max_steps,
             "completed_steps": len(metrics_history),
             "checkpoints": checkpoints,
@@ -205,6 +214,30 @@ def record_to_conversation(record: Mapping[str, Any]) -> list[dict[str, str]]:
         {"role": "user", "content": user_text},
         {"role": "assistant", "content": assistant_text},
     ]
+
+
+def _expand_assistant_training_targets(
+    conversations: Sequence[Sequence[dict[str, str]]],
+) -> list[list[dict[str, str]]]:
+    """Split multi-assistant chats into one target per assistant response.
+
+    Cookbook renderers warn against ``ALL_ASSISTANT_MESSAGES`` for renderers
+    without the extension property. Training one prefix ending in the target
+    assistant message preserves all assistant targets while using the safer
+    ``LAST_ASSISTANT_MESSAGE`` mode.
+    """
+    targets: list[list[dict[str, str]]] = []
+    for conversation in conversations:
+        prefix: list[dict[str, str]] = []
+        seen_user = False
+        for message in conversation:
+            copied = {"role": message["role"], "content": message["content"]}
+            prefix.append(copied)
+            if copied["role"] == "user":
+                seen_user = True
+            if copied["role"] == "assistant" and seen_user:
+                targets.append(list(prefix))
+    return targets
 
 
 def resolve_renderer_name(model_name: str, model_info_module: Any | None = None) -> str:

--- a/tests/test_tinker_runner.py
+++ b/tests/test_tinker_runner.py
@@ -107,9 +107,59 @@ def test_run_tinker_sft_experiment_writes_artifacts(tmp_path, monkeypatch):
     manifest = json.loads((run_dir / "manifest.json").read_text())
     assert manifest["checkpoints"]["state_path"].startswith("tinker://state/")
     assert manifest["checkpoints"]["sampler_path"].startswith("tinker://sampler/")
+    assert manifest["train_on_what"] == "last_assistant_message"
+    assert manifest["training_examples"] == 2
     assert json.loads((run_dir / "sample.json").read_text())["text"] == "sample text"
     assert state.training_client.forward_backward_calls == 2
     assert state.training_client.optim_step_calls == 2
+    assert {call["train_on_what"] for call in state.conversions} == {
+        "last_assistant_message"
+    }
+
+
+def test_run_tinker_sft_experiment_splits_multi_assistant_conversations(
+    tmp_path,
+    monkeypatch,
+):
+    state = _install_fake_tinker_stack(monkeypatch, losses=[0.5])
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [
+            {
+                "messages": [
+                    {"role": "system", "content": "Be brief."},
+                    {"role": "user", "content": "First"},
+                    {"role": "assistant", "content": "One"},
+                    {"role": "user", "content": "Second"},
+                    {"role": "assistant", "content": "Two"},
+                ]
+            },
+        ],
+    )
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=4),
+        str(data_path),
+        run_id="multi-assistant-run",
+        max_steps=1,
+        output_dir=str(tmp_path / "experiments"),
+    )
+
+    run_dir = tmp_path / "experiments" / "multi-assistant-run"
+    manifest = json.loads((run_dir / "manifest.json").read_text())
+    assert result["status"] == "COMPLETED"
+    assert manifest["training_examples"] == 2
+    assert len(state.conversions) == 4
+    converted_targets = {
+        call["conversation"][-1]["content"]
+        for call in state.conversions
+    }
+    assert converted_targets == {"One", "Two"}
+    assert {call["train_on_what"] for call in state.conversions} == {
+        "last_assistant_message"
+    }
 
 
 def test_run_tinker_sft_experiment_stops_on_cancel_and_writes_artifacts(tmp_path, monkeypatch):
@@ -296,10 +346,12 @@ class _FakeTrainingClient:
         self.losses = list(losses)
         self.forward_backward_calls = 0
         self.optim_step_calls = 0
+        self.batches = []
         self.sampling_client = _FakeSamplingClient()
 
     def forward_backward(self, batch, loss_fn):
         self.forward_backward_calls += 1
+        self.batches.append(batch)
         loss = self.losses[min(self.forward_backward_calls - 1, len(self.losses) - 1)]
         return _FakeFuture(types.SimpleNamespace(loss=loss))
 
@@ -358,14 +410,25 @@ def _install_fake_tinker_stack(monkeypatch, losses):
     model_info = types.ModuleType("tinker_cookbook.model_info")
     model_info.get_recommended_renderer_name = MagicMock(side_effect=KeyError("missing"))
     renderers = types.ModuleType("tinker_cookbook.renderers")
-    renderers.TrainOnWhat = types.SimpleNamespace(ALL_ASSISTANT_MESSAGES="assistant")
+    renderers.TrainOnWhat = types.SimpleNamespace(
+        ALL_ASSISTANT_MESSAGES="all_assistant_messages",
+        LAST_ASSISTANT_MESSAGE="last_assistant_message",
+    )
     renderers.get_renderer = MagicMock(return_value=_FakeRenderer())
     tokenizer_utils = types.ModuleType("tinker_cookbook.tokenizer_utils")
     tokenizer_utils.get_tokenizer = MagicMock(return_value=object())
     supervised_pkg = types.ModuleType("tinker_cookbook.supervised")
     supervised_data = types.ModuleType("tinker_cookbook.supervised.data")
+    conversions = []
 
     def conversation_to_datum(conversation, renderer, max_length, train_on_what):
+        conversions.append(
+            {
+                "conversation": conversation,
+                "max_length": max_length,
+                "train_on_what": train_on_what,
+            }
+        )
         return _FakeDatum(length=len(json.dumps(conversation)))
 
     supervised_data.conversation_to_datum = conversation_to_datum
@@ -396,4 +459,8 @@ def _install_fake_tinker_stack(monkeypatch, losses):
     monkeypatch.setitem(sys.modules, "tinker_cookbook.supervised.data", supervised_data)
 
     importlib.reload(importlib.import_module("src.tinker_api.sft_runner"))
-    return types.SimpleNamespace(training_client=training_client, service_client=service_client)
+    return types.SimpleNamespace(
+        training_client=training_client,
+        service_client=service_client,
+        conversions=conversions,
+    )


### PR DESCRIPTION
## Summary
- Switch the Tinker SFT runner from `ALL_ASSISTANT_MESSAGES` to `LAST_ASSISTANT_MESSAGE` when converting chat examples through cookbook renderers.
- Split multi-assistant conversations into one training prefix per assistant target, preserving all supervised targets while avoiding the renderer extension-property warning.
- Record `train_on_what` and `training_examples` in the run manifest for traceability.
- Add unit coverage for the manifest fields and multi-assistant splitting behavior.

## Why
A live partial pipeline surfaced repeated cookbook warnings for `Qwen/Qwen3.5-9B`: the selected renderer does not satisfy the extension property needed for `ALL_ASSISTANT_MESSAGES`. For chat/SFT V1, using `LAST_ASSISTANT_MESSAGE` per assistant target matches the safer cookbook path and eliminates the warning without losing assistant turns.

## Validation
- `python3 -m compileall src tests/test_tinker_runner.py` -> passed
- `uvx --with pytest --with anthropic --with langgraph --with tinker --with tinker-cookbook python -m pytest tests/test_tinker_runner.py -q` -> `12 passed`
- `RUN_LIVE_TINKER=1 TINKER_SMOKE_MODEL="Qwen/Qwen3.5-9B" TINKER_SMOKE_STEPS=2 uvx --with pytest --with anthropic --with langgraph --with tinker --with tinker-cookbook python -m pytest tests/integration/test_tinker_live_smoke.py -q -s` -> `1 passed in 53.74s`
- `git diff --check` -> passed

Stacked on #35.
