### PR TITLE
[codex] reserve validation split for small curated datasets

### DIFF
--- a/src/data_generator/curation.py
+++ b/src/data_generator/curation.py
@@ -199,8 +199,15 @@ def _first_text(record: Mapping[str, Any], keys: Sequence[str]) -> str:
 def _split_counts(n_records: int) -> dict[str, int]:
     if n_records <= 0:
         return {"train_size": 0, "val_size": 0, "test_size": 0}
+    if n_records == 1:
+        return {"train_size": 1, "val_size": 0, "test_size": 0}
+    if n_records == 2:
+        return {"train_size": 1, "val_size": 0, "test_size": 1}
+    if n_records < 10:
+        return {"train_size": n_records - 2, "val_size": 1, "test_size": 1}
+
     train_size = max(1, int(n_records * 0.8))
-    val_size = int(n_records * 0.1) if n_records >= 3 else 0
+    val_size = max(1, int(n_records * 0.1))
     test_size = max(0, n_records - train_size - val_size)
     return {
         "train_size": train_size,

--- a/tests/test_data_curation.py
+++ b/tests/test_data_curation.py
@@ -131,6 +131,25 @@ def test_curate_handoff_prefers_mode_c_curation_payload(tmp_path):
     ]
 
 
+def test_curate_handoff_keeps_validation_split_for_small_datasets(tmp_path):
+    handoff = {
+        "mode_used": "C",
+        "raw_data": {
+            "records": [
+                {"input": f"ticket {idx}", "output": "normal"}
+                for idx in range(6)
+            ]
+        },
+    }
+
+    result = curate_handoff_to_dataset_result(handoff, output_dir=str(tmp_path))
+
+    assert result["validation_report"]["passed"] is True
+    assert result["dataset"]["train_size"] == 4
+    assert result["dataset"]["val_size"] == 1
+    assert result["dataset"]["test_size"] == 1
+
+
 def test_curate_handoff_preserves_upstream_validation(tmp_path):
     handoff = {
         "mode_used": "C",


### PR DESCRIPTION
## Summary
- Reserve a validation row for curated datasets with 3-9 records instead of letting `int(n * 0.1)` round validation down to zero.
- Preserve existing behavior for empty, 1-row, and 2-row datasets.
- Keep 10+ row datasets on the existing 80/10/remainder split, with at least one validation row.

## Why
A bounded live web-structuring run produced 6 valid chat/SFT records, but curation reported `val_size=0`. That makes small live smoke datasets look trainable while lacking any validation holdout.

## Validation
- `python3 -m compileall src`
- `uv run --with pytest --with anthropic --with langgraph python -m pytest tests/test_data_curation.py tests/test_manager.py -q` -> `18 passed, 1 skipped`
- `uv run --with pytest --with anthropic --with langgraph --with requests --with tavily-python --with trafilatura --with pymupdf python -m pytest tests/test_data_curation.py tests/test_manager.py tests/test_mode_c.py tests/data_generator/test_handoff_contract_consistency.py tests/data_generator/test_mode_a_local_data.py tests/data_generator/test_mode_c_web.py tests/data_generator/test_mode_c_web_robust.py -q` -> `43 passed, 4 skipped`
