### PR TITLE
[codex] validate AutoResearch config patches

### DIFF
--- a/src/autoresearch/autoresearch.py
+++ b/src/autoresearch/autoresearch.py
@@ -706,7 +706,7 @@ def apply_patch(script_path: str, patch: str) -> str:
     if path.suffix == ".json":
         config_dict = json.loads(original)
         patch_dict = json.loads(patch)
-        config_dict.update(patch_dict)
+        config_dict = TrainingConfig.from_dict(config_dict).apply_patch(patch_dict).to_dict()
         # Write atomically via a temp file + rename so a crash mid-write
         # never leaves a partially-written config on disk.
         tmp = path.with_suffix(".json.tmp")
@@ -761,8 +761,6 @@ def _training_config_from_state(
     include_pending_patch: bool = False,
 ) -> TrainingConfig:
     data: dict[str, Any] = dict(state["current_config"])
-    if include_pending_patch and state.get("current_patch"):
-        data.update(json.loads(state["current_patch"]))
     data.setdefault("model_name", state["plan"].get("base_model") or DEFAULT_TINKER_MODEL)
     if "max_seq_len" in data and "max_seq_length" not in data:
         data["max_seq_length"] = data["max_seq_len"]
@@ -773,7 +771,10 @@ def _training_config_from_state(
         data["lora_rank"] = lora["rank"]
     if lora and "lora_alpha" not in data:
         data["lora_alpha"] = lora["alpha"]
-    return TrainingConfig.from_dict(data)
+    config = TrainingConfig.from_dict(data)
+    if include_pending_patch and state.get("current_patch"):
+        config = config.apply_patch(json.loads(state["current_patch"]))
+    return config
 
 
 def _write_current_config(config: TrainingConfig) -> None:

--- a/tests/test_propose_infra.py
+++ b/tests/test_propose_infra.py
@@ -336,6 +336,28 @@ def test_ar_apply_patch_returns_valid_original_json(tmp_path, base_config):
     assert old["batch_size"] == 16  # TrainingConfig default
 
 
+def test_ar_apply_patch_rejects_invalid_patch_without_writing(tmp_path, base_config):
+    config_path = tmp_path / "config.json"
+    base_config.save(config_path)
+    before = config_path.read_text()
+
+    with pytest.raises(ValueError, match="above maximum"):
+        ar_apply_patch(str(config_path), json.dumps({"learning_rate": 1.0}))
+
+    assert config_path.read_text() == before
+
+
+def test_ar_apply_patch_rejects_unknown_patch_without_writing(tmp_path, base_config):
+    config_path = tmp_path / "config.json"
+    base_config.save(config_path)
+    before = config_path.read_text()
+
+    with pytest.raises(ValueError, match="Unknown hyperparameter"):
+        ar_apply_patch(str(config_path), json.dumps({"not_a_real_param": 42}))
+
+    assert config_path.read_text() == before
+
+
 def test_ar_revert_patch_restores_original(tmp_path, base_config):
     config_path = tmp_path / "config.json"
     base_config.save(config_path)

--- a/tests/test_tinker_runner.py
+++ b/tests/test_tinker_runner.py
@@ -247,6 +247,23 @@ def test_autoresearch_run_node_uses_pending_proposal_patch(monkeypatch, tmp_path
     assert captured["config"].batch_size == 4
 
 
+def test_autoresearch_run_node_rejects_invalid_pending_patch(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    data_path = _write_jsonl(tmp_path / "train.jsonl", [{"input": "x", "output": "y"}])
+
+    def fail_runner(*_args, **_kwargs):
+        raise AssertionError("invalid patches should be rejected before Tinker runs")
+
+    monkeypatch.setattr(ar, "run_tinker_sft_experiment", fail_runner)
+    state = _autoresearch_state(str(data_path))
+    state["current_config"] = {"learning_rate": 1e-4, "batch_size": 4}
+    state["current_patch"] = json.dumps({"lora_rank": 3})
+
+    with pytest.raises(ValueError, match="candidates"):
+        ar.run_node(state)
+
+
 def test_autoresearch_propose_then_run_uses_proposed_config(monkeypatch, tmp_path):
     import src.autoresearch.autoresearch as ar
     from src.autoresearch.config import TrainingConfig


### PR DESCRIPTION
## Summary
- validate AutoResearch JSON config patches with `TrainingConfig.apply_patch` before writing `configs/current.json`
- validate pending graph-state patches before launching a Tinker candidate run
- add regression tests that invalid patches are rejected without mutating config files or calling Tinker

## Why
The proposal prompt asks Claude to stay inside safe bounds, but the runtime should enforce those bounds too. Without this, an invalid proposal could be written to disk or passed to Tinker before any typed validation happened.

## Validation
- `python3 -m compileall src`
- `uvx --with pytest --with anthropic --with langgraph --with tinker --with tinker-cookbook python -m pytest tests/test_propose_infra.py tests/test_autoresearch.py tests/test_tinker_runner.py -q` -> 75 passed
- `uvx --with pytest --with anthropic --with langgraph --with tinker --with tinker-cookbook python -m pytest tests/test_autoresearch.py tests/test_cost_manager.py tests/test_tinker_runner.py tests/test_propose_infra.py -q` -> 85 passed
- expanded stacked merge smoke (#39 + #45 + #47 + #48 + #43 + #40 + #42 + #44 + #46): broad non-live suite -> 191 passed, 4 skipped
- `git diff --check`
