### PR TITLE
[codex] structure Mode C web sources into SFT rows

### DIFF
--- a/src/data_generator/mode_c/__init__.py
+++ b/src/data_generator/mode_c/__init__.py
@@ -22,6 +22,10 @@ from src.data_generator.mode_c.synthetic import (
     scrape_web,
     validate_synthetic_records,
 )
+from src.data_generator.mode_c.structuring import (
+    WebStructuringResult,
+    structure_web_sources_for_sft,
+)
 from src.types import OrchestrationConfig, RawData
 
 
@@ -113,6 +117,7 @@ __all__ = [
     "DEFAULT_SYNTHETIC_EXAMPLES",
     "DEFAULT_TEACHER_MODEL",
     "SyntheticGenerationResult",
+    "WebStructuringResult",
     "acquire_synthetic_dataset",
     "acquire_web_data",
     "aggregate_web_sources_node",
@@ -125,6 +130,7 @@ __all__ = [
     "plan_synthetic_generation",
     "plan_web_acquisition_node",
     "scrape_web",
+    "structure_web_sources_for_sft",
     "search_web_sources_node",
     "validate_synthetic_records",
 ]

--- a/src/data_generator/mode_c/nodes.py
+++ b/src/data_generator/mode_c/nodes.py
@@ -140,7 +140,7 @@ def aggregate_web_sources_node(state: DataGenState) -> dict:
         },
     }
 
