### PR TITLE
[codex] estimate bounded Tinker run costs

### DIFF
--- a/src/decision_engine/decision_engine.py
+++ b/src/decision_engine/decision_engine.py
@@ -8,6 +8,7 @@ estimates cost, and writes the training script passed to AutoResearch.
 
 from __future__ import annotations
 
+import math
 import os
 from textwrap import dedent
 
@@ -79,6 +80,7 @@ def run_decision_engine(
         base_model=model_id,
         lora_config=lora,
         estimated_cost=cost["estimated_usd"],
+        estimated_run_cost_usd=estimate_autoresearch_run_cost(cost, config, dataset),
         estimated_time_min=cost["estimated_time_min"],
         training_script_path=script_path,
         eval_metric="primary_metric" if backend == "tinker_sft" else task["eval_metric"],
@@ -86,6 +88,38 @@ def run_decision_engine(
         dataset_path=dataset["dataset"]["path"],
         dataset=dataset["dataset"],
     )
+
+
+def estimate_autoresearch_run_cost(
+    cost: CostEstimate,
+    config: OrchestrationConfig,
+    dataset: DatasetResult,
+) -> float:
+    """Estimate one bounded AutoResearch Tinker launch from the full plan cost."""
+    total_cost = max(0.0, float(cost["estimated_usd"]))
+    if total_cost == 0.0:
+        return 0.0
+
+    hp = config["training_procedure"].get("hyperparameters", {})
+    max_steps = hp.get("max_steps")
+    if max_steps is None:
+        return round(total_cost, 4)
+
+    train_size = _positive_int(dataset["dataset"].get("train_size"), default=1)
+    batch_size = _positive_int(hp.get("batch_size"), default=16)
+    epochs = _positive_int(hp.get("num_epochs", hp.get("epochs")), default=3)
+    full_steps = max(1, math.ceil(train_size / batch_size) * epochs)
+    bounded_steps = _positive_int(max_steps, default=full_steps)
+    ratio = min(1.0, bounded_steps / full_steps)
+    return round(min(total_cost, max(0.01, total_cost * ratio)), 4)
+
+
+def _positive_int(value, *, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
 
 
 def analyze_task(config: OrchestrationConfig) -> TaskAnalysis:

--- a/tests/test_decision_engine.py
+++ b/tests/test_decision_engine.py
@@ -5,6 +5,7 @@ import pytest
 from src.decision_engine.decision_engine import (
     analyze_task,
     configure_lora,
+    estimate_autoresearch_run_cost,
     estimate_training_cost,
     find_base_model,
     run_decision_engine,
@@ -66,6 +67,44 @@ def test_estimate_training_cost_finetune_cheaper_than_pretrain():
     assert fine_tune_cost["confidence"] == "medium"
 
 
+def test_estimate_autoresearch_run_cost_scales_bounded_steps():
+    config = _make_config()
+    config["training_procedure"]["hyperparameters"]["max_steps"] = 5
+    dataset = _make_dataset(train_size=1000)
+    cost = estimate_training_cost("Qwen/Qwen3.5-9B", dataset, "fine-tune")
+
+    run_cost = estimate_autoresearch_run_cost(cost, config, dataset)
+
+    assert cost["estimated_usd"] == 1.12
+    assert run_cost == 0.0296
+
+
+def test_estimate_autoresearch_run_cost_uses_full_cost_when_unbounded():
+    config = _make_config()
+    dataset = _make_dataset(train_size=1000)
+    cost = estimate_training_cost("Qwen/Qwen3.5-9B", dataset, "fine-tune")
+
+    assert estimate_autoresearch_run_cost(cost, config, dataset) == cost["estimated_usd"]
+
+
+def test_estimate_autoresearch_run_cost_caps_at_full_cost():
+    config = _make_config()
+    config["training_procedure"]["hyperparameters"]["max_steps"] = 10_000
+    dataset = _make_dataset(train_size=42)
+    cost = estimate_training_cost("Qwen/Qwen3.5-9B", dataset, "fine-tune")
+
+    assert estimate_autoresearch_run_cost(cost, config, dataset) == cost["estimated_usd"]
+
+
+def test_estimate_autoresearch_run_cost_treats_invalid_max_steps_as_unbounded():
+    config = _make_config()
+    config["training_procedure"]["hyperparameters"]["max_steps"] = "many"
+    dataset = _make_dataset(train_size=1000)
+    cost = estimate_training_cost("Qwen/Qwen3.5-9B", dataset, "fine-tune")
+
+    assert estimate_autoresearch_run_cost(cost, config, dataset) == cost["estimated_usd"]
+
+
 def test_configure_lora_returns_valid_config():
     config = _make_config("text-classification")
     task = analyze_task(config)
@@ -108,5 +147,17 @@ def test_run_decision_engine_returns_training_plan(tmp_path, monkeypatch):
     assert plan["backend"] == "tinker_sft"
     assert os.path.exists(plan["training_script_path"])
     assert plan["estimated_cost"] > 0
+    assert plan["estimated_run_cost_usd"] == plan["estimated_cost"]
     assert plan["dataset_path"] == dataset["dataset"]["path"]
     assert plan["dataset"] == dataset["dataset"]
+
+
+def test_run_decision_engine_sets_bounded_run_cost(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config = _make_config("text-classification", budget=50.0)
+    config["training_procedure"]["hyperparameters"]["max_steps"] = 5
+    dataset = _make_dataset(train_size=1000)
+
+    plan = run_decision_engine(config, dataset)
+
+    assert 0.0 < plan["estimated_run_cost_usd"] < plan["estimated_cost"]


### PR DESCRIPTION
## Summary
- populate `TrainingPlan.estimated_run_cost_usd` from DecisionEngine for Tinker SFT plans
- scale the per-launch estimate by `max_steps / planned_steps` while keeping `estimated_cost` as the full plan estimate
- cap bounded estimates at the full cost and tolerate invalid step/count values without crashing
- add tests for bounded, unbounded, capped, invalid, and end-to-end plan cases

## Validation
- `python3 -m compileall src`
- `uv run --with pytest --with anthropic --with langgraph python -m pytest tests/test_decision_engine.py tests/test_autoresearch.py tests/test_tinker_runner.py -q` (`65 passed`)
- `uv run --with pytest --with anthropic --with langgraph --with datasets --with huggingface-hub --with requests python -m pytest tests --ignore=tests/data_generator/test_mode_b_hf_retrieval.py -q` (`161 passed, 5 skipped`)

## Notes
This is stacked on #69. The point is to feed #69 a real per-launch estimate without overloading the plan-level `estimated_cost` field.