### PR TITLE
[codex] expose API run artifacts

### DIFF
--- a/ml-agent-frontend/src/components/FinalResults.tsx
+++ b/ml-agent-frontend/src/components/FinalResults.tsx
@@ -1,3 +1,4 @@
+import { getApiBaseUrl } from '../api/runs';
 import type { TrainingState } from '../types';
 import Tooltip from './Tooltip';
 
@@ -24,6 +25,9 @@ const RESULT_TOOLTIPS: Record<string, { label: string; body: string }> = {
 export default function FinalResults({ state, onReset }: Props) {
   const lastMetric = state.metrics[state.metrics.length - 1];
   const bestIter = state.iterations.find(i => i.status === 'KEPT') ?? state.iterations[0];
+  const apiBaseUrl = getApiBaseUrl();
+  const artifactFiles = state.artifacts?.files.filter(file => file.exists) ?? [];
+  const checkpointEntries = Object.entries(state.artifacts?.checkpoints ?? {}).filter(([, value]) => value);
 
   const handleExportDiary = () => {
     const diary = {
@@ -35,6 +39,8 @@ export default function FinalResults({ state, onReset }: Props) {
       iterations: state.iterations,
       metrics: state.metrics,
       logs: state.logs,
+      artifacts: state.artifacts ?? null,
+      result: state.result ?? null,
     };
     const blob = new Blob([JSON.stringify(diary, null, 2)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
@@ -50,6 +56,14 @@ export default function FinalResults({ state, onReset }: Props) {
     { label: 'Val Accuracy', value: lastMetric ? `${(lastMetric.accuracy * 100).toFixed(1)}%` : '—' },
     { label: 'Total Cost', value: `$${state.costSpent.toFixed(2)}` },
   ];
+  const artifactHref = (downloadPath?: string | null) => (
+    apiBaseUrl && downloadPath ? `${apiBaseUrl}${downloadPath}` : null
+  );
+  const compactPath = (value?: string | null) => {
+    if (!value) return '—';
+    if (value.length <= 72) return value;
+    return `…${value.slice(-69)}`;
+  };
 
   return (
     <section
@@ -109,6 +123,61 @@ export default function FinalResults({ state, onReset }: Props) {
           );
         })}
       </div>
+
+      {state.artifacts && (
+        <div style={{
+          borderTop: '0.5px solid var(--border)',
+          paddingTop: '1rem',
+          marginBottom: '1.5rem',
+          textAlign: 'left',
+        }}>
+          <p style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '0.5rem' }}>
+            Artifacts
+          </p>
+          <div style={{ display: 'grid', gap: '0.4rem' }}>
+            {state.artifacts.modelPath && (
+              <div style={{ display: 'grid', gridTemplateColumns: '96px 1fr', gap: '0.75rem', alignItems: 'center' }}>
+                <span style={{ fontSize: '11px', color: 'var(--text-muted)' }}>Model</span>
+                <code style={{ fontSize: '11px', color: 'var(--text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {compactPath(state.artifacts.modelPath)}
+                </code>
+              </div>
+            )}
+            {artifactFiles.map(file => {
+              const href = artifactHref(file.downloadPath);
+              return (
+                <div
+                  key={file.name}
+                  style={{ display: 'grid', gridTemplateColumns: '96px 1fr auto', gap: '0.75rem', alignItems: 'center' }}
+                >
+                  <span style={{ fontSize: '11px', color: 'var(--text-muted)' }}>{file.label}</span>
+                  <code style={{ fontSize: '11px', color: 'var(--text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {compactPath(file.path)}
+                  </code>
+                  {href && (
+                    <a
+                      href={href}
+                      target="_blank"
+                      rel="noreferrer"
+                      style={{ fontSize: '11px', color: 'var(--accent)', textDecoration: 'none' }}
+                    >
+                      Open
+                    </a>
+                  )}
+                </div>
+              );
+            })}
+            {checkpointEntries.map(([key, value]) => (
+              <div key={key} style={{ display: 'grid', gridTemplateColumns: '96px 1fr', gap: '0.75rem', alignItems: 'center' }}>
+                <span style={{ fontSize: '11px', color: 'var(--text-muted)' }}>{key}</span>
+                <code style={{ fontSize: '11px', color: 'var(--text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {String(value)}
+                </code>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'center', flexWrap: 'wrap' }}>
         <span style={{ position: 'relative', display: 'inline-flex', alignItems: 'center', gap: '4px' }}>

--- a/ml-agent-frontend/src/hooks/useTrainingRun.ts
+++ b/ml-agent-frontend/src/hooks/useTrainingRun.ts
@@ -15,6 +15,8 @@ function makeInitialState(): TrainingState {
     iterations: [],
     logs: [],
     stages: [],
+    artifacts: null,
+    result: null,
     error: null,
   };
 }
@@ -44,6 +46,8 @@ function makeStartingState(
       { id: 4, label: 'AutoResearch', status: 'pending' },
       { id: 5, label: 'Finalization', status: 'pending' },
     ],
+    artifacts: null,
+    result: null,
     error: null,
   };
 }
@@ -75,6 +79,8 @@ export function useTrainingRun() {
       iterations: next.iterations,
       logs: next.logs,
       stages: next.stages,
+      artifacts: next.artifacts ?? null,
+      result: next.result ?? null,
       error: next.error,
       runId: next.run_id,
     });

--- a/ml-agent-frontend/src/hooks/useTrainingSimulation.ts
+++ b/ml-agent-frontend/src/hooks/useTrainingSimulation.ts
@@ -111,6 +111,8 @@ export function useTrainingSimulation() {
     iterations: [],
     logs: [],
     stages: makeStages(),
+    artifacts: null,
+    result: null,
   });
 
   const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
@@ -147,6 +149,8 @@ export function useTrainingSimulation() {
       iterations: [],
       logs: [],
       stages: makeStages(),
+      artifacts: null,
+      result: null,
     });
 
     let cursor = 0; // ms elapsed
@@ -258,6 +262,8 @@ export function useTrainingSimulation() {
       iterations: [],
       logs: [],
       stages: makeStages(),
+      artifacts: null,
+      result: null,
     });
   }, []);
 

--- a/ml-agent-frontend/src/types.ts
+++ b/ml-agent-frontend/src/types.ts
@@ -38,6 +38,24 @@ export interface LogEntry {
   type: LogType;
 }
 
+export interface ArtifactFile {
+  name: string;
+  label: string;
+  path?: string | null;
+  exists: boolean;
+  sizeBytes?: number | null;
+  contentType: string;
+  downloadPath?: string | null;
+}
+
+export interface RunArtifacts {
+  modelPath?: string | null;
+  checkpoints: Record<string, unknown>;
+  metrics?: Record<string, unknown> | null;
+  sample?: Record<string, unknown> | null;
+  files: ArtifactFile[];
+}
+
 export interface TrainingState {
   status: 'idle' | 'running' | 'complete' | 'failed';
   stage: number;
@@ -50,6 +68,8 @@ export interface TrainingState {
   iterations: Iteration[];
   logs: LogEntry[];
   stages: PipelineStage[];
+  artifacts?: RunArtifacts | null;
+  result?: Record<string, unknown> | null;
   error?: string | null;
   runId?: string;
 }

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -17,16 +17,19 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
 from fastapi.middleware.cors import CORSMiddleware
 
 from src.data_sources import looks_like_local_data_path, normalize_hf_dataset_source
 from src.manager.manager import invoke_manager_graph
 from src.runtime_context import output_root
 from src.server.schemas import (
+    ArtifactView,
     IterationView,
     LogEntryView,
     MetricPoint,
     PipelineStage,
+    RunArtifactsView,
     RunCreated,
     RunRequest,
     RunState,
@@ -42,6 +45,13 @@ STAGE_LABELS = [
     "Finalization",
 ]
 RUN_OUTPUT_ROOT = Path(os.getenv("MANAGER_RUN_OUTPUT_ROOT", "outputs/api-runs"))
+ARTIFACT_DEFINITIONS = {
+    "manifest": ("Manifest", "manifest.json", "application/json"),
+    "metrics": ("Metrics", "metrics.json", "application/json"),
+    "metrics_log": ("Metrics Log", "metrics.jsonl", "application/x-ndjson"),
+    "sample": ("Sample", "sample.json", "application/json"),
+    "diary": ("Research Diary", None, "application/x-ndjson"),
+}
 
 
 app = FastAPI(title="Nemoral ML Agent API")
@@ -66,6 +76,9 @@ class _RunRecord:
     iterations: list[IterationView] = field(default_factory=list)
     logs: list[LogEntryView] = field(default_factory=list)
     result: dict[str, Any] | None = None
+    artifacts: RunArtifactsView | None = None
+    artifact_paths: dict[str, Path] = field(default_factory=dict)
+    artifact_content_types: dict[str, str] = field(default_factory=dict)
     error: str | None = None
     stages: list[PipelineStage] = field(default_factory=list)
 
@@ -204,6 +217,108 @@ def _iterations_from_diary(path: str | None) -> list[IterationView]:
     return list(reversed(iterations))
 
 
+def _read_json_if_exists(path: Path | None) -> dict[str, Any] | None:
+    if path is None or not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _resolve_reported_path(record: _RunRecord, value: Any) -> Path | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+
+    raw_path = Path(value).expanduser()
+    if raw_path.is_absolute():
+        return raw_path
+
+    candidates = [
+        raw_path,
+        record.output_dir / raw_path,
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return raw_path
+
+
+def _artifact_view(
+    *,
+    run_id: str,
+    name: str,
+    label: str,
+    path: Path | None,
+    content_type: str,
+    downloadable: bool,
+) -> ArtifactView:
+    exists = bool(path and path.is_file())
+    return ArtifactView(
+        name=name,
+        label=label,
+        path=str(path) if path else None,
+        exists=exists,
+        sizeBytes=path.stat().st_size if exists and path is not None else None,
+        contentType=content_type,
+        downloadPath=f"/runs/{run_id}/artifacts/{name}" if downloadable else None,
+    )
+
+
+def _is_run_artifact_path(record: _RunRecord, path: Path | None) -> bool:
+    if path is None or not path.is_file():
+        return False
+    try:
+        path.resolve().relative_to(record.output_dir.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def _artifacts_from_result(record: _RunRecord, result: dict[str, Any]) -> RunArtifactsView:
+    model_path = _resolve_reported_path(record, result.get("weights_path"))
+    diary_path = _resolve_reported_path(record, result.get("research_diary_path"))
+
+    files: list[ArtifactView] = []
+    artifact_paths: dict[str, Path] = {}
+    artifact_content_types: dict[str, str] = {}
+
+    for name, (label, filename, content_type) in ARTIFACT_DEFINITIONS.items():
+        if name == "diary":
+            path = diary_path
+        else:
+            path = model_path / filename if model_path and filename else None
+        downloadable = _is_run_artifact_path(record, path)
+        view = _artifact_view(
+            run_id=record.run_id,
+            name=name,
+            label=label,
+            path=path,
+            content_type=content_type,
+            downloadable=downloadable,
+        )
+        files.append(view)
+        if downloadable and path is not None:
+            artifact_paths[name] = path
+            artifact_content_types[name] = content_type
+
+    manifest = _read_json_if_exists(artifact_paths.get("manifest"))
+    checkpoints = manifest.get("checkpoints", {}) if manifest else {}
+    metrics = _read_json_if_exists(artifact_paths.get("metrics"))
+    sample = _read_json_if_exists(artifact_paths.get("sample"))
+
+    record.artifact_paths = artifact_paths
+    record.artifact_content_types = artifact_content_types
+    return RunArtifactsView(
+        modelPath=str(model_path) if model_path else None,
+        checkpoints=checkpoints if isinstance(checkpoints, dict) else {},
+        metrics=metrics,
+        sample=sample,
+        files=files,
+    )
+
+
 def _store_manager_result(record: _RunRecord, result: dict[str, Any]) -> None:
     record.result = result
     record.status = "complete"
@@ -211,6 +326,7 @@ def _store_manager_result(record: _RunRecord, result: dict[str, Any]) -> None:
     metric = _metric_from_result(result)
     record.metrics = [metric] if metric else []
     record.iterations = _iterations_from_diary(result.get("research_diary_path"))
+    record.artifacts = _artifacts_from_result(record, result)
     _complete_all_stages(record)
     _append_log(record, "Manager", "Training pipeline complete", "success")
 
@@ -253,6 +369,7 @@ def _to_state(record: _RunRecord) -> RunState:
         iterations=record.iterations,
         logs=record.logs,
         stages=record.stages,
+        artifacts=record.artifacts,
         result=record.result,
         error=record.error,
     )
@@ -291,6 +408,22 @@ def get_run(run_id: str) -> RunState:
         if record is None:
             raise HTTPException(status_code=404, detail="run not found")
         return _to_state(record)
+
+
+@app.get("/api/runs/{run_id}/artifacts/{artifact_name}")
+def get_run_artifact(run_id: str, artifact_name: str) -> FileResponse:
+    with _LOCK:
+        record = _RUNS.get(run_id)
+        if record is None:
+            raise HTTPException(status_code=404, detail="run not found")
+        if artifact_name not in ARTIFACT_DEFINITIONS:
+            raise HTTPException(status_code=404, detail="artifact not found")
+        path = record.artifact_paths.get(artifact_name)
+        content_type = record.artifact_content_types.get(artifact_name)
+
+    if path is None or not path.is_file() or content_type is None:
+        raise HTTPException(status_code=404, detail="artifact not found")
+    return FileResponse(path, media_type=content_type, filename=path.name)
 
 
 def _reset_runs_for_tests() -> None:

--- a/src/server/schemas.py
+++ b/src/server/schemas.py
@@ -47,6 +47,24 @@ class LogEntryView(BaseModel):
     type: Literal["default", "success", "warning", "error"]
 
 
+class ArtifactView(BaseModel):
+    name: str
+    label: str
+    path: str | None = None
+    exists: bool
+    sizeBytes: int | None = None
+    contentType: str
+    downloadPath: str | None = None
+
+
+class RunArtifactsView(BaseModel):
+    modelPath: str | None = None
+    checkpoints: dict[str, Any] = Field(default_factory=dict)
+    metrics: dict[str, Any] | None = None
+    sample: dict[str, Any] | None = None
+    files: list[ArtifactView] = Field(default_factory=list)
+
+
 class RunState(BaseModel):
     run_id: str
     status: Literal["running", "complete", "failed"]
@@ -60,5 +78,6 @@ class RunState(BaseModel):
     iterations: list[IterationView]
     logs: list[LogEntryView]
     stages: list[PipelineStage]
+    artifacts: RunArtifactsView | None = None
     result: dict[str, Any] | None = None
     error: str | None = None

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -13,7 +13,7 @@ from src.runtime_context import get_output_root
 from src.server import app as server_app
 
 
-def _fake_model(tmp_path, *, total_cost=1.25):
+def _fake_model(tmp_path, *, total_cost=1.25, with_artifacts=False):
     diary_path = tmp_path / "diary.jsonl"
     diary_path.write_text(
         json.dumps(
@@ -32,8 +32,45 @@ def _fake_model(tmp_path, *, total_cost=1.25):
         + "\n",
         encoding="utf-8",
     )
+    weights_path = "outputs/experiments/run/model"
+    if with_artifacts:
+        run_dir = tmp_path / "experiments" / "tinker-run"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        weights_path = str(run_dir)
+        (run_dir / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "run_id": "tinker-run",
+                    "status": "COMPLETED",
+                    "checkpoints": {
+                        "state_path": "tinker://state/abc",
+                        "sampler_path": "tinker://sampler/abc",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        (run_dir / "metrics.json").write_text(
+            json.dumps(
+                {
+                    "train_loss": 0.31,
+                    "val_loss": 0.29,
+                    "test_loss": 0.33,
+                    "primary_metric": 0.775,
+                }
+            ),
+            encoding="utf-8",
+        )
+        (run_dir / "metrics.jsonl").write_text(
+            json.dumps({"step": 1, "val_loss": 0.29}) + "\n",
+            encoding="utf-8",
+        )
+        (run_dir / "sample.json").write_text(
+            json.dumps({"text": "sample completion"}),
+            encoding="utf-8",
+        )
     return {
-        "weights_path": "outputs/experiments/run/model",
+        "weights_path": weights_path,
         "metrics": {
             "scalar": 0.775,
             "metrics": {
@@ -141,6 +178,53 @@ def test_create_run_completes_with_manager_result(tmp_path, monkeypatch):
     assert state["metrics"][0]["accuracy"] == 0.775
     assert state["iterations"][0]["status"] == "KEPT"
     assert state["result"]["weights_path"] == "outputs/experiments/run/model"
+
+
+def test_create_run_surfaces_artifacts_and_allowlisted_downloads(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def fake_invoke(prompt, budget, data_path=None):
+        root = get_output_root()
+        assert root is not None
+        return _fake_model(root, total_cost=0.5, with_artifacts=True)
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune a small chat assistant on support tickets",
+            "budget": 25,
+            "task_type": "fine-tuning",
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    state = _wait_for_status(client, run_id, "complete")
+
+    artifacts = state["artifacts"]
+    assert artifacts["modelPath"].endswith(f"outputs/api-runs/{run_id}/experiments/tinker-run")
+    assert artifacts["checkpoints"]["state_path"] == "tinker://state/abc"
+    assert artifacts["metrics"]["val_loss"] == 0.29
+    assert artifacts["sample"]["text"] == "sample completion"
+
+    files = {item["name"]: item for item in artifacts["files"]}
+    assert files["manifest"]["exists"] is True
+    assert files["manifest"]["downloadPath"] == f"/runs/{run_id}/artifacts/manifest"
+    assert files["metrics_log"]["contentType"] == "application/x-ndjson"
+
+    manifest_response = client.get(f"/api/runs/{run_id}/artifacts/manifest")
+    assert manifest_response.status_code == 200
+    assert manifest_response.json()["checkpoints"]["sampler_path"] == "tinker://sampler/abc"
+
+    metrics_log_response = client.get(f"/api/runs/{run_id}/artifacts/metrics_log")
+    assert metrics_log_response.status_code == 200
+    assert '"step": 1' in metrics_log_response.text
+
+    missing_response = client.get(f"/api/runs/{run_id}/artifacts/not-real")
+    assert missing_response.status_code == 404
 
 
 def test_create_run_passes_existing_local_data_path(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add a typed run artifact summary to the FastAPI run state
- expose allowlisted run-local artifact downloads for manifest, metrics, metrics log, sample, and diary files
- show completed artifacts/checkpoints in the frontend final results and include them in diary export

## Validation
- python3 -m compileall src tests/test_server_api.py
- uv run --with pytest --with fastapi --with httpx --with anthropic --with langgraph python -m pytest tests/test_server_api.py tests/test_data_sources.py tests/test_manager.py -q
- npm ci
- npm run lint
- npm run build
- uv run --with pytest --with anthropic --with langgraph --with fastapi --with httpx --with datasets --with huggingface-hub --with requests python -m pytest tests -q --ignore=tests/data_generator/test_mode_b_hf_retrieval.py

## Notes
- artifact download links are only registered for files inside the run output directory, so returned paths outside the run folder are surfaced as metadata but not served by the API