-    return {
+    unstructured = {
         "raw_data": raw_data,
         "human_readable": report,
         "validation_report": {
@@ -154,6 +154,29 @@ def aggregate_web_sources_node(state: DataGenState) -> dict:
             "sample_accuracy_estimate": 0.0,
         },
     }
+
+    structuring_mode = _web_structuring_mode()
+    if structuring_mode == "off":
+        return unstructured
+
+    structured = structure_web_sources_for_sft(state["config"], pages)
+    if structured.validation_report["passed"] or structuring_mode == "required":
+        structured.raw_data["human_readable"] = report
+        structured.raw_data["format_meta"]["mode_c_backend"] = backend
+        structured.raw_data["format_meta"]["web_plan"] = web_plan
+        structured.raw_data["format_meta"]["num_search_results"] = len(search_results)
+        structured.raw_data["format_meta"]["num_pages_crawled"] = len(pages)
+        return {
+            "schema": structured.schema,
+            "raw_data": structured.raw_data,
+            "validation_report": structured.validation_report,
+            "human_readable": report,
+        }
+
+    issues = list(unstructured["validation_report"]["issues"])
+    issues.extend(structured.validation_report.get("issues", []))
+    unstructured["validation_report"]["issues"] = issues
+    return unstructured
 
 
 def _mode_c_synthetic_fallback_state(
@@ -189,6 +212,19 @@ def _mode_c_backend(state: DataGenState | dict) -> str:
     return selected
 
 
+def _web_structuring_mode() -> str:
+    selected = os.getenv("DATA_GENERATOR_WEB_STRUCTURING", "auto").strip().lower()
+    if selected in {"1", "true", "yes", "on"}:
+        return "required"
+    if selected in {"0", "false", "no", "off"}:
+        return "off"
+    if selected not in {"auto", "required"}:
+        raise ValueError(
+            "DATA_GENERATOR_WEB_STRUCTURING must be one of: auto, required, off"
+        )
+    return selected
+
+
 def mock_plan_web_acquisition(config):
     from src.data_generator.mode_c.mock_llm import mock_plan_web_acquisition as _impl
 
@@ -211,3 +247,9 @@ def build_web_human_readable_report(*, web_plan, search_results, pages):
     from src.data_generator.mode_c.report import build_web_human_readable_report as _impl
 
     return _impl(web_plan=web_plan, search_results=search_results, pages=pages)
+
+
+def structure_web_sources_for_sft(config, pages):
+    from src.data_generator.mode_c.structuring import structure_web_sources_for_sft as _impl
+
+    return _impl(config, pages)

--- a/src/data_generator/mode_c/structuring.py
+++ b/src/data_generator/mode_c/structuring.py
@@ -1,0 +1,261 @@
+"""Teacher-backed structuring for Mode C web-acquired sources."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from src.data_generator.mode_c.synthetic import (
+    DEFAULT_TEACHER_MODEL,
+    determine_data_schema,
+    morph_to_standard,
+    synthetic_quality_to_validation_report,
+)
+from src.types import DataSchema, OrchestrationConfig, RawData, ValidationReport
+
+
+@dataclass(frozen=True)
+class WebStructuringResult:
+    schema: DataSchema
+    raw_data: RawData
+    validation_report: ValidationReport
+    teacher_used: bool
+
+
+def structure_web_sources_for_sft(
+    config: OrchestrationConfig | Mapping[str, Any],
+    pages: Sequence[Mapping[str, Any]],
+    *,
+    teacher_client: Any = None,
+    teacher_model: str = DEFAULT_TEACHER_MODEL,
+    max_records: int = 24,
+) -> WebStructuringResult:
+    """Turn raw web pages into trainable chat/SFT records when a teacher exists.
+
+    Raw crawled pages are source material, not supervised data. This stage asks a
+    teacher model to emit concrete input/output examples grounded in the source
+    excerpts. If no teacher is available, the result is intentionally invalid so
+    downstream curation will not train on targetless web records.
+    """
+    schema = determine_data_schema(
+        config,
+        teacher_client=teacher_client,
+        teacher_model=teacher_model,
+    )
+    source_pages = [page for page in pages if _page_excerpt(page)]
+    if not source_pages:
+        return _unstructured_result(schema, pages, "No usable web page excerpts to structure.")
+
+    client = teacher_client or _optional_anthropic_client()
+    if client is None:
+        return _unstructured_result(
+            schema,
+            pages,
+            "Mode C web structuring requires a teacher client or ANTHROPIC_API_KEY.",
+        )
+
+    try:
+        message = client.messages.create(
+            model=teacher_model,
+            max_tokens=max(1600, min(max_records, len(source_pages) * 3) * 320),
+            temperature=0.4,
+            system=(
+                "You convert acquired public web source excerpts into supervised "
+                "fine-tuning examples. Return only valid JSON arrays."
+            ),
+            messages=[
+                {
+                    "role": "user",
+                    "content": _structuring_prompt(config, schema, source_pages, max_records),
+                }
+            ],
+        )
+        records = _coerce_teacher_records(_parse_json_array(_message_text(message)))
+    except Exception as exc:
+        if os.getenv("DATA_GENERATOR_WEB_STRUCTURING_STRICT") == "1":
+            raise
+        return _unstructured_result(schema, pages, f"Teacher web structuring failed: {exc}")
+
+    raw = morph_to_standard(
+        {
+            "records": records,
+            "format_meta": {
+                "modality": "text",
+                "file_type": "web_structured_chat_jsonl",
+                "encoding": "utf-8",
+                "schema": schema,
+                "teacher_model": teacher_model,
+                "teacher_used": True,
+                "source_record_count": len(source_pages),
+                "requested_records": max_records,
+            },
+        },
+        schema,
+    )
+    quality = raw["format_meta"]["quality_report"]
+    validation = synthetic_quality_to_validation_report(quality)
+    return WebStructuringResult(
+        schema=schema,
+        raw_data=raw,
+        validation_report=validation,
+        teacher_used=True,
+    )
+
+
+def _unstructured_result(
+    schema: DataSchema,
+    pages: Sequence[Mapping[str, Any]],
+    issue: str,
+) -> WebStructuringResult:
+    return WebStructuringResult(
+        schema=schema,
+        raw_data={
+            "records": [],
+            "format_meta": {
+                "modality": "text",
+                "file_type": "web_structured_chat_jsonl",
+                "encoding": "utf-8",
+                "schema": schema,
+                "teacher_used": False,
+                "source_record_count": len(pages),
+                "quality_report": {
+                    "passed": False,
+                    "issues": [issue],
+                    "total_records": 0,
+                    "valid_records": 0,
+                    "duplicate_records": 0,
+                    "label_counts": {},
+                },
+            },
+        },
+        validation_report={
+            "passed": False,
+            "issues": [issue],
+            "sample_accuracy_estimate": 0.0,
+        },
+        teacher_used=False,
+    )
+
+
+def _structuring_prompt(
+    config: Mapping[str, Any],
+    schema: DataSchema,
+    pages: Sequence[Mapping[str, Any]],
+    max_records: int,
+) -> str:
+    sources = []
+    for index, page in enumerate(pages[:8], start=1):
+        sources.append(
+            {
+                "source_id": f"source_{index}",
+                "url": str(page.get("url") or ""),
+                "title": str(page.get("title") or ""),
+                "excerpt": _page_excerpt(page)[:1800],
+            }
+        )
+
+    return f"""Structure acquired web sources into supervised fine-tuning data.
+
+Task:
+{_task_prompt(config)}
+
+Target schema:
+{json.dumps(schema, indent=2)}
+
+Source excerpts:
+{json.dumps(sources, indent=2)}
+
+Rules:
+- Return a JSON array of at most {max_records} objects.
+- Each object must include "input", "output", and "messages".
+- "messages" must contain a user message and an assistant message.
+- The assistant target must satisfy the target schema exactly.
+- Use only information supported by the provided source excerpts.
+- Include "source_url" when a source URL supports the example.
+- If the sources are not useful for the task, return [].
+
+Example object:
+{{
+  "input": "task input grounded in a source excerpt",
+  "output": "schema-compatible answer or label",
+  "messages": [
+    {{"role": "user", "content": "task input grounded in a source excerpt"}},
+    {{"role": "assistant", "content": "schema-compatible answer or label"}}
+  ],
+  "source_url": "https://example.com/source"
+}}"""
+
+
+def _coerce_teacher_records(records: Sequence[Any]) -> list[dict[str, Any]]:
+    coerced: list[dict[str, Any]] = []
+    for item in records:
+        if not isinstance(item, Mapping):
+            continue
+        record = dict(item)
+        source_url = str(record.get("source_url") or record.get("url") or "").strip()
+        metadata = record.get("metadata") if isinstance(record.get("metadata"), Mapping) else {}
+        metadata = dict(metadata)
+        if source_url:
+            metadata["source_url"] = source_url
+            record["url"] = source_url
+        record["source"] = "mode_c_web_structuring"
+        record["synthetic"] = True
+        record["metadata"] = metadata
+        coerced.append(record)
+    return coerced
+
+
+def _optional_anthropic_client() -> Any | None:
+    if not os.getenv("ANTHROPIC_API_KEY"):
+        return None
+    try:
+        import anthropic
+    except Exception:
+        return None
+    return anthropic.Anthropic()
+
+
+def _parse_json_array(text: str) -> list[Any]:
+    parsed = json.loads(_strip_fences(text))
+    if not isinstance(parsed, list):
+        raise ValueError("teacher response must be a JSON array")
+    return parsed
+
+
+def _strip_fences(text: str) -> str:
+    stripped = text.strip()
+    if not stripped.startswith("```"):
+        return stripped
+    lines = [
+        line for line in stripped.splitlines()
+        if not line.strip().startswith("```")
+    ]
+    return "\n".join(lines).strip()
+
+
+def _message_text(message: Any) -> str:
+    content = getattr(message, "content", message)
+    if isinstance(content, str):
+        return content
+    if isinstance(content, Sequence):
+        parts: list[str] = []
+        for item in content:
+            text = getattr(item, "text", None)
+            if text is not None:
+                parts.append(str(text))
+        return "\n".join(parts)
+    return str(content)
+
+
+def _page_excerpt(page: Mapping[str, Any]) -> str:
+    for key in ("content", "snippet", "title"):
+        value = page.get(key)
+        if value is not None and str(value).strip():
+            return " ".join(str(value).split())
+    return ""
+
+
+def _task_prompt(config: Mapping[str, Any]) -> str:
+    return " ".join(str(config.get("prompt") or "the requested ML task").split())

--- a/tests/test_mode_c_web_structuring.py
+++ b/tests/test_mode_c_web_structuring.py
@@ -1,0 +1,201 @@
+import json
+from types import SimpleNamespace
+
+from src.data_generator.mode_c.nodes import aggregate_web_sources_node
+from src.data_generator.mode_c.structuring import (
+    WebStructuringResult,
+    structure_web_sources_for_sft,
+)
+
+
+def _config():
+    return {
+        "data": False,
+        "prompt": "classify support tickets by urgency",
+        "compute_budget": 10.0,
+        "training_procedure": {
+            "task_type": "text-classification",
+            "data_format": "chat jsonl",
+            "training_type": "SFT",
+            "base_model": None,
+            "hyperparameters": {},
+            "notes": "",
+        },
+    }
+
+
+def _pages():
+    return [
+        {
+            "source": "web_page",
+            "url": "https://example.com/urgency",
+            "title": "Support urgency guide",
+            "content": (
+                "Urgent support tickets include production outages, active "
+                "security incidents, and customer data loss."
+            ),
+            "metadata": {"extraction_method": "trafilatura"},
+        }
+    ]
+
+
+class _FakeTeacher:
+    def __init__(self):
+        self.messages = _FakeMessages()
+
+
+class _FakeMessages:
+    def __init__(self):
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        prompt = kwargs["messages"][0]["content"]
+        if "Infer a supervised fine-tuning data schema" in prompt:
+            payload = {
+                "input_format": "support ticket text",
+                "output_format": "one of: urgent, normal",
+                "input_description": "A support ticket.",
+                "output_description": "The urgency label.",
+                "example_pair": {
+                    "input": "The checkout service is down for all users.",
+                    "output": "urgent",
+                },
+            }
+        else:
+            payload = [
+                {
+                    "input": "The production checkout service is down for all users.",
+                    "output": "urgent",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "The production checkout service is down for all users.",
+                        },
+                        {"role": "assistant", "content": "urgent"},
+                    ],
+                    "source_url": "https://example.com/urgency",
+                },
+                {
+                    "input": "A user asks how to change their profile photo.",
+                    "output": "normal",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "A user asks how to change their profile photo.",
+                        },
+                        {"role": "assistant", "content": "normal"},
+                    ],
+                    "source_url": "https://example.com/urgency",
+                },
+            ]
+        return SimpleNamespace(content=[SimpleNamespace(text=json.dumps(payload))])
+
+
+def test_structure_web_sources_with_teacher_returns_trainable_records(monkeypatch):
+    monkeypatch.delenv("DATA_GENERATOR_SYNTHETIC_OFFLINE", raising=False)
+    teacher = _FakeTeacher()
+
+    result = structure_web_sources_for_sft(
+        _config(),
+        _pages(),
+        teacher_client=teacher,
+        max_records=4,
+    )
+
+    assert result.validation_report["passed"] is True
+    assert result.teacher_used is True
+    assert result.raw_data["format_meta"]["file_type"] == "web_structured_chat_jsonl"
+    assert result.raw_data["format_meta"]["teacher_used"] is True
+    assert len(result.raw_data["records"]) == 2
+    assert {record["output"] for record in result.raw_data["records"]} == {
+        "urgent",
+        "normal",
+    }
+    assert all(record["messages"] for record in result.raw_data["records"])
+    assert len(teacher.messages.calls) == 2
+
+
+def test_aggregate_web_sources_uses_structured_records_when_required(monkeypatch):
+    monkeypatch.setenv("DATA_GENERATOR_WEB_STRUCTURING", "required")
+    from src.data_generator.mode_c import nodes as mode_c_nodes
+
+    schema = {
+        "input_format": "support ticket text",
+        "output_format": "one of: urgent, normal",
+        "input_description": "A support ticket.",
+        "output_description": "The urgency label.",
+        "example_pair": {"input": "The site is down.", "output": "urgent"},
+    }
+    structured_raw = {
+        "records": [
+            {
+                "input": "The site is down.",
+                "output": "urgent",
+                "messages": [
+                    {"role": "user", "content": "The site is down."},
+                    {"role": "assistant", "content": "urgent"},
+                ],
+            }
+        ],
+        "format_meta": {
+            "modality": "text",
+            "file_type": "web_structured_chat_jsonl",
+            "encoding": "utf-8",
+            "schema": schema,
+            "teacher_used": True,
+        },
+    }
+
+    monkeypatch.setattr(
+        mode_c_nodes,
+        "structure_web_sources_for_sft",
+        lambda _config, _pages: WebStructuringResult(
+            schema=schema,
+            raw_data=structured_raw,
+            validation_report={
+                "passed": True,
+                "issues": [],
+                "sample_accuracy_estimate": 1.0,
+            },
+            teacher_used=True,
+        ),
+    )
+
+    out = aggregate_web_sources_node(
+        {
+            "config": _config(),
+            "web_plan": {"planner_backend": "test"},
+            "web_search_results": [{"url": "https://example.com/urgency"}],
+            "web_pages": _pages(),
+            "mode_c_backend": "web",
+        }
+    )
+
+    assert out["validation_report"]["passed"] is True
+    assert out["schema"] == schema
+    assert out["raw_data"]["format_meta"]["file_type"] == "web_structured_chat_jsonl"
+    assert out["raw_data"]["records"][0]["output"] == "urgent"
+
+
+def test_aggregate_web_sources_without_teacher_keeps_raw_web_invalid(monkeypatch):
+    monkeypatch.setenv("DATA_GENERATOR_WEB_STRUCTURING", "auto")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    out = aggregate_web_sources_node(
+        {
+            "config": _config(),
+            "web_plan": {"planner_backend": "test"},
+            "web_search_results": [{"url": "https://example.com/urgency"}],
+            "web_pages": _pages(),
+            "mode_c_backend": "web",
+        }
+    )
+
+    assert out["validation_report"]["passed"] is False
+    assert out["raw_data"]["format_meta"]["file_type"] == "web_aggregated_sources"
+    assert out["raw_data"]["records"][0]["url"] == "https://example.com/urgency"
+    assert any(
+        "web structuring requires a teacher" in issue
+        for issue in out["validation_report"]["issues"]
+    )


### PR DESCRIPTION
## Summary
- Add a teacher-backed Mode C web structuring stage that converts crawled source excerpts into schema-valid chat/SFT records.
- Keep the safety behavior from #40: raw web pages remain invalid training data unless structuring succeeds.
- Add `DATA_GENERATOR_WEB_STRUCTURING=auto|required|off` control. `auto` tries structuring when a teacher is available; `required` returns the structuring result even if it fails; `off` preserves raw source handoff behavior.
- Preserve source/web acquisition metadata on structured raw data so curation and reviewers can trace where records came from.
- Add unit coverage for teacher structuring, aggregate-node wiring, and the no-teacher invalid fallback.

## Why
#40 correctly stops targetless raw web pages from becoming fake SFT targets. This PR adds the missing next stage: when a teacher model is available, Mode C can now turn acquired public web source material into actual supervised examples. If the teacher is unavailable or the sources are not useful, validation stays false and downstream curation refuses to train.

## Validation
- `python3 -m compileall src tests/test_mode_c_web_structuring.py tests/test_mode_c.py tests/test_data_curation.py` -> passed
- `uvx --with pytest --with anthropic --with langgraph --with requests --with tavily-python --with trafilatura --with pymupdf --with datasets --with huggingface-hub --with pyarrow --with tinker --with tinker-cookbook python -m pytest tests/test_mode_c_web_structuring.py tests/test_mode_c.py tests/test_data_curation.py -q` -> `25 passed`
- `uvx --with pytest --with anthropic --with langgraph --with requests --with tinker --with tinker-cookbook --with tavily-python --with trafilatura --with pymupdf --with datasets --with huggingface-hub --with pyarrow python -m pytest tests -q --ignore=tests/data_generator/test_mode_b_hf_retrieval.py --ignore=tests/data_generator/test_mode_c_web.py --ignore=tests/data_generator/test_mode_c_web_robust.py --ignore=tests/integration/test_tinker_live_smoke.py` -> `172 passed, 4 skipped`
- Tiny live Claude-only structuring validation on one manual web excerpt -> passed; 4 schema-valid records, teacher used.
- `git diff --check` -> passed

Stacked on #40.
