### PR TITLE
[codex] add AutoResearch budget preflight guard

### DIFF
--- a/src/autoresearch/autoresearch.py
+++ b/src/autoresearch/autoresearch.py
@@ -848,7 +848,6 @@ def _estimated_run_cost_from_state(state: AutoResearchState) -> float:
         hyperparameters.get("estimated_run_cost_usd")
         if isinstance(hyperparameters, Mapping)
         else None,
-        plan.get("estimated_cost"),
     )
     for value in candidates:
         if value is None:

--- a/src/autoresearch/autoresearch.py
+++ b/src/autoresearch/autoresearch.py
@@ -224,7 +224,10 @@ def baseline_node(state: AutoResearchState) -> dict:
         "best_score": baseline_score,
         "best_script": experiment["model_path"],
         "last_result": experiment,
-        "should_stop": budget_status == BudgetStatus.EXCEEDED,
+        "should_stop": (
+            budget_status == BudgetStatus.EXCEEDED
+            or experiment["status"] == JobStatus.CANCELLED
+        ),
     }
 
 
@@ -300,7 +303,10 @@ def run_node(state: AutoResearchState) -> dict:
 
     return {
         "last_result": result,
-        "should_stop": budget_status == BudgetStatus.EXCEEDED,
+        "should_stop": (
+            budget_status == BudgetStatus.EXCEEDED
+            or result["status"] == JobStatus.CANCELLED
+        ),
     }
 
 
@@ -308,10 +314,16 @@ def revert_and_continue_node(state: AutoResearchState) -> dict:
     """LangGraph node (early stop path). Reverts the patch before normal logging."""
     revert_patch(str(_CONFIG_PATH), state["original_content"])
 
