### PR TITLE
[codex] compare AutoResearch candidates against current best

### DIFF
--- a/src/autoresearch/autoresearch.py
+++ b/src/autoresearch/autoresearch.py
@@ -364,7 +364,8 @@ def revert_and_continue_node(state: AutoResearchState) -> dict:
 def evaluate_node(state: AutoResearchState) -> dict:
     """LangGraph node. Calls run_evals(), compare_scores(), flag_regression(). Returns: { last_score, last_delta }."""
     last_score = run_evals(state["last_result"]["model_path"], state["eval_suite"])
-    last_delta = compare_scores(last_score, state["baseline_score"])
+    reference_score = state.get("best_score") or state["baseline_score"]
+    last_delta = compare_scores(last_score, reference_score)
     regressed = flag_regression(last_delta)
 
     log_event(
@@ -375,6 +376,7 @@ def evaluate_node(state: AutoResearchState) -> dict:
         + ("  ⚠ REGRESSION" if regressed else ""),
         metadata={
             "score": last_score,
+            "reference_score": reference_score,
             "delta": last_delta,
             "regression": regressed,
         },
@@ -456,7 +458,7 @@ def log_node(state: AutoResearchState) -> dict:
             else {"train_loss": 0.0, "val_loss": 0.0, "test_loss": 0.0, "primary_metric": 0.0}
         )
         patch_dict = json.loads(state.get("current_patch", "{}"))
-        diff = _patch_to_diff(patch_dict, state["current_config"])
+        diff = _patch_to_diff(patch_dict, _pre_patch_config_from_state(state))
         record: IterationRecord = {
             "iteration": iteration_number,
             "hypothesis": state.get("last_description", str(patch_dict)),
@@ -545,6 +547,18 @@ def continue_edge(state: AutoResearchState) -> Literal["propose", "__end__"]:
         return "__end__"
 
     return "propose"
+
+
+def _pre_patch_config_from_state(state: AutoResearchState) -> dict[str, Any]:
+    original_content = state.get("original_content")
+    if original_content:
+        try:
+            original_config = json.loads(original_content)
+        except json.JSONDecodeError:
+            original_config = None
+        if isinstance(original_config, dict):
+            return original_config
+    return state["current_config"]
 
 
 def _spent_usd_from_state(state: AutoResearchState) -> float:

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -190,6 +190,36 @@ def test_flag_regression_at_boundary_is_not_triggered():
     assert flag_regression(delta, threshold=-0.01) is False
 
 
+def test_evaluate_node_compares_against_current_best(monkeypatch):
+    import src.autoresearch.autoresearch as ar
+
+    monkeypatch.setattr(
+        ar,
+        "run_evals",
+        lambda _model_path, _suite: {"scalar": 0.70, "metrics": {}, "critique": ""},
+    )
+    state = _make_state(
+        eval_suite={"primary_metric": "accuracy", "metrics": [], "test_split_path": "",
+                    "use_llm_grading": False},
+        baseline_score={"scalar": 0.50, "metrics": {}, "critique": ""},
+        best_score={"scalar": 0.80, "metrics": {}, "critique": ""},
+        last_result={
+            "job_id": "candidate",
+            "status": "COMPLETED",
+            "metrics": {"train_loss": 0.3, "val_loss": 0.4,
+                        "test_loss": 0.5, "primary_metric": 0.70},
+            "model_path": "candidate-model",
+            "cost_usd": 0.01,
+            "logs_path": "candidate.jsonl",
+        },
+    )
+
+    out = ar.evaluate_node(state)
+
+    assert out["last_delta"]["improved"] is False
+    assert out["last_delta"]["absolute"] == pytest.approx(-0.10)
+
+
 # ─── log_iteration ────────────────────────────────────────────────────────────
 
 def test_log_iteration_appends_to_diary(tmp_path, monkeypatch):
@@ -233,6 +263,40 @@ def test_log_iteration_returns_extended_diary(tmp_path, monkeypatch):
         result = log_iteration(existing, new_record)
         assert len(result) == 2
         assert result[-1]["iteration"] == 2
+    finally:
+        ar._DIARY_PATH = original_path
+
+
+def test_log_node_uses_pre_patch_config_for_kept_diff(tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    original_path = ar._DIARY_PATH
+    ar._DIARY_PATH = tmp_path / "diary.jsonl"
+    try:
+        state = _make_state(
+            eval_suite={"primary_metric": "accuracy", "metrics": [], "test_split_path": "",
+                        "use_llm_grading": False},
+            current_config={"learning_rate": 2e-4, "batch_size": 4},
+            current_patch=json.dumps({"learning_rate": 2e-4}),
+            original_content=json.dumps({"learning_rate": 1e-4, "batch_size": 4}),
+            last_description="Increase learning rate.",
+            last_delta={"absolute": 0.1, "relative_pct": 20.0, "improved": True},
+            last_result={
+                "job_id": "candidate",
+                "status": "COMPLETED",
+                "metrics": {"train_loss": 0.3, "val_loss": 0.4,
+                            "test_loss": 0.5, "primary_metric": 0.70},
+                "model_path": "candidate-model",
+                "cost_usd": 0.01,
+                "logs_path": "candidate.jsonl",
+            },
+        )
+
+        out = ar.log_node(state)
+
+        assert out["diary"][0]["decision"] == "KEPT"
+        assert "- learning_rate: 0.0001" in out["diary"][0]["patch"]
+        assert "+ learning_rate: 0.0002" in out["diary"][0]["patch"]
     finally:
         ar._DIARY_PATH = original_path
 


### PR DESCRIPTION
## Summary
- compare candidate eval scores against the current best score instead of the original baseline
- keep diary diffs anchored to the pre-patch config, even after a kept patch advances `current_config`
- add regression tests for worse-than-best candidates and kept-patch diary diffs

## Why
The full AutoResearch loop could accept a candidate that beat the original baseline while still being worse than the current best run. That makes the search look productive while moving backward. The diary diff had a related audit issue: after `keep_node` advanced `current_config`, `log_node` could render the accepted patch as old=new.

## Validation
- `python3 -m compileall src`
- `uvx --with pytest --with anthropic --with langgraph --with tinker --with tinker-cookbook python -m pytest tests/test_autoresearch.py tests/test_cost_manager.py tests/test_tinker_runner.py -q` -> 52 passed
- expanded stacked merge smoke (#39 + #45 + #47 + #43 + #40 + #42 + #44 + #46): broad non-live suite -> 188 passed, 4 skipped
- `git diff --check`
