### PR TITLE
[codex] average Tinker final metrics

### DIFF
--- a/src/tinker_api/sft_runner.py
+++ b/src/tinker_api/sft_runner.py
@@ -512,14 +512,20 @@ def _final_metrics(metrics_history: list[dict[str, Any]], status: str) -> Traini
             "test_loss": loss,
             "primary_metric": _score_from_loss(loss),
         }
-    last = metrics_history[-1]
-    loss = float(last["train_loss"])
+    train_loss = _mean_metric(metrics_history, "train_loss")
+    val_loss = _mean_metric(metrics_history, "val_loss")
+    test_loss = _mean_metric(metrics_history, "test_loss")
     return {
-        "train_loss": loss,
-        "val_loss": float(last["val_loss"]),
-        "test_loss": float(last["test_loss"]),
-        "primary_metric": float(last["primary_metric"]),
+        "train_loss": train_loss,
+        "val_loss": val_loss,
+        "test_loss": test_loss,
+        "primary_metric": _score_from_loss(val_loss),
     }
+
+
+def _mean_metric(metrics_history: list[dict[str, Any]], key: str) -> float:
+    values = [float(step[key]) for step in metrics_history]
+    return sum(values) / len(values)
 
 
 def _dataset_path_for_manifest(

--- a/tests/test_tinker_runner.py
+++ b/tests/test_tinker_runner.py
@@ -102,7 +102,7 @@ def test_run_tinker_sft_experiment_writes_artifacts(tmp_path, monkeypatch):
     run_dir = tmp_path / "experiments" / "unit-run"
     assert result["status"] == "COMPLETED"
     assert result["model_path"] == str(run_dir)
-    assert json.loads((run_dir / "metrics.json").read_text())["val_loss"] == pytest.approx(0.25)
+    assert json.loads((run_dir / "metrics.json").read_text())["val_loss"] == pytest.approx(0.375)
     assert (run_dir / "metrics.jsonl").read_text().count("\n") == 2
     manifest = json.loads((run_dir / "manifest.json").read_text())
     assert manifest["checkpoints"]["state_path"].startswith("tinker://state/")
@@ -187,8 +187,8 @@ def test_run_tinker_sft_experiment_reads_tinker_loss_sum_metric(
 
     run_dir = tmp_path / "experiments" / "loss-sum-run"
     metrics = json.loads((run_dir / "metrics.json").read_text())
-    assert result["metrics"]["train_loss"] == pytest.approx(2.25)
-    assert metrics["primary_metric"] == pytest.approx(1.0 / 3.25)
+    assert result["metrics"]["train_loss"] == pytest.approx(2.875)
+    assert metrics["primary_metric"] == pytest.approx(1.0 / 3.875)
 
 
 def test_run_tinker_sft_experiment_stops_on_cancel_and_writes_artifacts(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- summarize `metrics.json` using the mean observed step loss instead of the final batch loss
- recompute `primary_metric` from the averaged validation loss
- keep `metrics.jsonl` as the per-step trace for detailed inspection

## Why
Live 5-step paired Tinker runs on the small web-SFT dataset showed large batch-to-batch loss swings because the dataset is tiny and cycled. Using only the last batch made AutoResearch decisions noisier than the observed trajectory warranted.

## Validation
- python3 -m compileall src
- uv run --with pytest --with anthropic --with langgraph python -m pytest tests/test_tinker_runner.py -q
- uv run --with pytest --with anthropic --with langgraph python -m pytest tests/test_tinker_runner.py tests/test_tinker_api.py tests/test_autoresearch.py -q
- local unpublished stack with #55/#56/#57/#58/#59/#60: compileall + broad non-live suite excluding live Tinker/HF passed (`200 passed, 7 skipped`)

## Live validation
- Before this PR, the 5-step paired run compared `learning_rate=0.0001` against `0.0005` on `Qwen/Qwen3.5-9B`; final-batch scoring saw only a small edge (`0.08615` vs `0.08739`), while the per-step trace showed substantial volatility.
- After this PR, a 5-step live run produced `metrics.json` with `val_loss=11.902454127464443`, exactly matching the mean of the per-step `metrics.jsonl` losses, and `primary_metric=0.07750463517412384`.