### PR TITLE
[codex] guard Manager on untrainable DataGen output

### DIFF
--- a/src/manager/manager.py
+++ b/src/manager/manager.py
@@ -77,7 +77,10 @@ def query_data_node(state: ManagerState) -> dict:
             return {"has_data": True, "data_path": resolved_path}
         return {"has_data": False, "data_path": None}
 
-    path = query_user_for_data()
+    try:
+        path = query_user_for_data()
+    except EOFError:
+        path = None
     return {"has_data": path is not None, "data_path": path}
 
 
@@ -119,6 +122,7 @@ def orchestrate_node(state: ManagerState) -> dict:
     log_event(AgentName.MANAGER, LogLevel.INFO, "Starting DataGen sub-agent", {})
     handoff = invoke_data_generator_graph(config, state.get("data_path"))
     dataset = _handoff_to_dataset_result(handoff)
+    _ensure_dataset_is_trainable(dataset)
 
     # ── 2. Decision Engine — pick model, estimate cost, write training script
     log_event(AgentName.MANAGER, LogLevel.INFO, "Running Decision Engine", {})
@@ -213,6 +217,18 @@ def _handoff_to_dataset_result(handoff: dict) -> DatasetResult:
     from src.data_generator.curation import curate_handoff_to_dataset_result
 
     return curate_handoff_to_dataset_result(handoff)
+
+
+def _ensure_dataset_is_trainable(dataset: DatasetResult) -> None:
+    validation = dataset["validation_report"]
+    split = dataset["dataset"]
+    if validation["passed"] and split["train_size"] > 0:
+        return
+
+    issues = "; ".join(validation.get("issues") or [])
+    if not issues:
+        issues = "no trainable examples were produced"
+    raise ValueError(f"DataGen did not produce a trainable dataset: {issues}")
 
 
 def build_orchestration_config(

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -104,6 +104,27 @@ def test_query_data_node_uses_programmatic_data_path_without_input(tmp_path, mon
     assert out == {"has_data": True, "data_path": str(data_path.resolve())}
 
 
+def test_query_data_node_treats_eof_as_no_data(monkeypatch):
+    def raise_eof(_prompt):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", raise_eof)
+
+    out = query_data_node(
+        {
+            "prompt": "build an assistant",
+            "budget": 5.0,
+            "data_path": None,
+            "has_data": False,
+            "task_reasoning": None,
+            "config": None,
+            "result": None,
+        }
+    )
+
+    assert out == {"has_data": False, "data_path": None}
+
+
 def test_invoke_manager_graph_returns_trained_model():
     pytest.skip("end-to-end graph test requires LangGraph + live sub-agents")
 
@@ -210,3 +231,36 @@ def test_orchestrate_node_returns_trained_model(tmp_path, monkeypatch):
     assert "result" in out
     assert out["result"]["n_iterations"] == 3
     assert out["result"]["cost"]["total_usd"] == 1.0
+
+
+def test_orchestrate_node_stops_before_training_on_untrainable_dataset(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    fake_handoff = {
+        "mode_used": "C",
+        "curation_payload": {
+            "records": [
+                {
+                    "content": "A raw web page without an assistant target.",
+                    "source_kind": "web_page",
+                    "source_locator": "https://example.com/raw",
+                }
+            ]
+        },
+        "validation_report": {
+            "passed": False,
+            "issues": ["raw web pages require structuring before training"],
+            "sample_accuracy_estimate": 0.0,
+        },
+    }
+
+    with patch("src.data_generator.graph.invoke_data_generator_graph",
+               return_value=fake_handoff), \
+         patch("src.decision_engine.decision_engine.run_decision_engine") as mock_de, \
+         patch("src.autoresearch.autoresearch.invoke_autoresearch_graph") as mock_ar, \
+         patch("src.observability.observability.log_event"):
+
+        with pytest.raises(ValueError, match="DataGen did not produce a trainable dataset"):
+            orchestrate_node(_make_orchestrate_state())
+
+    mock_de.assert_not_called()
+    mock_ar.assert_not_called()


### PR DESCRIPTION
## Summary
- stop Manager orchestration before DecisionEngine/AutoResearch when DataGen curation produces no trainable SFT rows or a failed validation report
- treat EOF/no stdin during the initial data prompt as “no user data,” so non-interactive Manager runs can proceed into Mode C instead of hanging/crashing
- add tests for both runtime boundaries

## Why
Mode C web acquisition can legitimately produce raw source material that still needs structuring. Without this guard, Manager would pass an empty/failed curated dataset into the Tinker path and fail later with a less helpful runner error. This keeps the failure at the DataGen boundary where the remediation is clear.

## Validation
- `python3 -m compileall src`
- `uvx --with pytest --with anthropic --with langgraph python -m pytest tests/test_manager.py tests/test_data_curation.py -q` -> 19 passed, 1 skipped
- `uvx --with pytest --with anthropic --with langgraph --with requests --with tavily-python --with trafilatura --with pymupdf python -m pytest tests/test_manager.py tests/test_data_curation.py tests/test_mode_c.py tests/data_generator/test_mode_c_web.py tests/data_generator/test_mode_c_web_robust.py -q` -> 33 passed, 3 skipped
- `git diff --check`
