### PR TITLE
[codex] preserve chat messages through DataGen curation

### DIFF
--- a/src/data_generator/nodes.py
+++ b/src/data_generator/nodes.py
@@ -191,7 +191,7 @@ def _normalize_single_record(mode: str, record: dict[str, Any], index: int) -> d
         "metadata": record.get("metadata") if isinstance(record.get("metadata"), dict) else {},
     }
 
-    return {
+    normalized = {
         "record_id": f"{mode.lower()}_{index:06d}",
         "input": input_value,
         "output": output_value,
@@ -200,6 +200,9 @@ def _normalize_single_record(mode: str, record: dict[str, Any], index: int) -> d
         "source_kind": _infer_source_kind(mode, record),
         "metadata": metadata,
     }
+    if "messages" in record:
+        normalized["messages"] = record["messages"]
+    return normalized
 
 
 def _coerce_primary_input(record: dict[str, Any]) -> str:

--- a/tests/data_generator/test_handoff_contract_consistency.py
+++ b/tests/data_generator/test_handoff_contract_consistency.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+
+from src.data_generator.curation import curate_handoff_to_dataset_result
 from src.data_generator.nodes import build_handoff_node
 
 
@@ -52,6 +55,48 @@ def test_mode_a_handoff_preserves_raw_and_adds_standardized_curation_payload():
     assert handoff["curation_payload"]["records"][0]["record_id"].startswith("a_")
     assert handoff["curation_payload"]["records"][1]["source_locator"] == "/tmp/dir/part.json"
     assert "Sub-Agent 2 Curation Input" in handoff["curation_human_readable"]
+
+
+def test_mode_a_handoff_preserves_chat_messages_through_curation(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    messages = [
+        {"role": "system", "content": "Answer with the escalation label."},
+        {"role": "user", "content": "Payment service is down for all customers."},
+        {"role": "assistant", "content": "urgent"},
+    ]
+    state = {
+        "config": _base_config(),
+        "data_path": "/tmp/chat.jsonl",
+        "mode": "A",
+        "raw_data": {
+            "records": [
+                {
+                    "messages": messages,
+                    "source_path": "/tmp/chat.jsonl",
+                    "row_index": 1,
+                }
+            ],
+            "format_meta": {"modality": "text", "file_type": "jsonl", "encoding": "utf-8"},
+        },
+        "hf_candidates": [],
+        "selected_candidate": None,
+        "web_plan": None,
+        "web_search_results": [],
+        "human_readable": None,
+    }
+
+    handoff = build_handoff_node(state)["handoff"]
+    curation_record = handoff["curation_payload"]["records"][0]
+    assert curation_record["messages"] == messages
+
+    dataset = curate_handoff_to_dataset_result(handoff)
+    rows = [
+        json.loads(line)
+        for line in open(dataset["dataset"]["path"], encoding="utf-8")
+        if line.strip()
+    ]
+    assert rows == [{"messages": messages}]
+    assert dataset["validation_report"]["passed"] is True
 
 
 def test_mode_b_handoff_keeps_hf_artifacts_and_standardizes_records():


### PR DESCRIPTION
## Summary
- Preserves top-level `messages` when DataGen normalizes records into the curation payload.
- Adds a contract test proving Mode A chat JSONL records survive handoff normalization and are written by curation as chat/SFT `messages`, not flattened `input`/`output`.

## Validation
- `python3 -m compileall src/data_generator/nodes.py tests/data_generator/test_handoff_contract_consistency.py`
- `uvx --with pytest --with anthropic --with langgraph --with requests --with tinker --with tinker-cookbook --with tavily-python --with trafilatura --with pymupdf --with datasets --with huggingface-hub --with pyarrow python -m pytest tests/data_generator/test_handoff_contract_consistency.py tests/test_data_curation.py tests/test_tinker_runner.py -q` -> `23 passed`
- `uvx --with pytest --with anthropic --with langgraph --with requests --with tinker --with tinker-cookbook --with tavily-python --with trafilatura --with pymupdf --with datasets --with huggingface-hub --with pyarrow python -m pytest tests/data_generator/test_handoff_contract_consistency.py tests/data_generator/test_deployment_style_handoff_artifacts.py tests/test_data_curation.py tests/test_manager.py tests/test_tinker_runner.py -q` -> `36 passed, 1 skipped`
- `git diff --check`
