### PR TITLE
[codex] bridge frontend to Manager run API

### DIFF
--- a/ml-agent-frontend/README.md
+++ b/ml-agent-frontend/README.md
@@ -10,6 +10,16 @@ npm run dev        # http://localhost:5173
 npm run build      # production build → dist/
 ```
 
+By default the UI runs in local simulation mode. To use the real Manager API:
+
+```bash
+cd ..
+uvicorn src.server.app:app --reload --port 8000
+
+cd ml-agent-frontend
+VITE_API_BASE_URL=/api npm run dev
+```
+
 ## Deploy (Vercel)
 
 ```bash

--- a/ml-agent-frontend/src/App.tsx
+++ b/ml-agent-frontend/src/App.tsx
@@ -1,10 +1,15 @@
 import { useTrainingSimulation } from './hooks/useTrainingSimulation';
+import { useTrainingRun } from './hooks/useTrainingRun';
+import { isBackendApiConfigured } from './api/runs';
 import InputForm from './components/InputForm';
 import Dashboard from './components/Dashboard';
 import type { TaskType } from './types';
 
 export default function App() {
-  const { state, start, reset } = useTrainingSimulation();
+  const simulation = useTrainingSimulation();
+  const backend = useTrainingRun();
+  const controller = isBackendApiConfigured() ? backend : simulation;
+  const { state, start, reset } = controller;
 
   const handleStart = (prompt: string, budget: number, taskType: TaskType) => {
     start(prompt, budget, taskType);

--- a/ml-agent-frontend/src/api/runs.ts
+++ b/ml-agent-frontend/src/api/runs.ts
@@ -1,0 +1,58 @@
+import type { TaskType, TrainingState } from '../types';
+
+export interface CreateRunResponse {
+  run_id: string;
+  status: 'running';
+}
+
+export interface BackendRunState extends TrainingState {
+  run_id: string;
+  result?: Record<string, unknown> | null;
+}
+
+interface CreateRunRequest {
+  prompt: string;
+  budget: number;
+  task_type: TaskType;
+  data_path?: string | null;
+}
+
+export function getApiBaseUrl(): string | null {
+  const value = import.meta.env.VITE_API_BASE_URL?.trim();
+  if (!value) return null;
+  return value.replace(/\/$/, '');
+}
+
+export function isBackendApiConfigured(): boolean {
+  return getApiBaseUrl() !== null;
+}
+
+async function requestJson<T>(path: string, options?: RequestInit): Promise<T> {
+  const baseUrl = getApiBaseUrl();
+  if (!baseUrl) {
+    throw new Error('Backend API is not configured.');
+  }
+
+  const headers = new Headers(options?.headers);
+  headers.set('Content-Type', 'application/json');
+  const response = await fetch(`${baseUrl}${path}`, {
+    ...options,
+    headers,
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(body || `Request failed with status ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+export function createRun(request: CreateRunRequest): Promise<CreateRunResponse> {
+  return requestJson<CreateRunResponse>('/runs', {
+    method: 'POST',
+    body: JSON.stringify(request),
+  });
+}
+
+export function getRun(runId: string): Promise<BackendRunState> {
+  return requestJson<BackendRunState>(`/runs/${runId}`);
+}

--- a/ml-agent-frontend/src/components/ActivityLog.tsx
+++ b/ml-agent-frontend/src/components/ActivityLog.tsx
@@ -8,6 +8,7 @@ interface Props {
 const typeColor: Record<LogEntry['type'], string> = {
   success: 'var(--success)',
   warning: 'var(--warning)',
+  error: 'var(--danger)',
   default: 'var(--text-muted)',
 };
 

--- a/ml-agent-frontend/src/components/Dashboard.tsx
+++ b/ml-agent-frontend/src/components/Dashboard.tsx
@@ -24,8 +24,22 @@ const headerStyle: React.CSSProperties = {
 };
 
 function StatusDot({ status }: { status: TrainingState['status'] }) {
-  const color = status === 'complete' ? 'var(--success)' : status === 'running' ? 'var(--accent)' : 'var(--text-muted)';
-  const label = status === 'complete' ? 'COMPLETE' : status === 'running' ? 'RUNNING' : 'IDLE';
+  const color =
+    status === 'complete'
+      ? 'var(--success)'
+      : status === 'failed'
+        ? 'var(--danger)'
+        : status === 'running'
+          ? 'var(--accent)'
+          : 'var(--text-muted)';
+  const label =
+    status === 'complete'
+      ? 'COMPLETE'
+      : status === 'failed'
+        ? 'FAILED'
+        : status === 'running'
+          ? 'RUNNING'
+          : 'IDLE';
 
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
@@ -118,6 +132,26 @@ export default function Dashboard({ state, onReset }: Props) {
 
         {/* Pipeline + budget */}
         <PipelineProgress stages={state.stages} costSpent={state.costSpent} budget={state.budget} />
+
+        {state.status === 'failed' && (
+          <section
+            style={{
+              background: 'var(--danger-dim)',
+              border: '0.5px solid var(--danger)',
+              borderRadius: 'var(--radius)',
+              padding: '0.875rem 1rem',
+              marginBottom: '1.5rem',
+            }}
+            role="alert"
+          >
+            <p style={{ fontSize: '12px', fontWeight: 600, color: 'var(--danger)', marginBottom: '0.25rem' }}>
+              Run failed
+            </p>
+            <p style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>
+              {state.error ?? 'The backend run ended before producing a model.'}
+            </p>
+          </section>
+        )}
 
         {/* 4 metric cards */}
         <MetricsGrid metrics={state.metrics} costSpent={state.costSpent} budget={state.budget} />

--- a/ml-agent-frontend/src/components/Tooltip.tsx
+++ b/ml-agent-frontend/src/components/Tooltip.tsx
@@ -42,8 +42,6 @@ export default function Tooltip({ label, body, placement = 'top' }: Props) {
     <span style={{ position: 'relative', display: 'inline-flex', alignItems: 'center' }}>
       <button
         type="button"
-        onMouseEnter={show}
-        onMouseLeave={hide}
         onFocus={show}
         onBlur={hide}
         aria-label={`More info: ${label}`}

--- a/ml-agent-frontend/src/hooks/useTrainingRun.ts
+++ b/ml-agent-frontend/src/hooks/useTrainingRun.ts
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createRun, getRun } from '../api/runs';
+import type { TaskType, TrainingState } from '../types';
+
+function makeInitialState(): TrainingState {
+  return {
+    status: 'idle',
+    stage: -1,
+    prompt: '',
+    budget: 50,
+    taskType: 'classification',
+    costSpent: 0,
+    metrics: [],
+    iterations: [],
+    logs: [],
+    stages: [],
+    error: null,
+  };
+}
+
+function makeStartingState(prompt: string, budget: number, taskType: TaskType): TrainingState {
+  return {
+    status: 'running',
+    stage: 0,
+    prompt,
+    budget,
+    taskType,
+    costSpent: 0,
+    metrics: [],
+    iterations: [],
+    logs: [],
+    stages: [
+      { id: 0, label: 'Manager Init', status: 'in-progress' },
+      { id: 1, label: 'Data Discovery', status: 'pending' },
+      { id: 2, label: 'Model Selection', status: 'pending' },
+      { id: 3, label: 'Training', status: 'pending' },
+      { id: 4, label: 'AutoResearch', status: 'pending' },
+      { id: 5, label: 'Finalization', status: 'pending' },
+    ],
+    error: null,
+  };
+}
+
+export function useTrainingRun() {
+  const [state, setState] = useState<TrainingState>(makeInitialState);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => stopPolling, [stopPolling]);
+
+  const poll = useCallback(async (runId: string) => {
+    const next = await getRun(runId);
+    setState({
+      status: next.status,
+      stage: next.stage,
+      prompt: next.prompt,
+      budget: next.budget,
+      taskType: next.taskType,
+      costSpent: next.costSpent,
+      metrics: next.metrics,
+      iterations: next.iterations,
+      logs: next.logs,
+      stages: next.stages,
+      error: next.error,
+      runId: next.run_id,
+    });
+
+    if (next.status === 'complete' || next.status === 'failed') {
+      stopPolling();
+    }
+  }, [stopPolling]);
+
+  const start = useCallback(async (prompt: string, budget: number, taskType: TaskType) => {
+    stopPolling();
+    setState(makeStartingState(prompt, budget, taskType));
+
+    try {
+      const created = await createRun({
+        prompt,
+        budget,
+        task_type: taskType,
+        data_path: null,
+      });
+      setState(prev => ({ ...prev, runId: created.run_id }));
+      await poll(created.run_id);
+      pollRef.current = setInterval(() => {
+        void poll(created.run_id).catch((error: unknown) => {
+          stopPolling();
+          setState(prev => ({
+            ...prev,
+            status: 'failed',
+            error: error instanceof Error ? error.message : String(error),
+          }));
+        });
+      }, 2000);
+    } catch (error) {
+      setState(prev => ({
+        ...prev,
+        status: 'failed',
+        error: error instanceof Error ? error.message : String(error),
+      }));
+    }
+  }, [poll, stopPolling]);
+
+  const reset = useCallback(() => {
+    stopPolling();
+    setState(makeInitialState());
+  }, [stopPolling]);
+
+  return { state, start, reset };
+}

--- a/ml-agent-frontend/src/types.ts
+++ b/ml-agent-frontend/src/types.ts
@@ -1,6 +1,6 @@
 export type StageStatus = 'pending' | 'in-progress' | 'complete';
 export type TaskType = 'classification' | 'regression' | 'fine-tuning';
-export type LogType = 'default' | 'success' | 'warning';
+export type LogType = 'default' | 'success' | 'warning' | 'error';
 export type IterationStatus = 'KEPT' | 'REVERTED' | 'PENDING';
 
 export interface PipelineStage {
@@ -32,7 +32,7 @@ export interface LogEntry {
 }
 
 export interface TrainingState {
-  status: 'idle' | 'running' | 'complete';
+  status: 'idle' | 'running' | 'complete' | 'failed';
   stage: number;
   prompt: string;
   budget: number;
@@ -42,4 +42,6 @@ export interface TrainingState {
   iterations: Iteration[];
   logs: LogEntry[];
   stages: PipelineStage[];
+  error?: string | null;
+  runId?: string;
 }

--- a/ml-agent-frontend/vite.config.ts
+++ b/ml-agent-frontend/vite.config.ts
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000',
+    },
+  },
 })

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,6 @@ torch>=2.2.0
 pytest>=8.0.0
 tinker
 tinker-cookbook
+fastapi>=0.115.0
+uvicorn>=0.30.0
+httpx>=0.27.0

--- a/src/server/__init__.py
+++ b/src/server/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP server entrypoints for the ML agent frontend bridge."""

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -1,0 +1,249 @@
+"""FastAPI bridge between the Vite frontend and the Manager graph.
+
+The server deliberately keeps the v1 contract small: start a run, poll its
+state, and surface the final Manager result. Detailed live log streaming can be
+added later once observability emits run-scoped events.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+
+from src.manager.manager import invoke_manager_graph
+from src.server.schemas import (
+    IterationView,
+    LogEntryView,
+    MetricPoint,
+    PipelineStage,
+    RunCreated,
+    RunRequest,
+    RunState,
+)
+
+
+STAGE_LABELS = [
+    "Manager Init",
+    "Data Discovery",
+    "Model Selection",
+    "Training",
+    "AutoResearch",
+    "Finalization",
+]
+
+
+app = FastAPI(title="Nemoral ML Agent API")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],
+    allow_credentials=False,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@dataclass
+class _RunRecord:
+    run_id: str
+    request: RunRequest
+    status: str = "running"
+    stage: int = 0
+    cost_spent: float = 0.0
+    metrics: list[MetricPoint] = field(default_factory=list)
+    iterations: list[IterationView] = field(default_factory=list)
+    logs: list[LogEntryView] = field(default_factory=list)
+    result: dict[str, Any] | None = None
+    error: str | None = None
+    stages: list[PipelineStage] = field(default_factory=list)
+
+
+_RUNS: dict[str, _RunRecord] = {}
+_LOCK = threading.RLock()
+
+
+def _initial_stages() -> list[PipelineStage]:
+    return [
+        PipelineStage(id=index, label=label, status="pending")
+        for index, label in enumerate(STAGE_LABELS)
+    ]
+
+
+def _time_label() -> str:
+    return datetime.now().strftime("%H:%M:%S")
+
+
+def _append_log(record: _RunRecord, component: str, message: str, kind: str = "default") -> None:
+    record.logs.insert(
+        0,
+        LogEntryView(time=_time_label(), component=component, message=message, type=kind),
+    )
+    record.logs = record.logs[:100]
+
+
+def _mark_stage(record: _RunRecord, stage: int, status: str = "in-progress") -> None:
+    record.stage = stage
+    updated = []
+    for item in record.stages:
+        if item.id < stage:
+            updated.append(PipelineStage(id=item.id, label=item.label, status="complete"))
+        elif item.id == stage:
+            updated.append(PipelineStage(id=item.id, label=item.label, status=status))
+        else:
+            updated.append(PipelineStage(id=item.id, label=item.label, status="pending"))
+    record.stages = updated
+
+
+def _complete_all_stages(record: _RunRecord) -> None:
+    record.stage = len(STAGE_LABELS) - 1
+    record.stages = [
+        PipelineStage(id=item.id, label=item.label, status="complete")
+        for item in record.stages
+    ]
+
+
+def _fail_current_stage(record: _RunRecord, message: str) -> None:
+    record.status = "failed"
+    record.error = message
+    _append_log(record, "Manager", message, "error")
+
+
+def _metric_from_result(result: dict[str, Any]) -> MetricPoint | None:
+    score = result.get("metrics") or {}
+    metrics = score.get("metrics") or {}
+    scalar = float(score.get("scalar") or metrics.get("primary_metric") or 0.0)
+
+    loss = metrics.get("val_loss")
+    if loss is None:
+        loss = metrics.get("train_loss")
+    if loss is None:
+        loss = max(0.0, 1.0 - scalar)
+
+    return MetricPoint(loss=float(loss), accuracy=scalar, iteration=1)
+
+
+def _iterations_from_diary(path: str | None) -> list[IterationView]:
+    if not path:
+        return []
+
+    diary_path = Path(path)
+    if not diary_path.exists():
+        return []
+
+    iterations: list[IterationView] = []
+    for line in diary_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        metrics = row.get("metrics") or {}
+        iteration = int(row.get("iteration") or len(iterations) + 1)
+        decision = row.get("decision") or "PENDING"
+        if decision not in {"KEPT", "REVERTED", "PENDING"}:
+            decision = "PENDING"
+
+        iterations.append(
+            IterationView(
+                id=f"iter-{iteration}",
+                experiment=str(row.get("hypothesis") or "AutoResearch iteration"),
+                diff=row.get("patch"),
+                loss=float(metrics.get("val_loss") or metrics.get("train_loss") or 0.0),
+                f1=float(metrics.get("primary_metric") or 0.0),
+                status=decision,
+            )
+        )
+    return list(reversed(iterations))
+
+
+def _store_manager_result(record: _RunRecord, result: dict[str, Any]) -> None:
+    record.result = result
+    record.status = "complete"
+    record.cost_spent = float((result.get("cost") or {}).get("total_usd") or 0.0)
+    metric = _metric_from_result(result)
+    record.metrics = [metric] if metric else []
+    record.iterations = _iterations_from_diary(result.get("research_diary_path"))
+    _complete_all_stages(record)
+    _append_log(record, "Manager", "Training pipeline complete", "success")
+
+
+def _run_manager(record: _RunRecord) -> None:
+    with _LOCK:
+        _mark_stage(record, 0)
+        _append_log(record, "Manager", "Run accepted")
+        _append_log(record, "Manager", "Manager graph is running")
+
+    try:
+        result = invoke_manager_graph(
+            record.request.prompt,
+            record.request.budget,
+            record.request.data_path,
+        )
+    except Exception as exc:  # surfaced to the browser as a failed run state
+        with _LOCK:
+            _fail_current_stage(record, str(exc))
+        return
+
+    with _LOCK:
+        _store_manager_result(record, dict(result))
+
+
+def _to_state(record: _RunRecord) -> RunState:
+    return RunState(
+        run_id=record.run_id,
+        status=record.status,
+        stage=record.stage,
+        prompt=record.request.prompt,
+        budget=record.request.budget,
+        taskType=record.request.task_type,
+        costSpent=record.cost_spent,
+        metrics=record.metrics,
+        iterations=record.iterations,
+        logs=record.logs,
+        stages=record.stages,
+        result=record.result,
+        error=record.error,
+    )
+
+
+@app.get("/api/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/api/runs", response_model=RunCreated)
+def create_run(request: RunRequest) -> RunCreated:
+    if request.data_path and not Path(request.data_path).exists():
+        raise HTTPException(status_code=400, detail="data_path does not exist")
+
+    run_id = str(uuid.uuid4())
+    record = _RunRecord(run_id=run_id, request=request, stages=_initial_stages())
+    with _LOCK:
+        _RUNS[run_id] = record
+
+    thread = threading.Thread(target=_run_manager, args=(record,), daemon=True)
+    thread.start()
+    return RunCreated(run_id=run_id, status="running")
+
+
+@app.get("/api/runs/{run_id}", response_model=RunState)
+def get_run(run_id: str) -> RunState:
+    with _LOCK:
+        record = _RUNS.get(run_id)
+        if record is None:
+            raise HTTPException(status_code=404, detail="run not found")
+        return _to_state(record)
+
+
+def _reset_runs_for_tests() -> None:
+    with _LOCK:
+        _RUNS.clear()

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -8,6 +8,7 @@ added later once observability emits run-scoped events.
 from __future__ import annotations
 
 import json
+import os
 import threading
 import uuid
 from dataclasses import dataclass, field
@@ -38,12 +39,27 @@ STAGE_LABELS = [
     "AutoResearch",
     "Finalization",
 ]
+LOCAL_DEV_ORIGIN_REGEX = r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$"
+
+
+def _cors_origins_from_env() -> list[str]:
+    origins = [
+        "http://localhost:5173",
+        "http://127.0.0.1:5173",
+    ]
+    extra_origins = os.getenv("MANAGER_API_CORS_ORIGINS", "")
+    for origin in extra_origins.split(","):
+        normalized = origin.strip().rstrip("/")
+        if normalized and normalized not in origins:
+            origins.append(normalized)
+    return origins
 
 
 app = FastAPI(title="Nemoral ML Agent API")
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],
+    allow_origins=_cors_origins_from_env(),
+    allow_origin_regex=LOCAL_DEV_ORIGIN_REGEX,
     allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/src/server/schemas.py
+++ b/src/server/schemas.py
@@ -1,0 +1,63 @@
+"""Pydantic schemas for the browser-facing run API."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class RunRequest(BaseModel):
+    prompt: str = Field(min_length=10, max_length=2000)
+    budget: float = Field(gt=0, le=500)
+    task_type: Literal["classification", "regression", "fine-tuning"] = "fine-tuning"
+    data_path: str | None = None
+
+
+class RunCreated(BaseModel):
+    run_id: str
+    status: Literal["running"]
+
+
+class PipelineStage(BaseModel):
+    id: int
+    label: str
+    status: Literal["pending", "in-progress", "complete"]
+
+
+class MetricPoint(BaseModel):
+    loss: float
+    accuracy: float
+    iteration: int
+
+
+class IterationView(BaseModel):
+    id: str
+    experiment: str
+    diff: str | None = None
+    loss: float
+    f1: float
+    status: Literal["KEPT", "REVERTED", "PENDING"]
+
+
+class LogEntryView(BaseModel):
+    time: str
+    component: str
+    message: str
+    type: Literal["default", "success", "warning", "error"]
+
+
+class RunState(BaseModel):
+    run_id: str
+    status: Literal["running", "complete", "failed"]
+    stage: int
+    prompt: str
+    budget: float
+    taskType: Literal["classification", "regression", "fine-tuning"]
+    costSpent: float
+    metrics: list[MetricPoint]
+    iterations: list[IterationView]
+    logs: list[LogEntryView]
+    stages: list[PipelineStage]
+    result: dict[str, Any] | None = None
+    error: str | None = None

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -1,0 +1,153 @@
+"""Tests for the browser-facing FastAPI run bridge."""
+
+from __future__ import annotations
+
+import json
+import time
+
+from fastapi.testclient import TestClient
+
+from src.server import app as server_app
+
+
+def _fake_model(tmp_path, *, total_cost=1.25):
+    diary_path = tmp_path / "diary.jsonl"
+    diary_path.write_text(
+        json.dumps(
+            {
+                "iteration": 1,
+                "hypothesis": "Decrease learning rate",
+                "patch": "- learning_rate: 0.0002\n+ learning_rate: 0.0001",
+                "metrics": {
+                    "train_loss": 0.31,
+                    "val_loss": 0.29,
+                    "primary_metric": 0.775,
+                },
+                "decision": "KEPT",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return {
+        "weights_path": "outputs/experiments/run/model",
+        "metrics": {
+            "scalar": 0.775,
+            "metrics": {
+                "train_loss": 0.31,
+                "val_loss": 0.29,
+                "primary_metric": 0.775,
+            },
+            "critique": "ok",
+        },
+        "cost": {
+            "data_gen_usd": 0.0,
+            "training_usd": total_cost,
+            "llm_calls_usd": 0.0,
+            "total_usd": total_cost,
+            "termination_reason": "training_complete",
+        },
+        "n_iterations": 1,
+        "research_diary_path": str(diary_path),
+    }
+
+
+def _wait_for_status(client: TestClient, run_id: str, status: str):
+    deadline = time.time() + 5
+    last = None
+    while time.time() < deadline:
+        response = client.get(f"/api/runs/{run_id}")
+        response.raise_for_status()
+        last = response.json()
+        if last["status"] == status:
+            return last
+        time.sleep(0.05)
+    raise AssertionError(f"run did not reach {status}; last state={last}")
+
+
+def setup_function():
+    server_app._reset_runs_for_tests()
+
+
+def test_health_check():
+    client = TestClient(server_app.app)
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_create_run_completes_with_manager_result(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_invoke(prompt, budget, data_path=None):
+        calls.append((prompt, budget, data_path))
+        return _fake_model(tmp_path)
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune a small chat assistant on support tickets",
+            "budget": 25,
+            "task_type": "fine-tuning",
+            "data_path": None,
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    state = _wait_for_status(client, run_id, "complete")
+
+    assert calls == [
+        ("Fine tune a small chat assistant on support tickets", 25.0, None)
+    ]
+    assert state["costSpent"] == 1.25
+    assert state["metrics"][0]["loss"] == 0.29
+    assert state["metrics"][0]["accuracy"] == 0.775
+    assert state["iterations"][0]["status"] == "KEPT"
+    assert state["result"]["weights_path"] == "outputs/experiments/run/model"
+
+
+def test_create_run_surfaces_manager_failure(monkeypatch):
+    def fail_invoke(prompt, budget, data_path=None):
+        raise RuntimeError("DataGen did not produce a trainable dataset")
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fail_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Train a classifier from public web data",
+            "budget": 20,
+            "task_type": "classification",
+        },
+    )
+
+    assert response.status_code == 200
+    state = _wait_for_status(client, response.json()["run_id"], "failed")
+    assert "DataGen did not produce a trainable dataset" in state["error"]
+    assert state["logs"][0]["type"] == "error"
+
+
+def test_missing_data_path_is_rejected_before_background_run(monkeypatch):
+    def fail_invoke(prompt, budget, data_path=None):
+        raise AssertionError("manager should not be called for missing data_path")
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fail_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune on my local data",
+            "budget": 20,
+            "task_type": "fine-tuning",
+            "data_path": "/path/that/does/not/exist.jsonl",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "data_path does not exist" in response.text

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -76,6 +76,33 @@ def test_health_check():
     assert response.json() == {"status": "ok"}
 
 
+def test_cors_allows_alternate_local_dev_ports():
+    client = TestClient(server_app.app)
+
+    response = client.options(
+        "/api/runs",
+        headers={
+            "Origin": "http://127.0.0.1:5177",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "http://127.0.0.1:5177"
+
+
+def test_cors_origins_can_be_extended_from_env(monkeypatch):
+    monkeypatch.setenv(
+        "MANAGER_API_CORS_ORIGINS",
+        "https://preview.example.com, http://localhost:5173",
+    )
+
+    origins = server_app._cors_origins_from_env()
+
+    assert origins.count("http://localhost:5173") == 1
+    assert "https://preview.example.com" in origins
+
+
 def test_create_run_completes_with_manager_result(tmp_path, monkeypatch):
     calls = []
 


### PR DESCRIPTION
## Summary
- Adds a FastAPI run bridge with `POST /api/runs`, `GET /api/runs/{run_id}`, and `GET /api/health`.
- Runs the existing Manager graph in a background worker and exposes browser-friendly run state, final metrics, cost, errors, and diary-derived AutoResearch iterations.
- Adds a typed frontend API client and polling hook; the UI keeps simulation mode by default and switches to the real backend only when `VITE_API_BASE_URL` is configured.
- Fixes the existing frontend `Tooltip` duplicate event prop that blocked `tsc`/Vite build.

## Validation
- `python3 -m compileall src/server tests/test_server_api.py`
- `uvx --with pytest --with fastapi --with httpx --with anthropic --with langgraph --with requests --with tinker --with tinker-cookbook --with tavily-python --with trafilatura --with pymupdf --with datasets --with huggingface-hub --with pyarrow python -m pytest tests/test_server_api.py tests/test_manager.py -q`
- `npm ci && npm run lint && npm run build` in `ml-agent-frontend`
- `git diff --cached --check` before commit

## Notes
- Base branch is `codex/manager-datagen-validation-gate` because API-triggered no-data runs depend on the non-interactive Manager guard.
- V1 polling is coarse until observability emits run-scoped live events.