+    budget_skipped = _last_result_was_budget_skipped(state)
+    reason = (
+        "budget preflight skipped iteration"
+        if budget_skipped
+        else "catastrophic failure"
+    )
     log_event(
         AgentName.AUTORESEARCH,
         LogLevel.WARN,
-        f"REVERTED (early-stop): catastrophic failure on iteration {state['iteration'] + 1}",
+        f"REVERTED (early-stop): {reason} on iteration {state['iteration'] + 1}",
         metadata={
             "iteration": state["iteration"] + 1,
             "metrics": state["last_result"]["metrics"] if state.get("last_result") else {},
@@ -413,7 +425,11 @@ def log_node(state: AutoResearchState) -> dict:
             notes = f"+{state['last_delta']['relative_pct']:.1f}% on {state['eval_suite']['primary_metric']}"
         elif _last_result_was_early_stopped(state):
             decision = "REVERTED"
-            notes = "Early-stopped: catastrophic failure (NaN/Inf loss or primary metric collapse)"
+            notes = (
+                "Skipped: budget preflight rejected the Tinker run"
+                if _last_result_was_budget_skipped(state)
+                else "Early-stopped: catastrophic failure (NaN/Inf loss or primary metric collapse)"
+            )
         else:
             decision = "REVERTED"
             delta_pct = state["last_delta"]["relative_pct"] if state["last_delta"] else 0.0
@@ -485,6 +501,23 @@ def _last_result_was_early_stopped(state: AutoResearchState) -> bool:
     if last_result["status"] in {JobStatus.FAILED, JobStatus.CANCELLED}:
         return True
     return check_early_stop(last_result["metrics"])
+
+
+def _last_result_was_budget_skipped(state: AutoResearchState) -> bool:
+    last_result = state.get("last_result")
+    if not last_result:
+        return False
+    try:
+        manifest_path = Path(last_result["model_path"]) / "manifest.json"
+    except (KeyError, TypeError):
+        return False
+    if not manifest_path.exists():
+        return False
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    return bool(manifest.get("budget_preflight_skipped"))
 
 
 def decision_edge(state: AutoResearchState) -> Literal["keep", "revert"]:
@@ -801,12 +834,155 @@ def _max_steps_from_state(state: AutoResearchState) -> int:
     return DEFAULT_LIVE_SMOKE_STEPS
 
 
+def _estimated_run_cost_from_state(state: AutoResearchState) -> float:
+    """Returns the best available USD estimate for the next Tinker launch."""
+    plan = state.get("plan", {})
+    procedure = state.get("config", {}).get("training_procedure", {})
+    hyperparameters = (
+        procedure.get("hyperparameters", {})
+        if isinstance(procedure, Mapping)
+        else {}
+    )
+    candidates = (
+        plan.get("estimated_run_cost_usd"),
+        hyperparameters.get("estimated_run_cost_usd")
+        if isinstance(hyperparameters, Mapping)
+        else None,
+        plan.get("estimated_cost"),
+    )
+    for value in candidates:
+        if value is None:
+            continue
+        try:
+            return max(0.0, float(value))
+        except (TypeError, ValueError):
+            continue
+    return 0.0
+
+
+def _remaining_budget_from_state(state: AutoResearchState) -> float:
+    cost_manager = state.get("cost_manager")
+    if cost_manager is not None and hasattr(cost_manager, "remaining_budget"):
+        try:
+            return max(0.0, float(cost_manager.remaining_budget))
+        except (TypeError, ValueError):
+            pass
+
+    budget = state.get("config", {}).get("compute_budget", float("inf"))
+    try:
+        return max(0.0, float(budget) - _spent_usd_from_state(state))
+    except (TypeError, ValueError):
+        return float("inf")
+
+
+def _budget_preflight_skip_reason(
+    state: AutoResearchState,
+    estimated_cost: float,
+) -> str | None:
+    cost_manager = state.get("cost_manager")
+    remaining = _remaining_budget_from_state(state)
+
+    if cost_manager is not None and hasattr(cost_manager, "can_start_run"):
+        can_start = cost_manager.can_start_run(estimated_cost)
+    else:
+        can_start = remaining > 0 and estimated_cost <= remaining
+
+    if can_start:
+        return None
+    if remaining <= 0:
+        return "remaining budget is exhausted before launch"
+    if estimated_cost > remaining:
+        return (
+            f"estimated run cost ${estimated_cost:.2f} exceeds remaining "
+            f"budget ${remaining:.2f}"
+        )
+    return "budget preflight rejected launch"
+
+
+def _budget_limited_experiment_result(
+    run_id: str,
+    *,
+    reason: str,
+    estimated_cost: float,
+    remaining_budget: float,
+    output_dir: str = "outputs/experiments",
+) -> ExperimentResult:
+    run_dir = Path(output_dir) / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    loss = float("inf")
+    metrics: TrainingMetrics = {
+        "train_loss": loss,
+        "val_loss": loss,
+        "test_loss": loss,
+        "primary_metric": 0.0,
+    }
+    metrics_row = {
+        "step": 0,
+        **metrics,
+        "budget_preflight_skipped": True,
+        "reason": reason,
+    }
+    metrics_path = run_dir / "metrics.jsonl"
+    metrics_path.write_text(json.dumps(metrics_row) + "\n")
+    (run_dir / "metrics.json").write_text(json.dumps(metrics, indent=2))
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "run_id": run_id,
+                "status": JobStatus.CANCELLED,
+                "backend": "tinker_sft",
+                "budget_preflight_skipped": True,
+                "budget_skip_reason": reason,
+                "estimated_cost_usd": round(float(estimated_cost), 6),
+                "remaining_budget_usd": round(float(remaining_budget), 6),
+                "completed_steps": 0,
+                "checkpoints": {},
+            },
+            indent=2,
+        )
+    )
+    (run_dir / "sample.json").write_text(
+        json.dumps({"prompt": [], "text": "", "tokens": [], "error": reason}, indent=2)
+    )
+    return {
+        "job_id": run_id,
+        "status": JobStatus.CANCELLED,
+        "metrics": metrics,
+        "model_path": str(run_dir),
+        "cost_usd": 0.0,
+        "logs_path": str(metrics_path),
+    }
+
+
 def _run_tinker_experiment_for_state(
     state: AutoResearchState,
     *,
     phase: str,
 ) -> ExperimentResult:
     run_id = f"autoresearch-{phase}-{state['iteration']}-{uuid4().hex[:8]}"
