### PR TITLE
[codex] avoid free-text HF parser false positives

### DIFF
--- a/src/data_generator/mode_b.py
+++ b/src/data_generator/mode_b.py
@@ -17,9 +17,12 @@ def parse_explicit_hf_dataset_ids(config: OrchestrationConfig, data_path: str | 
 
     tp = config.get("training_procedure", {})
     if isinstance(tp, dict):
-        for key in ("hf_dataset_ids", "hf_dataset_urls", "dataset_ids", "sources", "notes"):
+        for key in ("hf_dataset_ids", "hf_dataset_urls", "dataset_ids", "sources"):
             value = tp.get(key)
             raw_items.extend(_coerce_source_tokens(value))
+        notes = tp.get("notes")
+        if isinstance(notes, str):
+            raw_items.extend(_extract_hf_mentions(notes))
 
     # New orchestrator envelope format support.
     data_request = config.get("data_request")  # type: ignore[arg-type]
@@ -148,9 +151,9 @@ def _coerce_source_tokens(value: object) -> list[str]:
 
 def _extract_hf_mentions(value: str) -> list[str]:
     mentions: list[str] = []
-    for match in re.findall(r"huggingface\.co/datasets/([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)", value):
+    for match in re.findall(r"hf://([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)", value):
         mentions.append(match)
-    for match in re.findall(r"\b([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)\b", value):
+    for match in re.findall(r"huggingface\.co/datasets/([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)", value):
         mentions.append(match)
     return mentions
 

--- a/tests/data_generator/test_mode_b_hf_retrieval.py
+++ b/tests/data_generator/test_mode_b_hf_retrieval.py
@@ -654,6 +654,39 @@ def test_hf_row_limit_distributes_remainder_across_splits(monkeypatch) -> None:
     ]
 
 
+def test_parse_hf_dataset_ids_ignores_free_text_slash_words() -> None:
+    from src.data_generator.mode_b import parse_explicit_hf_dataset_ids
+
+    config = {
+        "prompt": "Compare the Mode B/Tinker path with the web/DataGen path.",
+        "training_procedure": {
+            "task_type": "text-classification",
+            "notes": "Overnight bounded live Mode B/Tinker validation.",
+        },
+    }
+
+    assert parse_explicit_hf_dataset_ids(config) == []
+
+
+def test_parse_hf_dataset_ids_keeps_explicit_sources_and_urls() -> None:
+    from src.data_generator.mode_b import parse_explicit_hf_dataset_ids
+
+    config = {
+        "prompt": "Use hf://SetFit/sst2 for the smoke run.",
+        "data_request": {"sources": [{"type": "hf_dataset", "id": "mteb/banking77"}]},
+        "training_procedure": {
+            "task_type": "text-classification",
+            "notes": "Reference: https://huggingface.co/datasets/DeepPavlov/clinc150",
+        },
+    }
+
+    assert parse_explicit_hf_dataset_ids(config) == [
+        "DeepPavlov/clinc150",
+        "mteb/banking77",
+        "SetFit/sst2",
+    ]
+
+
 def test_live_hf_retrieval_requires_explicit_opt_in(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.delenv(RUN_LIVE_HF_RETRIEVAL_ENV, raising=False)
 


### PR DESCRIPTION
## Summary
- stop treating arbitrary `word/word` text in prompts or training notes as Hugging Face dataset IDs
- keep structured bare dataset IDs working in explicit source fields
- keep free-text discovery for explicit `hf://org/dataset` and `https://huggingface.co/datasets/org/dataset` mentions
- add regression coverage for the `Mode B/Tinker` false-positive path exposed by live validation

## Why
A live Mode B/Tinker smoke correctly fetched `SetFit/sst2`, but also attempted a bogus `B/Tinker` dataset because `training_procedure.notes` contained `Mode B/Tinker`. That produced an avoidable malformed curation row.

## Validation
- `python3 -m compileall src tests/data_generator/test_mode_b_hf_retrieval.py`
- `uv run --with pytest --with langgraph --with anthropic --with requests python -m pytest tests/data_generator/test_mode_b_hf_retrieval.py tests/data_generator/test_handoff_contract_consistency.py -q` (`10 passed, 2 skipped`)
- `uv run --with pytest --with langgraph --with anthropic --with requests python -m pytest tests/data_generator/test_mode_b_hf_retrieval.py tests/data_generator/test_handoff_contract_consistency.py tests/test_manager.py -q` (`19 passed, 3 skipped`)
- live no-Tinker HF validation: `SetFit/sst2` only, 6 records, split 2/2/2, no curation issues
- `git diff --check`