### PR TITLE
[codex] preserve dataset splits for AutoResearch

### DIFF
--- a/src/autoresearch/autoresearch.py
+++ b/src/autoresearch/autoresearch.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 import math
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, Mapping
 from uuid import uuid4
 
 import anthropic
@@ -176,28 +176,7 @@ def init_node(state: AutoResearchState) -> dict:
         "eval_metric": state["plan"]["eval_metric"],
         "complexity": "medium",
     }
-    # Construct a minimal DatasetResult so create_eval_suite can derive the test path.
-    # The real dataset path comes from DataGen (F2); we point at the standard test split location.
-    dataset_path = state["plan"].get(
-        "dataset_path",
-        str(Path(state["plan"]["training_script_path"]).parent),
-    )
-    dataset_result: DatasetResult = {
-        "dataset": {
-            "path": dataset_path,
-            "format": "jsonl",
-            "train_size": 0,
-            "val_size": 0,
-            "test_size": 0,
-        },
-        "mode_used": "A",
-        "quality_notes": "",
-        "validation_report": {
-            "passed": True,
-            "issues": [],
-            "sample_accuracy_estimate": 0.0,
-        },
-    }
+    dataset_result = _dataset_result_from_plan(state["plan"])
 
     eval_suite = create_eval_suite(task_analysis, dataset_result)
 
@@ -735,14 +714,33 @@ def revert_patch(script_path: str, original_content: str) -> None:
 # ─── RUN HELPERS ──────────────────────────────────────────────────────────────
 
 def _dataset_result_from_plan(plan: TrainingPlan) -> DatasetResult:
-    dataset_path = plan.get("dataset_path") or str(Path(plan["training_script_path"]).parent)
+    dataset_meta = plan.get("dataset")
+    if isinstance(dataset_meta, Mapping):
+        dataset_path = str(
+            dataset_meta.get("path")
+            or plan.get("dataset_path")
+            or Path(plan["training_script_path"]).parent
+        )
+        dataset_format = str(dataset_meta.get("format") or "jsonl")
+        train_size = max(0, int(dataset_meta.get("train_size") or 0))
+        val_size = max(0, int(dataset_meta.get("val_size") or 0))
+        test_size = max(0, int(dataset_meta.get("test_size") or 0))
+    else:
+        dataset_path = plan.get("dataset_path") or str(
+            Path(plan["training_script_path"]).parent
+        )
+        dataset_format = "jsonl"
+        train_size = 0
+        val_size = 0
+        test_size = 0
+
     return {
         "dataset": {
             "path": dataset_path,
-            "format": "jsonl",
-            "train_size": 0,
-            "val_size": 0,
-            "test_size": 0,
+            "format": dataset_format,
+            "train_size": train_size,
+            "val_size": val_size,
+            "test_size": test_size,
         },
         "mode_used": "A",
         "quality_notes": "AutoResearch Tinker SFT dataset",

--- a/src/decision_engine/decision_engine.py
+++ b/src/decision_engine/decision_engine.py
@@ -83,6 +83,7 @@ def run_decision_engine(
         eval_metric=task["eval_metric"],
         backend="tinker_sft",
         dataset_path=dataset["dataset"]["path"],
+        dataset=dataset["dataset"],
     )
 
 

--- a/src/types.py
+++ b/src/types.py
@@ -151,6 +151,7 @@ class _TrainingPlanRequired(TypedDict):
 class TrainingPlan(_TrainingPlanRequired, total=False):
     backend: str            # 'tinker_sft' for the SDK-native Tinker v1 path
     dataset_path: str       # Local JSONL path consumed by the Tinker SFT runner
+    dataset: StandardDataset  # Aggregate dataset metadata, including split counts
 
 
 class EvalScore(TypedDict):

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -447,6 +447,165 @@ def test_continue_edge_ends_at_max_iterations():
     assert continue_edge(state) == "__end__"
 
 
+def test_dataset_result_from_plan_preserves_split_counts(tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    dataset_path = tmp_path / "train.jsonl"
+    dataset_path.write_text('{"input": "x", "output": "y"}\n')
+    plan = {
+        "strategy": "fine-tune",
+        "base_model": "Qwen/Qwen3.5-9B",
+        "lora_config": {"rank": 8, "alpha": 16, "dropout": 0.05, "target_modules": []},
+        "estimated_cost": 1.0,
+        "estimated_time_min": 5,
+        "training_script_path": "outputs/scripts/train.py",
+        "eval_metric": "primary_metric",
+        "backend": "tinker_sft",
+        "dataset_path": "ignored-when-dataset-present.jsonl",
+        "dataset": {
+            "path": str(dataset_path),
+            "format": "jsonl",
+            "train_size": 2,
+            "val_size": 1,
+            "test_size": 1,
+        },
+    }
+
+    dataset_result = ar._dataset_result_from_plan(plan)
+
+    assert dataset_result["dataset"] == plan["dataset"]
+
+
+def test_autoresearch_graph_passes_plan_dataset_splits_to_tinker(monkeypatch, tmp_path):
+    pytest.importorskip("langgraph", reason="langgraph not installed")
+    import src.autoresearch.autoresearch as ar
+
+    config_path = tmp_path / "configs" / "current.json"
+    monkeypatch.setattr(ar, "_CONFIG_PATH", config_path)
+    dataset_path = tmp_path / "train.jsonl"
+    dataset_path.write_text(
+        "".join(
+            json.dumps({"input": f"row {i}", "output": "label"}) + "\n"
+            for i in range(4)
+        )
+    )
+    calls = []
+
+    class FakeCostManager:
+        def __init__(self, budget):
+            self.budget = budget
+            self.spent_usd = 0.0
+
+        @property
+        def status(self):
+            return "EXCEEDED" if self.spent_usd >= self.budget else "OK"
+
+        def start(self, job_id):
+            self.job_id = job_id
+
+        def stop(self):
+            pass
+
+        def record_spend(self, amount, category="training"):
+            self.spent_usd += amount
+            return self.status
+
+        def cost_breakdown(self, termination_reason=None):
+            return {
+                "data_gen_usd": 0.0,
+                "training_usd": self.spent_usd,
+                "llm_calls_usd": 0.0,
+                "total_usd": self.spent_usd,
+                "termination_reason": termination_reason or "training_complete",
+            }
+
+    def fake_runner(config, dataset, *, run_id=None, max_steps=None, **kwargs):
+        index = len(calls)
+        calls.append(
+            {
+                "path": dataset["dataset"]["path"],
+                "splits": {
+                    "train": dataset["dataset"]["train_size"],
+                    "val": dataset["dataset"]["val_size"],
+                    "test": dataset["dataset"]["test_size"],
+                },
+            }
+        )
+        val_loss = 0.5 if index == 0 else 0.4
+        run_dir = tmp_path / f"run-{index}"
+        run_dir.mkdir()
+        (run_dir / "metrics.json").write_text(
+            json.dumps({"train_loss": val_loss, "val_loss": val_loss, "test_loss": val_loss})
+        )
+        return {
+            "job_id": run_id,
+            "status": "COMPLETED",
+            "metrics": {
+                "train_loss": val_loss,
+                "val_loss": val_loss,
+                "test_loss": val_loss,
+                "primary_metric": 1 / (1 + val_loss),
+            },
+            "model_path": str(run_dir),
+            "cost_usd": 0.02,
+            "logs_path": str(run_dir / "metrics.jsonl"),
+        }
+
+    monkeypatch.setattr(ar, "run_tinker_sft_experiment", fake_runner)
+    monkeypatch.setattr(
+        ar,
+        "propose_hypothesis",
+        lambda *args, **kwargs: {
+            "description": "Increase learning rate for a bounded candidate run.",
+            "patch": json.dumps({"learning_rate": 2e-4}),
+            "expected_effect": "Improve heldout loss.",
+            "search_strategy": "playbook",
+        },
+    )
+
+    plan = {
+        "strategy": "fine-tune",
+        "base_model": "Qwen/Qwen3.5-9B",
+        "lora_config": {"rank": 8, "alpha": 16, "dropout": 0.05, "target_modules": []},
+        "estimated_cost": 1.0,
+        "estimated_time_min": 5,
+        "training_script_path": "outputs/scripts/train.py",
+        "eval_metric": "primary_metric",
+        "backend": "tinker_sft",
+        "dataset_path": str(dataset_path),
+        "dataset": {
+            "path": str(dataset_path),
+            "format": "jsonl",
+            "train_size": 2,
+            "val_size": 1,
+            "test_size": 1,
+        },
+    }
+    config = {
+        "data": False,
+        "prompt": "test",
+        "compute_budget": 0.03,
+        "training_procedure": {
+            "task_type": "text-classification",
+            "data_format": "jsonl",
+            "training_type": "SFT",
+            "base_model": "Qwen/Qwen3.5-9B",
+            "hyperparameters": {"learning_rate": 1e-4, "batch_size": 1},
+            "notes": "",
+        },
+    }
+
+    result = ar.invoke_autoresearch_graph(plan, config, FakeCostManager(0.03))
+
+    assert [call["path"] for call in calls] == [str(dataset_path), str(dataset_path)]
+    assert [call["splits"] for call in calls] == [
+        {"train": 2, "val": 1, "test": 1},
+        {"train": 2, "val": 1, "test": 1},
+    ]
+    assert result["n_iterations"] == 1
+    assert result["cost"]["termination_reason"] == "budget_limit"
+
+
 def test_invoke_autoresearch_graph_cost_breakdown_includes_baseline_cost(monkeypatch):
     import src.autoresearch.autoresearch as ar
     from src.cost_manager.cost_manager import CostManager

--- a/tests/test_decision_engine.py
+++ b/tests/test_decision_engine.py
@@ -101,8 +101,11 @@ def test_write_pretrain_script_creates_file(tmp_path, monkeypatch):
 def test_run_decision_engine_returns_training_plan(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     config = _make_config("text-classification", budget=50.0)
-    plan = run_decision_engine(config, _make_dataset())
+    dataset = _make_dataset(train_size=42)
+    plan = run_decision_engine(config, dataset)
     assert plan["strategy"] in ("fine-tune", "pre-train")
     assert plan["eval_metric"] == "accuracy"
     assert os.path.exists(plan["training_script_path"])
     assert plan["estimated_cost"] > 0
+    assert plan["dataset_path"] == dataset["dataset"]["path"]
+    assert plan["dataset"] == dataset["dataset"]


### PR DESCRIPTION
## Summary
- carry aggregate `StandardDataset` metadata on `TrainingPlan` alongside the legacy `dataset_path`
- populate that metadata from DecisionEngine so DataGen split counts survive into AutoResearch
- have AutoResearch reconstruct `DatasetResult` from the plan metadata for eval-suite setup and Tinker runner calls

## Why
DataGen curation now produces train/val/test counts and PR #62 teaches the Tinker runner to use them, but AutoResearch was rebuilding a zero-count `DatasetResult` from only `dataset_path`. That meant the full graph still lost heldout split information before Tinker saw it.

## Validation
- `python3 -m compileall src`
- `uv run --with pytest --with langgraph --with anthropic --with requests python -m pytest tests/test_autoresearch.py tests/test_decision_engine.py tests/test_tinker_runner.py -q`
- `uv run --with pytest --with langgraph --with anthropic --with requests python -m pytest tests/test_tinker_api.py tests/test_tinker_runner.py tests/test_autoresearch.py tests/test_decision_engine.py tests/test_manager.py tests/test_e2e_propose.py -q`
- `git diff --check`
- Local unpublished full stack including #62/#63: compileall plus broad non-live suite excluding live Tinker/HF retrieval passed with `206 passed, 7 skipped`
- Live full AutoResearch graph smoke on the 22-row web DataGen dataset with #62/#63: both baseline and candidate calls received split 17/2/3; `Qwen/Qwen3.5-9B`, 2 steps each; candidate `learning_rate=5e-4` improved heldout scalar from `0.0675` to `0.2300`

This pairs with #62: this PR preserves the split metadata through AutoResearch; #62 consumes it inside the Tinker runner.