### PR TITLE
[codex] record estimated Tinker spend floor

### DIFF
--- a/src/autoresearch/autoresearch.py
+++ b/src/autoresearch/autoresearch.py
@@ -1008,7 +1008,33 @@ def _record_experiment_cost(
     cost_manager = state.get("cost_manager")
     if cost_manager is None or not hasattr(cost_manager, "record_spend"):
         return None
-    return cost_manager.record_spend(float(result.get("cost_usd", 0.0)), category=category)
+    accounted_cost = _accounted_experiment_cost(state, result)
+    result["cost_usd"] = accounted_cost
+    return cost_manager.record_spend(accounted_cost, category=category)
+
+
+def _accounted_experiment_cost(
+    state: AutoResearchState,
+    result: ExperimentResult,
+) -> float:
+    actual_cost = max(0.0, float(result.get("cost_usd", 0.0)))
+    if _experiment_result_was_budget_skipped(result):
+        return actual_cost
+    return max(actual_cost, _estimated_run_cost_from_state(state))
+
+
+def _experiment_result_was_budget_skipped(result: ExperimentResult) -> bool:
+    try:
+        manifest_path = Path(result["model_path"]) / "manifest.json"
+    except (KeyError, TypeError):
+        return False
+    if not manifest_path.exists():
+        return False
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    return bool(manifest.get("budget_preflight_skipped"))
 
 
 def submit_experiment(

--- a/tests/test_tinker_runner.py
+++ b/tests/test_tinker_runner.py
@@ -449,6 +449,45 @@ def test_autoresearch_baseline_preflight_skips_unaffordable_run(monkeypatch, tmp
     assert "estimated run cost" in manifest["budget_skip_reason"]
 
 
+def test_autoresearch_records_estimated_cost_floor(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+    from src.cost_manager.cost_manager import CostManager
+
+    data_path = _write_jsonl(tmp_path / "train.jsonl", [{"input": "x", "output": "y"}])
+
+    def fake_runner(config, dataset, *, run_id=None, max_steps=None, **kwargs):
+        run_dir = tmp_path / "estimated-floor"
+        run_dir.mkdir()
+        (run_dir / "metrics.json").write_text(
+            json.dumps({"train_loss": 0.3, "val_loss": 0.3, "test_loss": 0.3})
+        )
+        return {
+            "job_id": run_id,
+            "status": "COMPLETED",
+            "metrics": {
+                "train_loss": 0.3,
+                "val_loss": 0.3,
+                "test_loss": 0.3,
+                "primary_metric": 1 / 1.3,
+            },
+            "model_path": str(run_dir),
+            "cost_usd": 0.01,
+            "logs_path": str(run_dir / "metrics.jsonl"),
+        }
+
+    monkeypatch.setattr(ar, "run_tinker_sft_experiment", fake_runner)
+    state = _autoresearch_state(str(data_path))
+    state["config"]["compute_budget"] = 2.0
+    state["cost_manager"] = CostManager(2.0)
+    state["plan"]["estimated_run_cost_usd"] = 1.0
+
+    result = ar.baseline_node(state)
+
+    assert result["baseline_result"]["cost_usd"] == 1.0
+    assert state["cost_manager"].spent_usd == 1.0
+    assert result["should_stop"] is False
+
+
 def _write_jsonl(path: Path, rows: list[dict]) -> Path:
     path.write_text("".join(json.dumps(row) + "\n" for row in rows))
     return path


### PR DESCRIPTION
## Summary
- make AutoResearch account at least `estimated_run_cost_usd` for launched Tinker runs
- keep budget-preflight skips at zero spend because no SDK call happened
- mutate the in-graph `ExperimentResult.cost_usd` to the accounted conservative value so diary/cost reporting match the CostManager ledger
- add coverage for low reported runner cost being raised to the estimated run-cost floor

## Validation
- `python3 -m compileall src`
- `uv run --with pytest --with anthropic --with langgraph python -m pytest tests/test_cost_manager.py tests/test_decision_engine.py tests/test_tinker_runner.py tests/test_autoresearch.py -q` (`77 passed`)
- `uv run --with pytest --with anthropic --with langgraph --with datasets --with huggingface-hub --with requests python -m pytest tests --ignore=tests/data_generator/test_mode_b_hf_retrieval.py -q` (`162 passed, 5 skipped`)
- Local unpublished stack with #55-#72: compileall plus full non-live suite (`225 passed, 9 skipped`)
- Live stack smoke: offline synthetic DataGen + deterministic proposal + two 2-step Tinker runs on `Qwen/Qwen3.5-9B`; candidate `learning_rate=5e-4` kept and estimated spend floor stopped at exact software budget `$2.24`

## Notes
This is stacked on #70. Without this floor, the preflight estimate only gates a single launch and the loop can continue indefinitely if the runner reports very low token-estimated spend.