### PR TITLE
[codex] fix AutoResearch SFT early stop

### DIFF
--- a/src/autoresearch/autoresearch.py
+++ b/src/autoresearch/autoresearch.py
@@ -324,7 +324,7 @@ def run_node(state: AutoResearchState) -> dict:
 
 
 def revert_and_continue_node(state: AutoResearchState) -> dict:
-    """LangGraph node (early stop path). Calls revert_patch(), logs REVERTED, increments iteration. Returns: { current_script, diary, iteration }."""
+    """LangGraph node (early stop path). Reverts the patch before normal logging."""
     revert_patch(str(_CONFIG_PATH), state["original_content"])
 
     log_event(
@@ -337,27 +337,10 @@ def revert_and_continue_node(state: AutoResearchState) -> dict:
         },
     )
 
-    # Build and persist the diary entry for this early-stopped iteration.
-    # last_result always exists here because run_node already wrote it.
-    patch_dict = json.loads(state.get("current_patch", "{}"))
-    diff = _patch_to_diff(patch_dict, state["current_config"])
-    record: IterationRecord = {
-        "iteration": state["iteration"] + 1,
-        "hypothesis": state.get("last_description", str(patch_dict)),
-        "patch": diff,
-        "cost_usd": state["last_result"]["cost_usd"],
-        "metrics": state["last_result"]["metrics"],
-        "decision": "REVERTED",
-        "notes": "Early-stopped: catastrophic failure (NaN/exploding loss/accuracy collapse)",
-    }
-    updated_diary = log_iteration(state["diary"], record)
-
     return {
         "current_script": state["plan"]["training_script_path"],
         "original_content": None,
-        "last_delta": None,  # signals early-stop path to log_node
-        "diary": updated_diary,
-        "iteration": state["iteration"] + 1,
+        "last_delta": None,  # signals early-stop path to log_node.
     }
 
 
@@ -447,6 +430,9 @@ def log_node(state: AutoResearchState) -> dict:
         if state["last_delta"] is not None and state["last_delta"]["improved"]:
             decision = "KEPT"
             notes = f"+{state['last_delta']['relative_pct']:.1f}% on {state['eval_suite']['primary_metric']}"
+        elif _last_result_was_early_stopped(state):
+            decision = "REVERTED"
+            notes = "Early-stopped: catastrophic failure (NaN/Inf loss or primary metric collapse)"
         else:
             decision = "REVERTED"
             delta_pct = state["last_delta"]["relative_pct"] if state["last_delta"] else 0.0
@@ -507,6 +493,17 @@ def early_stop_edge(state: AutoResearchState) -> Literal["evaluate", "revert_and
     if check_early_stop(state["last_result"]["metrics"]):
         return "revert_and_continue"
     return "evaluate"
+
+
+def _last_result_was_early_stopped(state: AutoResearchState) -> bool:
+    if state.get("last_delta") is not None:
+        return False
+    last_result = state.get("last_result")
+    if last_result is None:
+        return True
+    if last_result["status"] in {JobStatus.FAILED, JobStatus.CANCELLED}:
+        return True
+    return check_early_stop(last_result["metrics"])
 
 
 def decision_edge(state: AutoResearchState) -> Literal["keep", "revert"]:
@@ -886,18 +883,16 @@ def wait_for_experiment(job_id: str, timeout_min: int) -> ExperimentResult:
 
 
 def check_early_stop(metrics: TrainingMetrics) -> bool:
-    """Returns True on catastrophic failure: exploding loss (>10× baseline), NaN, or accuracy collapse."""
+    """Returns True on catastrophic failure: non-finite loss or primary metric collapse."""
     for key in ("train_loss", "val_loss"):
         val = metrics.get(key)
         if val is not None and (math.isnan(val) or math.isinf(val)):
             return True
 
-    train_loss = metrics.get("train_loss")
-    if train_loss is not None and train_loss > 10.0:
-        return True
-
     primary = metrics.get("primary_metric")
-    if primary is not None and primary < 0.01:
+    if primary is not None and (
+        math.isnan(primary) or math.isinf(primary) or primary < 0.01
+    ):
         return True
 
     return False

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -100,14 +100,14 @@ def test_check_early_stop_true_on_inf_loss():
     assert check_early_stop(metrics) is True
 
 
-def test_check_early_stop_true_on_exploding_loss():
+def test_check_early_stop_false_on_high_finite_sft_loss():
     metrics = {
         "train_loss": 15.0,
         "val_loss": 14.0,
         "test_loss": 14.5,
         "primary_metric": 0.10,
     }
-    assert check_early_stop(metrics) is True
+    assert check_early_stop(metrics) is False
 
 
 def test_check_early_stop_true_on_accuracy_collapse():
@@ -116,6 +116,16 @@ def test_check_early_stop_true_on_accuracy_collapse():
         "val_loss": 0.45,
         "test_loss": 0.50,
         "primary_metric": 0.001,
+    }
+    assert check_early_stop(metrics) is True
+
+
+def test_check_early_stop_true_on_nonfinite_primary_metric():
+    metrics = {
+        "train_loss": 0.4,
+        "val_loss": 0.45,
+        "test_loss": 0.50,
+        "primary_metric": float("nan"),
     }
     assert check_early_stop(metrics) is True
 
