### PR TITLE
[codex] preserve source split counts in curation

### DIFF
--- a/src/data_generator/curation.py
+++ b/src/data_generator/curation.py
@@ -31,24 +31,28 @@ def curate_handoff_to_dataset_result(
     config = handoff.get("config") if isinstance(handoff.get("config"), Mapping) else {}
     records, record_source = _records_from_handoff(handoff)
 
-    curated: list[dict[str, Any]] = []
+    curated_with_splits: list[tuple[dict[str, Any], str | None]] = []
     issues: list[str] = []
     for index, record in enumerate(records):
         if not isinstance(record, Mapping):
             issues.append(f"row {index}: record must be an object")
             continue
         try:
-            curated.append(
-                curate_record(
-                    record,
-                    mode=mode,
-                    config=config,
-                    record_source=record_source,
+            curated_with_splits.append(
+                (
+                    curate_record(
+                        record,
+                        mode=mode,
+                        config=config,
+                        record_source=record_source,
+                    ),
+                    _source_split(record),
                 )
             )
         except ValueError as exc:
             issues.append(f"row {index}: {exc}")
 
+    curated, split_counts = _apply_source_splits(curated_with_splits)
     output_path = Path(output_dir) / filename
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with open(output_path, "w") as fh:
@@ -76,7 +80,7 @@ def curate_handoff_to_dataset_result(
     dataset: StandardDataset = {
         "path": os.path.abspath(output_path),
         "format": "jsonl",
-        **_split_counts(len(curated)),
+        **split_counts,
     }
     validation_report: ValidationReport = {
         "passed": bool(curated) and upstream_passed,
@@ -214,6 +218,52 @@ def _split_counts(n_records: int) -> dict[str, int]:
         "val_size": val_size,
         "test_size": test_size,
     }
+
+
+def _apply_source_splits(
+    curated_with_splits: Sequence[tuple[dict[str, Any], str | None]],
+) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    if not curated_with_splits:
+        return [], _split_counts(0)
+    if not any(split for _record, split in curated_with_splits):
+        curated = [record for record, _split in curated_with_splits]
+        return curated, _split_counts(len(curated))
+
+    train: list[dict[str, Any]] = []
+    val: list[dict[str, Any]] = []
+    test: list[dict[str, Any]] = []
+    for record, split in curated_with_splits:
+        if split == "val":
+            val.append(record)
+        elif split == "test":
+            test.append(record)
+        else:
+            train.append(record)
+
+    ordered = [*train, *val, *test]
+    return ordered, {
+        "train_size": len(train),
+        "val_size": len(val),
+        "test_size": len(test),
+    }
+
+
+def _source_split(record: Mapping[str, Any]) -> str | None:
+    split = record.get("split")
+    metadata = record.get("metadata")
+    if split is None and isinstance(metadata, Mapping):
+        split = metadata.get("split")
+    if split is None:
+        return None
+
+    normalized = str(split).strip().lower()
+    if normalized in {"train", "training"}:
+        return "train"
+    if normalized in {"validation", "valid", "val", "dev", "eval"}:
+        return "val"
+    if normalized in {"test", "testing"}:
+        return "test"
+    return None
 
 
 def _validation_issues(

--- a/tests/test_data_curation.py
+++ b/tests/test_data_curation.py
@@ -150,6 +150,40 @@ def test_curate_handoff_keeps_validation_split_for_small_datasets(tmp_path):
     assert result["dataset"]["test_size"] == 1
 
 
+def test_curate_handoff_preserves_source_split_order_and_counts(tmp_path):
+    handoff = {
+        "mode_used": "B",
+        "raw_data": {
+            "records": [
+                {"input": "validation row", "output": "v", "split": "validation"},
+                {"input": "test row", "output": "t", "metadata": {"split": "test"}},
+                {"input": "train row", "output": "tr", "split": "train"},
+                {"input": "dev row", "output": "d", "metadata": {"split": "dev"}},
+                {"input": "unknown row", "output": "u"},
+            ]
+        },
+    }
+
+    result = curate_handoff_to_dataset_result(handoff, output_dir=str(tmp_path))
+
+    assert result["validation_report"]["passed"] is True
+    assert result["dataset"]["train_size"] == 2
+    assert result["dataset"]["val_size"] == 2
+    assert result["dataset"]["test_size"] == 1
+    rows = [
+        json.loads(line)
+        for line in open(result["dataset"]["path"]).read().splitlines()
+        if line.strip()
+    ]
+    assert rows == [
+        {"input": "train row", "output": "tr"},
+        {"input": "unknown row", "output": "u"},
+        {"input": "validation row", "output": "v"},
+        {"input": "dev row", "output": "d"},
+        {"input": "test row", "output": "t"},
+    ]
+
+
 def test_curate_handoff_preserves_upstream_validation(tmp_path):
     handoff = {
         "mode_used": "C",


### PR DESCRIPTION
## Summary
- preserve source-provided split labels during DataGen curation
- write curated JSONL in train/val/test order when split labels are present
- compute `train_size`, `val_size`, and `test_size` from source labels instead of synthetic counts, while keeping the existing synthetic split fallback for unlabeled datasets

## Why
Mode B/HF retrieval can carry source split names, but curation flattened rows to trainable JSONL and recomputed synthetic counts. With heldout-aware Tinker scoring, that loses useful source validation/test boundaries.

## Validation
- `python3 -m compileall src`
- `uv run --with pytest --with langgraph --with anthropic --with requests python -m pytest tests/test_data_curation.py tests/test_manager.py tests/test_tinker_runner.py -q`
- `uv run --with pytest --with langgraph --with anthropic --with requests python -m pytest tests/test_data_curation.py tests/test_manager.py tests/test_tinker_runner.py tests/test_autoresearch.py tests/test_decision_engine.py -q`
- `git diff --check`
- Local unpublished full stack including #64: compileall plus broad non-live suite excluding live Tinker/HF retrieval passed with `207 passed, 7 skipped`
- Live Mode B partial using `SetFit/sst2` with `DATA_GENERATOR_MAX_ROWS_PER_DATASET=6`: DataGen saw source splits `train, train, validation, validation, test, test`; curation wrote dataset split counts `2/2/2` and validation passed