### PR TITLE
[codex] use primary metric for Tinker plans

### DIFF
--- a/src/decision_engine/decision_engine.py
+++ b/src/decision_engine/decision_engine.py
@@ -73,6 +73,7 @@ def run_decision_engine(
         lora = None
         script_path = write_pretrain_script(task, dataset, config)
 
+    backend = "tinker_sft"
     return TrainingPlan(
         strategy=strategy,
         base_model=model_id,
@@ -80,8 +81,8 @@ def run_decision_engine(
         estimated_cost=cost["estimated_usd"],
         estimated_time_min=cost["estimated_time_min"],
         training_script_path=script_path,
-        eval_metric=task["eval_metric"],
-        backend="tinker_sft",
+        eval_metric="primary_metric" if backend == "tinker_sft" else task["eval_metric"],
+        backend=backend,
         dataset_path=dataset["dataset"]["path"],
         dataset=dataset["dataset"],
     )

--- a/tests/test_decision_engine.py
+++ b/tests/test_decision_engine.py
@@ -104,7 +104,8 @@ def test_run_decision_engine_returns_training_plan(tmp_path, monkeypatch):
     dataset = _make_dataset(train_size=42)
     plan = run_decision_engine(config, dataset)
     assert plan["strategy"] in ("fine-tune", "pre-train")
-    assert plan["eval_metric"] == "accuracy"
+    assert plan["eval_metric"] == "primary_metric"
+    assert plan["backend"] == "tinker_sft"
     assert os.path.exists(plan["training_script_path"])
     assert plan["estimated_cost"] > 0
     assert plan["dataset_path"] == dataset["dataset"]["path"]


### PR DESCRIPTION
## Summary
- set DecisionEngine Tinker plans to use `eval_metric=primary_metric`
- keep task analysis metric mapping intact, but make the executable SDK-native plan match the actual AutoResearch evaluator
- update DecisionEngine coverage for the Tinker backend metric contract

## Why
The Tinker SFT path scores artifacts with `primary_metric = 1 / (1 + val_loss)`, but DecisionEngine still labeled text-classification plans as `accuracy`. That made logs and eval-suite metadata disagree with the scoring path used by AutoResearch.

## Validation
- `python3 -m compileall src`
- `uv run --with pytest --with langgraph --with anthropic --with requests python -m pytest tests/test_decision_engine.py tests/test_autoresearch.py tests/test_tinker_runner.py tests/test_manager.py -q`
- `uv run --with pytest --with langgraph --with anthropic --with requests python -m pytest tests/test_tinker_api.py tests/test_tinker_runner.py tests/test_autoresearch.py tests/test_decision_engine.py tests/test_manager.py tests/test_e2e_propose.py -q`
- `git diff --check`