+    estimated_cost = _estimated_run_cost_from_state(state)
+    remaining_budget = _remaining_budget_from_state(state)
+    skip_reason = _budget_preflight_skip_reason(state, estimated_cost)
+    if skip_reason:
+        log_event(
+            AgentName.AUTORESEARCH,
+            LogLevel.WARN,
+            "BUDGET: skipped Tinker launch before spend",
+            metadata={
+                "run_id": run_id,
+                "phase": phase,
+                "estimated_cost_usd": estimated_cost,
+                "remaining_budget_usd": remaining_budget,
+                "reason": skip_reason,
+            },
+        )
+        return _budget_limited_experiment_result(
+            run_id,
+            reason=skip_reason,
+            estimated_cost=estimated_cost,
+            remaining_budget=remaining_budget,
+        )
+
     cost_manager = state.get("cost_manager")
     if cost_manager is not None and hasattr(cost_manager, "start"):
         cost_manager.start(run_id)

--- a/src/cost_manager/cost_manager.py
+++ b/src/cost_manager/cost_manager.py
@@ -130,6 +130,19 @@ class CostManager:
         """Returns the current in-process budget status."""
         return check_budget_status(self.spent_usd, self.budget)
 
+    def can_start_run(self, estimated_cost: float = 0.0) -> bool:
+        """Returns whether a new run can start without exceeding remaining budget."""
+        try:
+            estimate = max(0.0, float(estimated_cost))
+        except (TypeError, ValueError):
+            estimate = 0.0
+
+        if self.status == BudgetStatus.EXCEEDED:
+            return False
+        if self.remaining_budget <= 0:
+            return False
+        return estimate <= self.remaining_budget
+
     def record_spend(self, amount: float, category: str = "training") -> str:
         """Records completed in-process spend and returns the updated budget status."""
         amount = float(amount)

--- a/src/types.py
+++ b/src/types.py
@@ -152,6 +152,7 @@ class TrainingPlan(_TrainingPlanRequired, total=False):
     backend: str            # 'tinker_sft' for the SDK-native Tinker v1 path
     dataset_path: str       # Local JSONL path consumed by the Tinker SFT runner
     dataset: StandardDataset  # Aggregate dataset metadata, including split counts
+    estimated_run_cost_usd: float  # Optional per-AutoResearch-launch budget guard
 
 
 class EvalScore(TypedDict):

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -439,6 +439,7 @@ def test_run_node_preflight_skips_unaffordable_candidate(monkeypatch, tmp_path):
             "eval_metric": "primary_metric",
             "backend": "tinker_sft",
             "dataset_path": str(tmp_path / "train.jsonl"),
