### PR TITLE
[codex] isolate API run output paths

### DIFF
--- a/src/autoresearch/autoresearch.py
+++ b/src/autoresearch/autoresearch.py
@@ -19,6 +19,7 @@ import anthropic
 
 from src.autoresearch.config import TrainingConfig
 from src.observability.observability import log_event
+from src.runtime_context import resolve_output_path
 from src.tinker_api.sft_runner import (
     DEFAULT_LIVE_SMOKE_STEPS,
     DEFAULT_TINKER_MODEL,
@@ -51,6 +52,18 @@ _CONFIG_PATH = Path("configs/current.json")  # the JSON file apply_patch/revert_
 _MAX_NO_IMPROVE = 3   # halt after this many consecutive non-improving iterations
 _MAX_ITERATIONS = 20  # hard cap on total iterations regardless of improvement
 _EXPERIMENT_CACHE: dict[str, ExperimentResult] = {}
+
+
+def _diary_path() -> Path:
+    return resolve_output_path(_DIARY_PATH, "logs", "research_diary.jsonl")
+
+
+def _config_path() -> Path:
+    return resolve_output_path(_CONFIG_PATH, "configs", "current.json")
+
+
+def _experiments_output_dir() -> Path:
+    return resolve_output_path(Path("outputs/experiments"), "experiments")
 
 
 def _patch_to_diff(patch_dict: dict, current_config: dict) -> str:
@@ -156,7 +169,7 @@ def invoke_autoresearch_graph(
         "metrics": final_state["best_score"],
         "cost": cost_breakdown,
         "n_iterations": final_state["iteration"],
-        "research_diary_path": str(_DIARY_PATH),
+        "research_diary_path": str(_diary_path()),
     }
 
 
@@ -227,6 +240,7 @@ def baseline_node(state: AutoResearchState) -> dict:
         _training_config_from_state(state),
         _dataset_result_from_plan(state["plan"]),
         max_steps=_max_steps_from_state(state),
+        output_dir=str(_experiments_output_dir()),
     )
     baseline_score = run_evals(experiment["model_path"], state["eval_suite"])
 
@@ -273,7 +287,7 @@ def propose_node(state: AutoResearchState) -> dict:
     )
 
     # Bug fix: patch the config JSON, not the training script (.py files are not patchable).
