### PR TITLE
[codex] read live Tinker loss metrics

### DIFF
--- a/src/tinker_api/sft_runner.py
+++ b/src/tinker_api/sft_runner.py
@@ -402,11 +402,25 @@ def _extract_loss(*results: Any) -> float:
             return float(loss)
         metrics = getattr(result, "metrics", None)
         if isinstance(metrics, Mapping):
-            for key in ("loss", "train_loss", "mean_loss", "nll"):
+            for key in (
+                "loss",
+                "loss:mean",
+                "mean_loss",
+                "train_loss",
+                "loss:sum",
+                "nll",
+            ):
                 value = metrics.get(key)
                 if isinstance(value, (int, float)):
                     return float(value)
-    return 0.0
+    metric_keys = [
+        sorted(result.metrics.keys())
+        for result in results
+        if result is not None and isinstance(getattr(result, "metrics", None), Mapping)
+    ]
+    raise TinkerAPIError(
+        f"Tinker forward/backward result did not include a recognized loss metric: {metric_keys}"
+    )
 
 
 def _score_from_loss(loss: float | None) -> float:

--- a/tests/test_tinker_runner.py
+++ b/tests/test_tinker_runner.py
@@ -162,6 +162,35 @@ def test_run_tinker_sft_experiment_splits_multi_assistant_conversations(
     }
 
 
+def test_run_tinker_sft_experiment_reads_tinker_loss_sum_metric(
+    tmp_path,
+    monkeypatch,
+):
+    _install_fake_tinker_stack(
+        monkeypatch,
+        losses=[{"loss:sum": 3.5}, {"loss:sum": 2.25}],
+    )
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [{"input": "Question", "output": "Answer"}],
+    )
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=1),
+        str(data_path),
+        run_id="loss-sum-run",
+        max_steps=2,
+        output_dir=str(tmp_path / "experiments"),
+    )
+
+    run_dir = tmp_path / "experiments" / "loss-sum-run"
+    metrics = json.loads((run_dir / "metrics.json").read_text())
+    assert result["metrics"]["train_loss"] == pytest.approx(2.25)
+    assert metrics["primary_metric"] == pytest.approx(1.0 / 3.25)
+
+
 def test_run_tinker_sft_experiment_stops_on_cancel_and_writes_artifacts(tmp_path, monkeypatch):
     _install_fake_tinker_stack(monkeypatch, losses=[0.5, 0.25, 0.1])
     from src.tinker_api import tinker_api
@@ -353,6 +382,8 @@ class _FakeTrainingClient:
         self.forward_backward_calls += 1
         self.batches.append(batch)
         loss = self.losses[min(self.forward_backward_calls - 1, len(self.losses) - 1)]
+        if isinstance(loss, dict):
+            return _FakeFuture(types.SimpleNamespace(metrics=loss))
         return _FakeFuture(types.SimpleNamespace(loss=loss))
 
     def optim_step(self, adam_params):


### PR DESCRIPTION
## Summary
- Read the live Tinker SDK loss metric shape (`metrics["loss:sum"]`) in the SFT runner.
- Prefer mean-style metric names when available, but no longer silently report `0.0` loss if the SDK result has only cookbook-style metrics.
- Raise a clear `TinkerAPIError` when no recognized loss metric is present, so AutoResearch does not treat missing metrics as a perfect run.

## Why
A bounded live web->Tinker smoke completed successfully but reported `train_loss=0.0`, `primary_metric=1.0`. Inspecting the cookbook showed the live SDK returns the scalar as `metrics["loss:sum"]`; the runner was not reading that key.

## Validation
- `python3 -m compileall src`
- `uv run --with pytest --with anthropic --with langgraph python -m pytest tests/test_tinker_runner.py -q` -> `13 passed`
- `uv run --with pytest --with anthropic --with langgraph python -m pytest tests/test_tinker_runner.py tests/test_tinker_api.py tests/test_autoresearch.py -q` -> `55 passed`
- Live 1-step validation on web-structured JSONL: `Qwen/Qwen3.5-9B`, `max_steps=1`, status `COMPLETED`, observed `train_loss=24.81933307647705` instead of `0.0`.
