### PR TITLE
[codex] batch Tinker heldout eval

### DIFF
--- a/src/tinker_api/sft_runner.py
+++ b/src/tinker_api/sft_runner.py
@@ -457,17 +457,29 @@ def _evaluate_holdout_loss(
     if not callable(forward):
         return None
 
-    batch = [
-        supervised_data.conversation_to_datum(
-            conversation,
-            renderer,
-            cfg.max_seq_length,
-            train_on_what,
-        )
-        for conversation in holdout_targets
-    ]
-    result = _future_result(forward(batch, loss_fn="cross_entropy"))
-    return _extract_forward_loss(result, batch)
+    batch_size = max(1, int(cfg.batch_size))
+    weighted_loss = 0.0
+    total_weight = 0.0
+    for start in range(0, len(holdout_targets), batch_size):
+        batch_targets = holdout_targets[start : start + batch_size]
+        batch = [
+            supervised_data.conversation_to_datum(
+                conversation,
+                renderer,
+                cfg.max_seq_length,
+                train_on_what,
+            )
+            for conversation in batch_targets
+        ]
+        result = _future_result(forward(batch, loss_fn="cross_entropy"))
+        loss = _extract_forward_loss(result, batch)
+        weight = _batch_loss_weight(batch)
+        weighted_loss += loss * weight
+        total_weight += weight
+
+    if total_weight <= 0:
+        return None
+    return weighted_loss / total_weight
 
 
 def _future_result(value: Any) -> Any:
@@ -595,6 +607,15 @@ def _datum_loss_weights(datum: Any) -> Any:
         if isinstance(loss_inputs, Mapping):
             return loss_inputs.get("weights")
     return None
+
+
+def _batch_loss_weight(datums: Sequence[Any]) -> float:
+    total = 0.0
+    for datum in datums:
+        weights = _to_float_sequence(_datum_loss_weights(datum))
+        if weights is not None:
+            total += sum(max(0.0, weight) for weight in weights)
+    return total if total > 0 else float(len(datums))
 
 
 def _score_from_loss(loss: float | None) -> float:

--- a/tests/test_tinker_runner.py
+++ b/tests/test_tinker_runner.py
@@ -252,6 +252,50 @@ def test_run_tinker_sft_experiment_scores_dataset_result_holdouts(
     assert heldout_prompts == ["validation", "test"]
 
 
+def test_run_tinker_sft_experiment_batches_holdout_forward_passes(
+    tmp_path,
+    monkeypatch,
+):
+    state = _install_fake_tinker_stack(
+        monkeypatch,
+        losses=[0.5],
+        forward_losses=[1.0, 3.0],
+    )
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [
+            {"input": "train", "output": "a"},
+            {"input": "validation one", "output": "b"},
+            {"input": "validation two", "output": "c"},
+            {"input": "validation three", "output": "d"},
+        ],
+    )
+    dataset_result = {
+        "dataset": {
+            "path": str(data_path),
+            "train_size": 1,
+            "val_size": 3,
+            "test_size": 0,
+        },
+        "next_agent": "decision_engine",
+    }
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=2),
+        dataset_result,
+        run_id="batched-holdout-run",
+        max_steps=1,
+        output_dir=str(tmp_path / "experiments"),
+    )
+
+    metrics = result["metrics"]
+    assert metrics["val_loss"] == pytest.approx((1.0 * 2 + 3.0 * 1) / 3)
+    assert state.training_client.forward_calls == 2
+    assert [len(batch) for batch in state.training_client.forward_batches] == [2, 1]
+
+
 def test_extract_forward_loss_uses_weighted_logprobs():
     from src.tinker_api.sft_runner import _extract_forward_loss
 


### PR DESCRIPTION
## Summary
- evaluate Tinker validation/test holdouts in bounded batches using the training batch size
- aggregate heldout losses with token weights when available, falling back to example counts
- keep existing no-holdout and path-only dataset behavior unchanged

## Why
PR #62 adds real heldout scoring, but it forwarded the entire val or test split in one SDK call. That works for smoke datasets but can make evaluation the largest request in a real run.

## Validation
- `python3 -m compileall src`
- `uv run --with pytest --with langgraph --with anthropic --with requests python -m pytest tests/test_tinker_runner.py tests/test_autoresearch.py tests/test_tinker_api.py -q`
- `uv run --with pytest --with langgraph --with anthropic --with requests python -m pytest tests/test_tinker_api.py tests/test_tinker_runner.py tests/test_autoresearch.py tests/test_e2e_propose.py -q`
- `git diff --check`
- Local unpublished full stack including #65: compileall plus broad non-live suite excluding live Tinker/HF retrieval passed with `208 passed, 7 skipped`
- Live Tinker smoke on the 22-row web DataGen dataset: `Qwen/Qwen3.5-9B`, 1 step, split 17/2/3, `batch_size=2`; completed with heldout `val_loss=10.5183`, `test_loss=10.0684`