+            "estimated_run_cost_usd": 2.0,
         },
         config={
             "compute_budget": 1.0,

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -364,6 +364,43 @@ def test_log_node_records_early_stop_once(tmp_path):
         ar._DIARY_PATH = original_path
 
 
+def test_log_node_labels_budget_preflight_skip(tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    run_dir = tmp_path / "budget-skip"
+    run_dir.mkdir()
+    (run_dir / "manifest.json").write_text(
+        json.dumps({"budget_preflight_skipped": True})
+    )
+    original_path = ar._DIARY_PATH
+    ar._DIARY_PATH = tmp_path / "diary.jsonl"
+    try:
+        state = _make_state(
+            eval_suite={"primary_metric": "primary_metric", "metrics": [], "test_split_path": "",
+                        "use_llm_grading": False},
+            current_config={"learning_rate": 1e-4, "batch_size": 4},
+            current_patch=json.dumps({"learning_rate": 2e-4}),
+            last_description="Increase learning rate.",
+            last_delta=None,
+            last_result={
+                "job_id": "candidate",
+                "status": "CANCELLED",
+                "metrics": {"train_loss": 1e9, "val_loss": 1e9,
+                            "test_loss": 1e9, "primary_metric": 0.0},
+                "model_path": str(run_dir),
+                "cost_usd": 0.0,
+                "logs_path": str(run_dir / "metrics.jsonl"),
+            },
+        )
+
+        out = ar.log_node(state)
+
+        assert out["diary"][0]["decision"] == "REVERTED"
+        assert "budget preflight" in out["diary"][0]["notes"]
+    finally:
+        ar._DIARY_PATH = original_path
+
+
 def test_completed_high_finite_sft_loss_flows_to_evaluate():
     import src.autoresearch.autoresearch as ar
 
@@ -380,6 +417,56 @@ def test_completed_high_finite_sft_loss_flows_to_evaluate():
     )
 
     assert ar.early_stop_edge(state) == "evaluate"
+
+
+def test_run_node_preflight_skips_unaffordable_candidate(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+    from src.cost_manager.cost_manager import CostManager
+
+    def fail_runner(*args, **kwargs):
+        raise AssertionError("Tinker runner should not start when preflight rejects")
+
+    monkeypatch.setattr(ar, "run_tinker_sft_experiment", fail_runner)
+    monkeypatch.chdir(tmp_path)
+    state = _make_state(
+        plan={
+            "strategy": "fine-tune",
+            "base_model": "Qwen/Qwen3.5-9B",
+            "lora_config": None,
+            "estimated_cost": 2.0,
+            "estimated_time_min": 5,
+            "training_script_path": "outputs/scripts/train.py",
+            "eval_metric": "primary_metric",
+            "backend": "tinker_sft",
+            "dataset_path": str(tmp_path / "train.jsonl"),
+        },
+        config={
+            "compute_budget": 1.0,
+            "prompt": "",
+            "data": False,
+            "training_procedure": {
+                "task_type": "text-classification",
+                "data_format": "jsonl",
+                "training_type": "SFT",
+                "base_model": "Qwen/Qwen3.5-9B",
+                "hyperparameters": {"learning_rate": 1e-4, "batch_size": 1},
+                "notes": "",
+            },
+        },
+        current_config={"learning_rate": 1e-4, "batch_size": 1},
+        current_patch=json.dumps({"learning_rate": 2e-4}),
+        cost_manager=CostManager(1.0),
+    )
+
+    out = ar.run_node(state)
+    manifest = json.loads(
+        (Path(out["last_result"]["model_path"]) / "manifest.json").read_text()
+    )
+
+    assert out["last_result"]["status"] == "CANCELLED"
+    assert out["last_result"]["cost_usd"] == 0.0
+    assert out["should_stop"] is True
+    assert manifest["budget_preflight_skipped"] is True
 
 
 # ─── continue_edge ────────────────────────────────────────────────────────────
@@ -567,7 +654,7 @@ def test_autoresearch_graph_passes_plan_dataset_splits_to_tinker(monkeypatch, tm
         "strategy": "fine-tune",
         "base_model": "Qwen/Qwen3.5-9B",
         "lora_config": {"rank": 8, "alpha": 16, "dropout": 0.05, "target_modules": []},
-        "estimated_cost": 1.0,
+        "estimated_cost": 0.005,
         "estimated_time_min": 5,
         "training_script_path": "outputs/scripts/train.py",
         "eval_metric": "primary_metric",

--- a/tests/test_cost_manager.py
+++ b/tests/test_cost_manager.py
@@ -69,6 +69,20 @@ def test_cost_manager_records_in_process_spend_by_category():
     assert manager.status == BudgetStatus.EXCEEDED
 
 
+def test_cost_manager_can_start_run_respects_remaining_budget():
+    manager = CostManager(1.0)
+
+    assert manager.can_start_run(0.25) is True
+    manager.record_spend(0.80)
+
+    assert manager.can_start_run(0.20) is True
+    assert manager.can_start_run(0.21) is False
+
+    manager.record_spend(0.20)
+    assert manager.remaining_budget == 0.0
+    assert manager.can_start_run(0.0) is False
+
+
 def test_cost_manager_cost_breakdown_uses_recorded_totals():
     manager = CostManager(10.0)
     manager.record_spend(1.25, category="training")

--- a/tests/test_tinker_runner.py
+++ b/tests/test_tinker_runner.py
@@ -433,7 +433,7 @@ def test_autoresearch_baseline_preflight_skips_unaffordable_run(monkeypatch, tmp
     state = _autoresearch_state(str(data_path))
     state["config"]["compute_budget"] = 0.01
     state["cost_manager"] = CostManager(0.01)
-    state["plan"]["estimated_cost"] = 1.0
+    state["plan"]["estimated_run_cost_usd"] = 1.0
 
     result = ar.baseline_node(state)
     run_dir = Path(result["baseline_result"]["model_path"])

--- a/tests/test_tinker_runner.py
+++ b/tests/test_tinker_runner.py
@@ -409,6 +409,7 @@ def test_autoresearch_baseline_node_records_cost_and_budget_stop(monkeypatch, tm
     state = _autoresearch_state(str(data_path))
     state["config"]["compute_budget"] = 0.01
     state["cost_manager"] = CostManager(0.01)
+    state["plan"]["estimated_cost"] = 0.0
 
     result = ar.baseline_node(state)
 
@@ -416,6 +417,36 @@ def test_autoresearch_baseline_node_records_cost_and_budget_stop(monkeypatch, tm
     assert result["should_stop"] is True
     assert state["cost_manager"].spent_usd == 0.02
     assert ar.continue_edge({**state, **result}) == "__end__"
+
+
+def test_autoresearch_baseline_preflight_skips_unaffordable_run(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+    from src.cost_manager.cost_manager import CostManager
+
+    data_path = _write_jsonl(tmp_path / "train.jsonl", [{"input": "x", "output": "y"}])
+
+    def fail_runner(*args, **kwargs):
+        raise AssertionError("Tinker runner should not start when preflight rejects")
+
+    monkeypatch.setattr(ar, "run_tinker_sft_experiment", fail_runner)
+    monkeypatch.chdir(tmp_path)
+    state = _autoresearch_state(str(data_path))
+    state["config"]["compute_budget"] = 0.01
+    state["cost_manager"] = CostManager(0.01)
+    state["plan"]["estimated_cost"] = 1.0
+
+    result = ar.baseline_node(state)
+    run_dir = Path(result["baseline_result"]["model_path"])
+
+    assert result["baseline_result"]["status"] == "CANCELLED"
+    assert result["baseline_result"]["cost_usd"] == 0.0
+    assert result["baseline_score"]["scalar"] == 0.0
+    assert result["should_stop"] is True
+    assert state["cost_manager"].spent_usd == 0.0
+    assert (run_dir / "metrics.json").exists()
+    manifest = json.loads((run_dir / "manifest.json").read_text())
+    assert manifest["budget_preflight_skipped"] is True
+    assert "estimated run cost" in manifest["budget_skip_reason"]
 
 
 def _write_jsonl(path: Path, rows: list[dict]) -> Path:


### PR DESCRIPTION
## Summary
- add a CostManager preflight check before SDK-native Tinker launches
- use explicit per-launch `estimated_run_cost_usd` when provided, while always refusing exhausted/zero remaining budgets
- write normal cancelled experiment artifacts when a run is skipped for budget, so eval/logging remains deterministic
- label budget skips separately from catastrophic model failures in AutoResearch diary/logging
- add unit coverage for baseline and candidate budget skips plus remaining-budget checks

## Validation
- `python3 -m compileall src`
- `uv run --with pytest --with anthropic --with langgraph python -m pytest tests/test_cost_manager.py tests/test_tinker_runner.py tests/test_autoresearch.py -q` (`64 passed`)
- `uv run --with pytest --with anthropic --with langgraph --with datasets --with huggingface-hub --with requests python -m pytest tests --ignore=tests/data_generator/test_mode_b_hf_retrieval.py -q` (`156 passed, 5 skipped`)

## Notes
`estimated_cost` remains a plan-level estimate and is not treated as the cost of every AutoResearch launch. Callers can set `estimated_run_cost_usd` for stricter preflight gating when they have a per-run estimate. The ignored HF retrieval file is still ungated on this AutoResearch base branch; PR #67 gates it in the DataGen stack.