### PR TITLE
[codex] require material AutoResearch improvement

### DIFF
--- a/src/autoresearch/autoresearch.py
+++ b/src/autoresearch/autoresearch.py
@@ -52,6 +52,8 @@ _DIARY_PATH = Path("outputs/logs/research_diary.jsonl")
 _CONFIG_PATH = Path("configs/current.json")  # the JSON file apply_patch/revert_patch target
 _MAX_NO_IMPROVE = 3   # halt after this many consecutive non-improving iterations
 _MAX_ITERATIONS = 20  # hard cap on total iterations regardless of improvement
+_MIN_RELATIVE_IMPROVEMENT_PCT = 1.0
+_MIN_ABSOLUTE_IMPROVEMENT = 1e-9
 _EXPERIMENT_CACHE: dict[str, ExperimentResult] = {}
 
 
@@ -928,10 +930,17 @@ def compare_scores(new_score: EvalScore, baseline_score: EvalScore) -> ScoreDelt
     base_val = baseline_score["scalar"]
     absolute = new_val - base_val
     relative_pct = (absolute / base_val * 100.0) if base_val != 0.0 else 0.0
+    if base_val == 0.0:
+        improved = absolute > _MIN_ABSOLUTE_IMPROVEMENT
+    else:
+        improved = (
+            absolute > _MIN_ABSOLUTE_IMPROVEMENT
+            and relative_pct >= _MIN_RELATIVE_IMPROVEMENT_PCT
+        )
     return {
         "absolute": absolute,
         "relative_pct": relative_pct,
-        "improved": absolute > 0.0,
+        "improved": improved,
     }
 
 

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -158,6 +158,21 @@ def test_compare_scores_not_improved_when_lower():
     assert delta["improved"] is False
 
 
+def test_compare_scores_tiny_positive_delta_is_not_improved():
+    new_score = {"scalar": 0.057829344672345545, "metrics": {}, "critique": ""}
+    baseline = {"scalar": 0.0577940194157755, "metrics": {}, "critique": ""}
+    delta = compare_scores(new_score, baseline)
+    assert delta["relative_pct"] == pytest.approx(0.0611, abs=0.001)
+    assert delta["improved"] is False
+
+
+def test_compare_scores_zero_baseline_allows_positive_improvement():
+    new_score = {"scalar": 0.01, "metrics": {}, "critique": ""}
+    baseline = {"scalar": 0.0, "metrics": {}, "critique": ""}
+    delta = compare_scores(new_score, baseline)
+    assert delta["improved"] is True
+
+
 def test_compare_scores_tie_not_improved():
     score = {"scalar": 0.85, "metrics": {}, "critique": ""}
     delta = compare_scores(score, score)


### PR DESCRIPTION
## Summary
- require at least a 1% relative score improvement before AutoResearch marks a candidate as improved
- keep positive improvements from a zero baseline valid
- add regression tests for the tiny +0.1% live wiggle seen in overnight validation

## Why
A live averaged-metrics AutoResearch run on the small web-SFT dataset kept a `lora_rank` change on only a +0.1% score wiggle. On noisy tiny-dataset Tinker runs, that is effectively a tie and should not advance the best config.

## Validation
- python3 -m compileall src
- uv run --with pytest --with anthropic --with langgraph python -m pytest tests/test_autoresearch.py -q
- uv run --with pytest --with anthropic --with langgraph python -m pytest tests/test_autoresearch.py tests/test_tinker_runner.py tests/test_tinker_api.py -q
- local unpublished stack with #55/#56/#57/#58/#59/#60/#61: compileall + broad non-live suite excluding live Tinker/HF passed (`202 passed, 7 skipped`)

## Live validation
- Triggering run: real Claude proposals and real Tinker 3-step candidates on `Qwen/Qwen3.5-9B` after mean-metrics scoring. `learning_rate=0.0005` improved by +39.3% and should still be kept; `lora_rank=16` improved by only about +0.1% and should be treated as no improvement.
- Replay after this PR: starting from `learning_rate=0.0005`, deterministic `lora_rank: 8 -> 16` produced another +0.1% delta and was correctly `REVERTED` with `n_iterations=1`.