@@ -299,6 +309,62 @@ def test_log_node_uses_pre_patch_config_for_kept_diff(tmp_path):
         assert "+ learning_rate: 0.0002" in out["diary"][0]["patch"]
     finally:
         ar._DIARY_PATH = original_path
+
+
+def test_log_node_records_early_stop_once(tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    original_path = ar._DIARY_PATH
+    ar._DIARY_PATH = tmp_path / "diary.jsonl"
+    try:
+        state = _make_state(
+            eval_suite={"primary_metric": "primary_metric", "metrics": [], "test_split_path": "",
+                        "use_llm_grading": False},
+            current_config={"learning_rate": 1e-4, "batch_size": 4},
+            current_patch=json.dumps({"learning_rate": 2e-4}),
+            original_content=None,
+            last_description="Increase learning rate.",
+            last_delta=None,
+            last_result={
+                "job_id": "candidate",
+                "status": "COMPLETED",
+                "metrics": {"train_loss": float("inf"), "val_loss": 0.4,
+                            "test_loss": 0.5, "primary_metric": 0.70},
+                "model_path": "candidate-model",
+                "cost_usd": 0.01,
+                "logs_path": "candidate.jsonl",
+            },
+        )
+
+        out = ar.log_node(state)
+
+        assert out["iteration"] == 1
+        assert len(out["diary"]) == 1
+        assert out["diary"][0]["iteration"] == 1
+        assert out["diary"][0]["decision"] == "REVERTED"
+        assert "Early-stopped" in out["diary"][0]["notes"]
+        lines = [l for l in ar._DIARY_PATH.read_text().splitlines() if l.strip()]
+        assert len(lines) == 1
+    finally:
+        ar._DIARY_PATH = original_path
+
+
+def test_completed_high_finite_sft_loss_flows_to_evaluate():
+    import src.autoresearch.autoresearch as ar
+
+    state = _make_state(
+        last_result={
+            "job_id": "candidate",
+            "status": "COMPLETED",
+            "metrics": {"train_loss": 24.8, "val_loss": 24.8,
+                        "test_loss": 24.8, "primary_metric": 0.0387},
+            "model_path": "candidate-model",
+            "cost_usd": 0.01,
+            "logs_path": "candidate.jsonl",
+        },
+    )
+
+    assert ar.early_stop_edge(state) == "evaluate"
 
 
 # ─── continue_edge ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- allow high but finite SFT loss to flow through evaluation instead of treating absolute loss > 10 as catastrophic
- keep early-stop diary and iteration accounting in one place so a stopped candidate records once
- add focused tests for non-finite metrics, high finite SFT loss, and early-stop diary accounting

## Validation
- python3 -m compileall src
- uv run --with pytest --with anthropic --with langgraph python -m pytest tests/test_autoresearch.py -q
- uv run --with pytest --with anthropic --with langgraph python -m pytest tests/test_autoresearch.py tests/test_tinker_runner.py tests/test_tinker_api.py -q
- local unpublished stack with #55/#56/#57/#58/#59: compileall + broad non-live suite excluding live Tinker/HF passed (`200 passed, 7 skipped`)

## Live validation
- Before this fix, a corrected-stack one-step live AutoResearch smoke on `Qwen/Qwen3.5-9B` surfaced the issue: real SFT loss was `24.8193`, which is finite and evaluable, but the old absolute-loss early stop reverted before evaluation and duplicated the diary iteration.
- After this fix, the same bounded live smoke reached `EVALUATE`, reverted normally on a tie, and returned `n_iterations=1`. Local Tinker cost report was `$0.00005`; the overnight ledger books a conservative `$1.00`.