-    original_content = apply_patch(str(_CONFIG_PATH), hypothesis["patch"])
+    original_content = apply_patch(str(_config_path()), hypothesis["patch"])
 
     log_event(
         AgentName.AUTORESEARCH,
@@ -309,6 +323,7 @@ def run_node(state: AutoResearchState) -> dict:
         _training_config_from_state(state),
         _dataset_result_from_plan(state["plan"]),
         max_steps=_max_steps_from_state(state),
+        output_dir=str(_experiments_output_dir()),
     )
 
     log_event(
@@ -323,7 +338,7 @@ def run_node(state: AutoResearchState) -> dict:
 
 def revert_and_continue_node(state: AutoResearchState) -> dict:
     """LangGraph node (early stop path). Calls revert_patch(), logs REVERTED, increments iteration. Returns: { current_script, diary, iteration }."""
-    revert_patch(str(_CONFIG_PATH), state["original_content"])
+    revert_patch(str(_config_path()), state["original_content"])
 
     log_event(
         AgentName.AUTORESEARCH,
@@ -414,7 +429,7 @@ def keep_node(state: AutoResearchState) -> dict:
 
 def revert_node(state: AutoResearchState) -> dict:
     """LangGraph node. Calls revert_patch(). Increments no_improve_streak. Returns: { current_script, no_improve_streak }."""
-    revert_patch(str(_CONFIG_PATH), state["original_content"])
+    revert_patch(str(_config_path()), state["original_content"])
 
     new_streak = state["no_improve_streak"] + 1
     log_event(
@@ -715,8 +730,9 @@ def _training_config_from_state(state: AutoResearchState) -> TrainingConfig:
 
 
 def _training_config_from_plan(plan: TrainingPlan) -> TrainingConfig:
-    if _CONFIG_PATH.exists():
-        data = TrainingConfig.load(_CONFIG_PATH).to_dict()
+    config_path = _config_path()
+    if config_path.exists():
+        data = TrainingConfig.load(config_path).to_dict()
     else:
         data = {"model_name": plan.get("base_model") or DEFAULT_TINKER_MODEL}
     data["model_name"] = plan.get("base_model") or data.get("model_name") or DEFAULT_TINKER_MODEL
@@ -752,6 +768,7 @@ def submit_experiment(
         _training_config_from_plan(plan),
         _dataset_result_from_plan(plan),
         max_steps=DEFAULT_LIVE_SMOKE_STEPS,
+        output_dir=str(_experiments_output_dir()),
     )
     _EXPERIMENT_CACHE[result["job_id"]] = result
     return result["job_id"]
@@ -763,7 +780,7 @@ def wait_for_experiment(job_id: str, timeout_min: int) -> ExperimentResult:
     if job_id in _EXPERIMENT_CACHE:
         return _EXPERIMENT_CACHE[job_id]
 
-    run_dir = Path("outputs/experiments") / job_id
+    run_dir = _experiments_output_dir() / job_id
     metrics_path = run_dir / "metrics.json"
     if not metrics_path.exists():
         raise TimeoutError(f"Tinker run {job_id} has no metrics artifact")
@@ -847,8 +864,9 @@ def decide_keep_or_revert(delta: ScoreDelta) -> Literal["KEEP", "REVERT"]:
 
 def log_iteration(diary: ResearchDiary, record: IterationRecord) -> ResearchDiary:
     """Appends an IterationRecord to the research diary and writes to disk as JSONL."""
-    _DIARY_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with open(_DIARY_PATH, "a") as f:
+    diary_path = _diary_path()
+    diary_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(diary_path, "a") as f:
         f.write(json.dumps(record) + "\n")
     return [*diary, record]
 

--- a/src/data_generator/artifacts.py
+++ b/src/data_generator/artifacts.py
@@ -7,6 +7,8 @@ from typing import Any
 from uuid import uuid4
 from datetime import datetime, timezone
 
+from src.runtime_context import get_output_root
+
 
 def save_subagent2_artifacts(handoff: dict[str, Any]) -> dict[str, str]:
     """
@@ -82,6 +84,10 @@ def _resolve_output_dir(handoff: dict[str, Any]) -> Path:
     configured = os.getenv("DATA_GENERATOR_ARTIFACT_DIR", "").strip()
     if configured:
         return Path(configured)
+
+    root = get_output_root()
+    if root is not None:
+        return root / "data_generator" / "artifacts"
 
     root = Path("artifacts") / "data_generator"
     run_stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")

--- a/src/data_generator/curation.py
+++ b/src/data_generator/curation.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
+from src.runtime_context import get_output_root
 from src.types import DatasetResult, StandardDataset, ValidationReport
 
 _INPUT_KEYS = ("input", "prompt", "question", "content", "text", "utterance")
@@ -49,7 +50,7 @@ def curate_handoff_to_dataset_result(
         except ValueError as exc:
             issues.append(f"row {index}: {exc}")
 
-    output_path = Path(output_dir) / filename
+    output_path = _curated_output_path(output_dir, filename)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with open(output_path, "w") as fh:
         for record in curated:
@@ -96,6 +97,13 @@ def curate_handoff_to_dataset_result(
         "quality_notes": quality_notes,
         "validation_report": validation_report,
     }
+
+
+def _curated_output_path(output_dir: str, filename: str) -> Path:
+    root = get_output_root()
+    if root is not None and output_dir == "outputs/datasets":
+        return root / "datasets" / filename
+    return Path(output_dir) / filename
 
 
 def curate_record(

--- a/src/decision_engine/decision_engine.py
+++ b/src/decision_engine/decision_engine.py
@@ -9,8 +9,10 @@ estimates cost, and writes the training script passed to AutoResearch.
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from textwrap import dedent
 
+from src.runtime_context import get_output_root
 from src.types import (
     CostEstimate,
     DatasetResult,
@@ -157,8 +159,7 @@ def write_finetune_script(
     config: OrchestrationConfig,
 ) -> str:
     """Generates a complete LoRA fine-tuning train.py. Returns the path to the written script."""
-    os.makedirs("outputs/scripts", exist_ok=True)
-    path = "outputs/scripts/train.py"
+    path = _training_script_path()
     hp = config["training_procedure"]["hyperparameters"]
 
     script = dedent(f"""\
@@ -222,8 +223,7 @@ def write_pretrain_script(
     config: OrchestrationConfig,
 ) -> str:
     """Generates a from-scratch train.py for pre-training. Returns the path to the written script."""
-    os.makedirs("outputs/scripts", exist_ok=True)
-    path = "outputs/scripts/train.py"
+    path = _training_script_path()
     hp = config["training_procedure"]["hyperparameters"]
 
     script = dedent(f"""\
@@ -267,3 +267,14 @@ def write_pretrain_script(
     with open(path, "w") as f:
         f.write(script)
     return os.path.abspath(path)
+
+
+def _training_script_path() -> str:
+    root = get_output_root()
+    path = (
+        root / "scripts" / "train.py"
+        if root is not None
+        else Path("outputs/scripts/train.py")
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return str(path)

--- a/src/manager/manager.py
+++ b/src/manager/manager.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 import json
 import os
 from datetime import datetime, timezone
+from pathlib import Path
 
+from src.runtime_context import get_output_root
 from src.types import (
     DatasetResult,
     ManagerState,
@@ -175,8 +177,17 @@ def log_decision(step: str, rationale: str, config: OrchestrationConfig) -> None
         "rationale": rationale,
         "config_snapshot": dict(config),
     }
-    with open(LOG_PATH, "a") as f:
+    log_path = _decision_log_path()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(log_path, "a") as f:
         f.write(json.dumps(entry) + "\n")
+
+
+def _decision_log_path() -> Path:
+    root = get_output_root()
+    if root is not None:
+        return root / "decisions.jsonl"
+    return Path(os.environ.get("DECISIONS_LOG", LOG_PATH))
 
 
 def reason_about_task(prompt: str, budget: float, has_data: bool) -> TaskReasoning:

--- a/src/runtime_context.py
+++ b/src/runtime_context.py
@@ -1,0 +1,35 @@
+"""Run-scoped runtime context for mutable output paths."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from pathlib import Path
+
+_OUTPUT_ROOT: ContextVar[Path | None] = ContextVar("output_root", default=None)
+
+
+def get_output_root() -> Path | None:
+    """Return the current run-scoped output root, if one is active."""
+    return _OUTPUT_ROOT.get()
+
+
+def resolve_output_path(default: str | Path, *run_parts: str) -> Path:
+    """Resolve a path under the active run root, otherwise return ``default``."""
+    root = get_output_root()
+    if root is None:
+        return Path(default)
+    return root.joinpath(*run_parts)
+
+
+@contextmanager
+def output_root(path: str | Path) -> Iterator[Path]:
+    """Temporarily route mutable outputs under ``path`` for this context."""
+    root = Path(path)
+    root.mkdir(parents=True, exist_ok=True)
+    token = _OUTPUT_ROOT.set(root)
+    try:
+        yield root
+    finally:
+        _OUTPUT_ROOT.reset(token)

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -8,6 +8,7 @@ added later once observability emits run-scoped events.
 from __future__ import annotations
 
 import json
+import os
 import threading
 import uuid
 from dataclasses import dataclass, field
@@ -19,6 +20,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 
 from src.manager.manager import invoke_manager_graph
+from src.runtime_context import output_root
 from src.server.schemas import (
     IterationView,
     LogEntryView,
@@ -38,6 +40,7 @@ STAGE_LABELS = [
     "AutoResearch",
     "Finalization",
 ]
+RUN_OUTPUT_ROOT = Path(os.getenv("MANAGER_RUN_OUTPUT_ROOT", "outputs/api-runs"))
 
 
 app = FastAPI(title="Nemoral ML Agent API")
@@ -54,6 +57,7 @@ app.add_middleware(
 class _RunRecord:
     run_id: str
     request: RunRequest
+    output_dir: Path
     status: str = "running"
     stage: int = 0
     cost_spent: float = 0.0
@@ -183,11 +187,12 @@ def _run_manager(record: _RunRecord) -> None:
         _append_log(record, "Manager", "Manager graph is running")
 
     try:
-        result = invoke_manager_graph(
-            record.request.prompt,
-            record.request.budget,
-            record.request.data_path,
-        )
+        with output_root(record.output_dir):
+            result = invoke_manager_graph(
+                record.request.prompt,
+                record.request.budget,
+                record.request.data_path,
+            )
     except Exception as exc:  # surfaced to the browser as a failed run state
         with _LOCK:
             _fail_current_stage(record, str(exc))
@@ -226,7 +231,13 @@ def create_run(request: RunRequest) -> RunCreated:
         raise HTTPException(status_code=400, detail="data_path does not exist")
 
     run_id = str(uuid.uuid4())
-    record = _RunRecord(run_id=run_id, request=request, stages=_initial_stages())
+    output_dir = RUN_OUTPUT_ROOT / run_id
+    record = _RunRecord(
+        run_id=run_id,
+        request=request,
+        output_dir=output_dir,
+        stages=_initial_stages(),
+    )
     with _LOCK:
         _RUNS[run_id] = record
 

--- a/tests/test_runtime_context.py
+++ b/tests/test_runtime_context.py
@@ -1,0 +1,94 @@
+"""Tests for run-scoped mutable output routing."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.autoresearch import autoresearch as ar
+from src.data_generator.curation import curate_handoff_to_dataset_result
+from src.decision_engine.decision_engine import write_finetune_script
+from src.manager.manager import build_orchestration_config, log_decision
+from src.runtime_context import output_root
+
+
+def test_output_root_routes_manager_datagen_decision_and_autoresearch(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    run_root = tmp_path / "runs" / "run-123"
+
+    config = build_orchestration_config(
+        {
+            "task_type": "text-classification",
+            "data_format": "jsonl",
+            "training_type": "SFT",
+            "suggested_base_model": None,
+            "hyperparameters": {
+                "learning_rate": 1e-4,
+                "batch_size": 2,
+                "epochs": 1,
+                "max_seq_len": 128,
+            },
+            "notes": "test",
+        },
+        "classify sentiment",
+        10.0,
+        False,
+    )
+
+    with output_root(run_root):
+        log_decision("build_config", "test rationale", config)
+        dataset = curate_handoff_to_dataset_result(
+            {
+                "mode_used": "B",
+                "raw_data": {
+                    "records": [
+                        {"input": "great", "output": "positive"},
+                        {"input": "bad", "output": "negative"},
+                        {"input": "ok", "output": "neutral"},
+                    ]
+                },
+            }
+        )
+        script_path = write_finetune_script(
+            "Qwen/Qwen3.5-9B",
+            dataset,
+            {
+                "rank": 8,
+                "alpha": 16,
+                "dropout": 0.05,
+                "target_modules": ["query", "value"],
+            },
+            config,
+        )
+        ar.log_iteration(
+            [],
+            {
+                "iteration": 1,
+                "hypothesis": "test",
+                "patch": "",
+                "cost_usd": 0.0,
+                "metrics": {
+                    "train_loss": 1.0,
+                    "val_loss": 1.0,
+                    "test_loss": 1.0,
+                    "primary_metric": 0.5,
+                },
+                "decision": "PENDING",
+                "notes": "",
+            },
+        )
+
+    assert (run_root / "decisions.jsonl").is_file()
+    assert Path(dataset["dataset"]["path"]) == run_root / "datasets" / "train_data.jsonl"
+    assert Path(script_path) == run_root / "scripts" / "train.py"
+    assert (run_root / "logs" / "research_diary.jsonl").is_file()
+
+    assert not Path("decisions.jsonl").exists()
+    assert not Path("outputs/datasets/train_data.jsonl").exists()
+    assert not Path("outputs/scripts/train.py").exists()
+
+    diary_line = (run_root / "logs" / "research_diary.jsonl").read_text().strip()
+    assert json.loads(diary_line)["decision"] == "PENDING"

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import json
 import time
+from pathlib import Path
 
 from fastapi.testclient import TestClient
 
+from src.runtime_context import get_output_root
 from src.server import app as server_app
 
 
@@ -77,11 +79,36 @@ def test_health_check():
 
 
 def test_create_run_completes_with_manager_result(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     calls = []
+    roots = []
 
     def fake_invoke(prompt, budget, data_path=None):
         calls.append((prompt, budget, data_path))
-        return _fake_model(tmp_path)
+        root = get_output_root()
+        assert root is not None
+        roots.append(root)
+
+        from src.manager.manager import build_orchestration_config, log_decision
+
+        log_decision(
+            "server_run",
+            "run-scoped output test",
+            build_orchestration_config(
+                {
+                    "task_type": "text-classification",
+                    "data_format": "jsonl",
+                    "training_type": "SFT",
+                    "suggested_base_model": None,
+                    "hyperparameters": {},
+                    "notes": "test",
+                },
+                prompt,
+                budget,
+                False,
+            ),
+        )
+        return _fake_model(root)
 
     monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
     client = TestClient(server_app.app)
@@ -103,6 +130,10 @@ def test_create_run_completes_with_manager_result(tmp_path, monkeypatch):
     assert calls == [
         ("Fine tune a small chat assistant on support tickets", 25.0, None)
     ]
+    assert len(roots) == 1
+    assert roots[0] == Path("outputs/api-runs") / run_id
+    assert (roots[0] / "decisions.jsonl").is_file()
+    assert not Path("decisions.jsonl").exists()
     assert state["costSpent"] == 1.25
     assert state["metrics"][0]["loss"] == 0.29
     assert state["metrics"][0]["accuracy"] == 0.775
@@ -110,8 +141,11 @@ def test_create_run_completes_with_manager_result(tmp_path, monkeypatch):
     assert state["result"]["weights_path"] == "outputs/experiments/run/model"
 
 
-def test_create_run_surfaces_manager_failure(monkeypatch):
+def test_create_run_surfaces_manager_failure(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
     def fail_invoke(prompt, budget, data_path=None):
+        assert get_output_root() is not None
         raise RuntimeError("DataGen did not produce a trainable dataset")
 
     monkeypatch.setattr(server_app, "invoke_manager_graph", fail_invoke)
@@ -132,7 +166,9 @@ def test_create_run_surfaces_manager_failure(monkeypatch):
     assert state["logs"][0]["type"] == "error"
 
 
-def test_missing_data_path_is_rejected_before_background_run(monkeypatch):
+def test_missing_data_path_is_rejected_before_background_run(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
     def fail_invoke(prompt, budget, data_path=None):
         raise AssertionError("manager should not be called for missing data_path")
 


### PR DESCRIPTION
## Summary
- Add a contextvars-based runtime output root for background/API Manager runs.
- Route Manager decisions, DataGen curation/artifacts, DecisionEngine scripts, AutoResearch config/diary, and Tinker experiment output directories under each API run root.
- Keep existing CLI/test defaults unchanged when no runtime output root is active.

## Validation
- python3 -m compileall src tests/test_runtime_context.py
- uv run --with pytest --with fastapi --with httpx --with anthropic --with langgraph python -m pytest tests/test_runtime_context.py tests/test_server_api.py tests/test_manager.py tests/test_autoresearch.py tests/test_data_curation.py -q
- uv run --with pytest --with fastapi --with httpx --with anthropic --with langgraph python -m pytest tests/test_server_api.py tests/test_runtime_context.py -q
- uv run --with pytest --with anthropic --with langgraph --with fastapi --with httpx --with datasets --with huggingface-hub --with requests python -m pytest tests -q --ignore=tests/data_generator/test_mode_b_hf_retrieval.py
- npm ci
- npm run lint
- npm run build

## Notes
The broad suite on this branch base still has an older ungated live Hugging Face retrieval file, so the final broad run explicitly ignored `tests/data_generator/test_mode_b_hf_retrieval.py`. I accidentally started it once, stopped it after it began downloading public HF datasets, and reran with the ignore flag. No paid provider spend was involved.