### PR TITLE
[codex] run AutoResearch candidates with proposed config

### DIFF
--- a/src/autoresearch/autoresearch.py
+++ b/src/autoresearch/autoresearch.py
@@ -165,6 +165,8 @@ def invoke_autoresearch_graph(
 
 def init_node(state: AutoResearchState) -> dict:
     """LangGraph node. Calls create_eval_suite(). Returns: { eval_suite, current_script, current_config, iteration: 0 }."""
+    _write_current_config(_training_config_from_state(state))
+
     task_analysis: TaskAnalysis = {
         "task_type": state["config"]["training_procedure"]["task_type"],
         "modality": "text",
@@ -739,8 +741,14 @@ def _dataset_result_from_plan(plan: TrainingPlan) -> DatasetResult:
     }
 
 
-def _training_config_from_state(state: AutoResearchState) -> TrainingConfig:
+def _training_config_from_state(
+    state: AutoResearchState,
+    *,
+    include_pending_patch: bool = False,
+) -> TrainingConfig:
     data: dict[str, Any] = dict(state["current_config"])
+    if include_pending_patch and state.get("current_patch"):
+        data.update(json.loads(state["current_patch"]))
     data.setdefault("model_name", state["plan"].get("base_model") or DEFAULT_TINKER_MODEL)
     if "max_seq_len" in data and "max_seq_length" not in data:
         data["max_seq_length"] = data["max_seq_len"]
@@ -752,6 +760,10 @@ def _training_config_from_state(state: AutoResearchState) -> TrainingConfig:
     if lora and "lora_alpha" not in data:
         data["lora_alpha"] = lora["alpha"]
     return TrainingConfig.from_dict(data)
+
+
+def _write_current_config(config: TrainingConfig) -> None:
+    config.save(_CONFIG_PATH)
 
 
 def _training_config_from_plan(plan: TrainingPlan) -> TrainingConfig:
@@ -788,7 +800,10 @@ def _run_tinker_experiment_for_state(
         cost_manager.start(run_id)
     try:
         return run_tinker_sft_experiment(
-            _training_config_from_state(state),
+            _training_config_from_state(
+                state,
+                include_pending_patch=phase == "iteration",
+            ),
             _dataset_result_from_plan(state["plan"]),
             run_id=run_id,
             max_steps=_max_steps_from_state(state),

--- a/tests/test_tinker_runner.py
+++ b/tests/test_tinker_runner.py
@@ -209,6 +209,119 @@ def test_autoresearch_run_node_calls_tinker_runner(monkeypatch, tmp_path):
     assert captured["config"].model_name == "Qwen/Qwen3.5-9B"
 
 
+def test_autoresearch_run_node_uses_pending_proposal_patch(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    data_path = _write_jsonl(tmp_path / "train.jsonl", [{"input": "x", "output": "y"}])
+    captured = {}
+
+    def fake_runner(config, dataset, *, max_steps=None, **kwargs):
+        captured["config"] = config
+        run_dir = tmp_path / "run-patched"
+        run_dir.mkdir()
+        (run_dir / "metrics.json").write_text(
+            json.dumps({"train_loss": 0.5, "val_loss": 0.5, "test_loss": 0.5})
+        )
+        return {
+            "job_id": "fake-run",
+            "status": "COMPLETED",
+            "metrics": {
+                "train_loss": 0.5,
+                "val_loss": 0.5,
+                "test_loss": 0.5,
+                "primary_metric": 2 / 3,
+            },
+            "model_path": str(run_dir),
+            "cost_usd": 0.01,
+            "logs_path": str(run_dir / "metrics.jsonl"),
+        }
+
+    monkeypatch.setattr(ar, "run_tinker_sft_experiment", fake_runner)
+    state = _autoresearch_state(str(data_path))
+    state["current_config"] = {"learning_rate": 1e-4, "batch_size": 4}
+    state["current_patch"] = json.dumps({"learning_rate": 2e-4})
+
+    ar.run_node(state)
+
+    assert captured["config"].learning_rate == pytest.approx(2e-4)
+    assert captured["config"].batch_size == 4
+
+
+def test_autoresearch_propose_then_run_uses_proposed_config(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+    from src.autoresearch.config import TrainingConfig
+
+    data_path = _write_jsonl(tmp_path / "train.jsonl", [{"input": "x", "output": "y"}])
+    config_path = tmp_path / "current.json"
+    TrainingConfig(
+        model_name="Qwen/Qwen3.5-9B",
+        learning_rate=1e-4,
+        batch_size=4,
+    ).save(config_path)
+    monkeypatch.setattr(ar, "_CONFIG_PATH", config_path)
+    monkeypatch.setattr(
+        ar,
+        "propose_hypothesis",
+        lambda *args, **kwargs: {
+            "description": "Increase learning rate for a bounded candidate run.",
+            "patch": json.dumps({"learning_rate": 2e-4}),
+            "expected_effect": "Lower validation loss.",
+            "search_strategy": "local",
+        },
+    )
+    captured = {}
+
+    def fake_runner(config, dataset, *, max_steps=None, **kwargs):
+        captured["config"] = config
+        run_dir = tmp_path / "run-proposed"
+        run_dir.mkdir()
+        (run_dir / "metrics.json").write_text(
+            json.dumps({"train_loss": 0.4, "val_loss": 0.4, "test_loss": 0.4})
+        )
+        return {
+            "job_id": "fake-run",
+            "status": "COMPLETED",
+            "metrics": {
+                "train_loss": 0.4,
+                "val_loss": 0.4,
+                "test_loss": 0.4,
+                "primary_metric": 1 / 1.4,
+            },
+            "model_path": str(run_dir),
+            "cost_usd": 0.01,
+            "logs_path": str(run_dir / "metrics.jsonl"),
+        }
+
+    monkeypatch.setattr(ar, "run_tinker_sft_experiment", fake_runner)
+    state = _autoresearch_state(str(data_path))
+    state["current_config"] = {"learning_rate": 1e-4, "batch_size": 4}
+    state["config"]["training_procedure"]["hyperparameters"] = dict(state["current_config"])
+
+    proposed = ar.propose_node(state)
+    ar.run_node({**state, **proposed})
+
+    assert captured["config"].learning_rate == pytest.approx(2e-4)
+    assert TrainingConfig.load(config_path).learning_rate == pytest.approx(2e-4)
+
+
+def test_autoresearch_init_node_seeds_current_config_json(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+    from src.autoresearch.config import TrainingConfig
+
+    config_path = tmp_path / "configs" / "current.json"
+    monkeypatch.setattr(ar, "_CONFIG_PATH", config_path)
+    state = _autoresearch_state(str(tmp_path / "train.jsonl"))
+    state["current_config"] = {"learning_rate": 1e-4, "batch_size": 4}
+    state["config"]["training_procedure"]["hyperparameters"] = dict(state["current_config"])
+
+    ar.init_node(state)
+
+    seeded = TrainingConfig.load(config_path)
+    assert seeded.model_name == "Qwen/Qwen3.5-9B"
+    assert seeded.learning_rate == pytest.approx(1e-4)
+    assert seeded.batch_size == 4
+
+
 def test_autoresearch_run_node_wraps_tinker_runner_with_cost_manager(monkeypatch, tmp_path):
     import src.autoresearch.autoresearch as ar
 


### PR DESCRIPTION
## Summary
- seed `configs/current.json` from the active AutoResearch state during init so proposal patching starts from the actual baseline config
- submit pending proposal patches to the Tinker runner during iteration runs, instead of rerunning the unpatched baseline hyperparameters
- add regression tests for direct `run_node`, `propose_node` -> `run_node`, and init config seeding

## Why
The full AutoResearch graph looked wired after the Tinker integration, but the proposal path had a silent failure mode: `propose_node` patched `configs/current.json`, while `run_node` built `TrainingConfig` only from `state["current_config"]`. That meant candidate experiments could ignore the proposed hyperparameter change and retrain the baseline config.

## Validation
- `python3 -m compileall src`
- `uvx --with pytest --with anthropic --with langgraph --with tinker --with tinker-cookbook python -m pytest tests/test_tinker_runner.py -q` -> 16 passed
- `uvx --with pytest --with anthropic --with langgraph --with tinker --with tinker-cookbook python -m pytest tests/test_autoresearch.py tests/test_cost_manager.py tests/test_tinker_runner.py -q` -> 50 passed
- expanded stacked merge smoke (#39 + #45 + #43 + #40 + #42 + #44 + #46): broad non-live suite -> 186 passed, 4 skipped
- live candidate-config graph smoke on expanded stack: offline synthetic DataGen -> curation -> DecisionEngine -> baseline Tinker + one deterministic proposal, both 2 steps; captured learning rates were `0.0001` then `0.0002`; Tinker reported `$0.000284`
- `git diff --check`
