### PR TITLE
[codex] harden Manager reasoning JSON parsing

### DIFF
--- a/src/manager/manager.py
+++ b/src/manager/manager.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from datetime import datetime, timezone
 
 from src.types import (
@@ -206,7 +207,57 @@ def reason_about_task(prompt: str, budget: float, has_data: bool) -> TaskReasoni
         system=system,
         messages=[{"role": "user", "content": user_msg}],
     )
-    return json.loads(message.content[0].text)
+    raw_text = message.content[0].text
+    return _parse_task_reasoning_response(raw_text)
+
+
+def _parse_task_reasoning_response(raw_text: str) -> TaskReasoning:
+    """Parse and validate the Manager LLM's task-reasoning JSON."""
+    try:
+        parsed = json.loads(_extract_json_payload(raw_text))
+    except json.JSONDecodeError as exc:
+        preview = raw_text.strip().replace("\n", " ")[:200]
+        raise ValueError(
+            f"Manager reasoning response was not valid JSON: {preview!r}"
+        ) from exc
+
+    if not isinstance(parsed, dict):
+        raise ValueError("Manager reasoning response must be a JSON object.")
+
+    required = {
+        "task_type",
+        "data_format",
+        "training_type",
+        "suggested_base_model",
+        "hyperparameters",
+        "notes",
+    }
+    missing = sorted(required - parsed.keys())
+    if missing:
+        raise ValueError(f"Manager reasoning response missing keys: {missing}")
+    if not isinstance(parsed["hyperparameters"], dict):
+        raise ValueError("Manager reasoning hyperparameters must be a JSON object.")
+
+    return TaskReasoning(
+        task_type=str(parsed["task_type"]),
+        data_format=str(parsed["data_format"]),
+        training_type=str(parsed["training_type"]),
+        suggested_base_model=(
+            None
+            if parsed["suggested_base_model"] is None
+            else str(parsed["suggested_base_model"])
+        ),
+        hyperparameters=dict(parsed["hyperparameters"]),
+        notes=str(parsed["notes"]),
+    )
+
+
+def _extract_json_payload(raw_text: str) -> str:
+    text = raw_text.strip()
+    fenced = re.fullmatch(r"```(?:json)?\s*(.*?)\s*```", text, re.DOTALL)
+    if fenced:
+        return fenced.group(1).strip()
+    return text
 
 
 def _handoff_to_dataset_result(handoff: dict) -> DatasetResult:

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -6,6 +6,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 from src.manager.manager import (
     _handoff_to_dataset_result,
+    _parse_task_reasoning_response,
     build_manager_graph,
     build_orchestration_config,
     log_decision,
@@ -78,6 +79,33 @@ def test_reason_about_task_returns_task_reasoning():
     assert result["task_type"] == "text-classification"
     assert result["training_type"] == "SFT"
     assert "learning_rate" in result["hyperparameters"]
+
+
+def test_reason_about_task_parses_fenced_json_response():
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text=f"```json\n{json.dumps(MOCK_REASONING)}\n```")]
+
+    with patch("anthropic.Anthropic") as MockClient:
+        MockClient.return_value.messages.create.return_value = mock_response
+        result = reason_about_task("classify movie sentiment", 50.0, False)
+
+    assert result["task_type"] == "text-classification"
+    assert result["suggested_base_model"] == "bert-base-uncased"
+
+
+def test_parse_task_reasoning_response_rejects_missing_keys():
+    payload = {
+        "task_type": "text-classification",
+        "data_format": "jsonl",
+    }
+
+    with pytest.raises(ValueError, match="missing keys"):
+        _parse_task_reasoning_response(json.dumps(payload))
+
+
+def test_parse_task_reasoning_response_rejects_non_json():
+    with pytest.raises(ValueError, match="not valid JSON"):
+        _parse_task_reasoning_response("Here is the plan: use SFT.")
 
 
 def test_query_data_node_uses_programmatic_data_path_without_input(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Parse Manager reasoning responses wrapped in markdown JSON fences.
- Validate required task-reasoning keys and hyperparameter shape before building orchestration config.
- Raise clear ValueError messages for malformed planner output instead of raw JSONDecodeError crashes.

## Validation
- python3 -m compileall src/manager
- uv run --with pytest --with anthropic --with langgraph python -m pytest tests/test_manager.py -q
- Local stack with #73: uv run --with pytest --with anthropic --with langgraph python -m pytest tests/test_manager.py tests/test_e2e_full_stack_contract.py -q
- Live Manager Mode B smoke on local stack: hf://SetFit/sst2 -> curation -> DecisionEngine -> baseline Tinker -> one candidate Tinker -> budget-limit stop at $2.24

## Context
A live Manager-driven Mode B smoke returned a valid JSON object inside a markdown json fence. The previous parser attempted json.loads on the whole string and crashed before DataGen/DecisionEngine/Tinker. This keeps the Manager boundary robust without changing downstream behavior.

## Live Result
The retry after this change completed one bounded Manager-driven AutoResearch iteration. Baseline scalar was 0.0556; the candidate batch-size patch regressed by -1.2% and was reverted; spend-floor accounting stopped the graph at termination_reason=budget_limit with total_usd=2.24.