### PR TITLE
[codex] add API progress refresh and cancellation

### DIFF
--- a/ml-agent-frontend/src/App.tsx
+++ b/ml-agent-frontend/src/App.tsx
@@ -9,7 +9,7 @@ export default function App() {
   const simulation = useTrainingSimulation();
   const backend = useTrainingRun();
   const controller = isBackendApiConfigured() ? backend : simulation;
-  const { state, start, reset } = controller;
+  const { state, start, reset, cancel } = controller;
 
   const handleStart: StartTraining = (prompt, budget, taskType, dataPath = null) => {
     return start(prompt, budget, taskType, dataPath);
@@ -19,5 +19,5 @@ export default function App() {
     return <InputForm onStart={handleStart} />;
   }
 
-  return <Dashboard state={state} onReset={reset} />;
+  return <Dashboard state={state} onReset={reset} onCancel={cancel} />;
 }

--- a/ml-agent-frontend/src/api/runs.ts
+++ b/ml-agent-frontend/src/api/runs.ts
@@ -57,3 +57,9 @@ export function createRun(request: CreateRunRequest): Promise<CreateRunResponse>
 export function getRun(runId: string): Promise<BackendRunState> {
   return requestJson<BackendRunState>(`/runs/${runId}`);
 }
+
+export function cancelRun(runId: string): Promise<BackendRunState> {
+  return requestJson<BackendRunState>(`/runs/${runId}/cancel`, {
+    method: 'POST',
+  });
+}

--- a/ml-agent-frontend/src/components/Dashboard.tsx
+++ b/ml-agent-frontend/src/components/Dashboard.tsx
@@ -9,6 +9,7 @@ import FinalResults from './FinalResults';
 interface Props {
   state: TrainingState;
   onReset: () => void;
+  onCancel: () => void;
 }
 
 const headerStyle: React.CSSProperties = {
@@ -29,7 +30,7 @@ function StatusDot({ status }: { status: TrainingState['status'] }) {
       ? 'var(--success)'
       : status === 'failed'
         ? 'var(--danger)'
-        : status === 'running'
+        : status === 'running' || status === 'cancelling'
           ? 'var(--accent)'
           : 'var(--text-muted)';
   const label =
@@ -37,7 +38,11 @@ function StatusDot({ status }: { status: TrainingState['status'] }) {
       ? 'COMPLETE'
       : status === 'failed'
         ? 'FAILED'
-        : status === 'running'
+        : status === 'cancelled'
+          ? 'CANCELLED'
+          : status === 'cancelling'
+            ? 'CANCELLING'
+            : status === 'running'
           ? 'RUNNING'
           : 'IDLE';
 
@@ -50,7 +55,7 @@ function StatusDot({ status }: { status: TrainingState['status'] }) {
           borderRadius: '50%',
           background: color,
           display: 'inline-block',
-          animation: status === 'running' ? 'pulse 1.5s ease-in-out infinite' : 'none',
+          animation: status === 'running' || status === 'cancelling' ? 'pulse 1.5s ease-in-out infinite' : 'none',
         }}
       />
       <span style={{ fontSize: '11px', fontWeight: 600, letterSpacing: '0.1em', color }}>
@@ -60,7 +65,9 @@ function StatusDot({ status }: { status: TrainingState['status'] }) {
   );
 }
 
-export default function Dashboard({ state, onReset }: Props) {
+export default function Dashboard({ state, onReset, onCancel }: Props) {
+  const canCancel = state.status === 'running' || state.status === 'cancelling';
+
   return (
     <div style={{ minHeight: '100vh' }}>
       <style>{`
@@ -82,22 +89,43 @@ export default function Dashboard({ state, onReset }: Props) {
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
           <StatusDot status={state.status} />
-          <button
-            onClick={onReset}
-            style={{
-              padding: '4px 10px',
-              background: 'transparent',
-              border: '0.5px solid var(--border)',
-              borderRadius: '6px',
-              color: 'var(--text-secondary)',
-              fontSize: '12px',
-              cursor: 'pointer',
-              fontFamily: 'inherit',
-            }}
-            aria-label="Reset training"
-          >
-            Reset
-          </button>
+          {canCancel ? (
+            <button
+              onClick={onCancel}
+              disabled={state.status === 'cancelling'}
+              style={{
+                padding: '4px 10px',
+                background: 'transparent',
+                border: '0.5px solid var(--warning)',
+                borderRadius: '6px',
+                color: 'var(--warning)',
+                fontSize: '12px',
+                cursor: state.status === 'cancelling' ? 'not-allowed' : 'pointer',
+                opacity: state.status === 'cancelling' ? 0.7 : 1,
+                fontFamily: 'inherit',
+              }}
+              aria-label="Cancel training"
+            >
+              {state.status === 'cancelling' ? 'Cancelling...' : 'Cancel'}
+            </button>
+          ) : (
+            <button
+              onClick={onReset}
+              style={{
+                padding: '4px 10px',
+                background: 'transparent',
+                border: '0.5px solid var(--border)',
+                borderRadius: '6px',
+                color: 'var(--text-secondary)',
+                fontSize: '12px',
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+              }}
+              aria-label="Reset training"
+            >
+              Reset
+            </button>
+          )}
         </div>
       </header>
 
@@ -165,6 +193,26 @@ export default function Dashboard({ state, onReset }: Props) {
             </p>
             <p style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>
               {state.error ?? 'The backend run ended before producing a model.'}
+            </p>
+          </section>
+        )}
+
+        {state.status === 'cancelled' && (
+          <section
+            style={{
+              background: 'var(--bg-surface)',
+              border: '0.5px solid var(--warning)',
+              borderRadius: 'var(--radius)',
+              padding: '0.875rem 1rem',
+              marginBottom: '1.5rem',
+            }}
+            role="status"
+          >
+            <p style={{ fontSize: '12px', fontWeight: 600, color: 'var(--warning)', marginBottom: '0.25rem' }}>
+              Run cancelled
+            </p>
+            <p style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>
+              The backend stopped the training pipeline at the next safe checkpoint.
             </p>
           </section>
         )}

--- a/ml-agent-frontend/src/hooks/useTrainingRun.ts
+++ b/ml-agent-frontend/src/hooks/useTrainingRun.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { createRun, getRun } from '../api/runs';
+import { cancelRun, createRun, getRun, type BackendRunState } from '../api/runs';
 import type { StartTraining, TaskType, TrainingState } from '../types';
 
 function makeInitialState(): TrainingState {
@@ -52,9 +52,34 @@ function makeStartingState(
   };
 }
 
+function isTerminalStatus(status: TrainingState['status']) {
+  return status === 'complete' || status === 'failed' || status === 'cancelled';
+}
+
+function stateFromBackend(next: BackendRunState): TrainingState {
+  return {
+    status: next.status,
+    stage: next.stage,
+    prompt: next.prompt,
+    budget: next.budget,
+    taskType: next.taskType,
+    dataPath: next.dataPath ?? null,
+    costSpent: next.costSpent,
+    metrics: next.metrics,
+    iterations: next.iterations,
+    logs: next.logs,
+    stages: next.stages,
+    artifacts: next.artifacts ?? null,
+    result: next.result ?? null,
+    error: next.error,
+    runId: next.run_id,
+  };
+}
+
 export function useTrainingRun() {
   const [state, setState] = useState<TrainingState>(makeInitialState);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const runIdRef = useRef<string | null>(null);
 
   const stopPolling = useCallback(() => {
     if (pollRef.current) {
@@ -67,25 +92,9 @@ export function useTrainingRun() {
 
   const poll = useCallback(async (runId: string) => {
     const next = await getRun(runId);
-    setState({
-      status: next.status,
-      stage: next.stage,
-      prompt: next.prompt,
-      budget: next.budget,
-      taskType: next.taskType,
-      dataPath: next.dataPath ?? null,
-      costSpent: next.costSpent,
-      metrics: next.metrics,
-      iterations: next.iterations,
-      logs: next.logs,
-      stages: next.stages,
-      artifacts: next.artifacts ?? null,
-      result: next.result ?? null,
-      error: next.error,
-      runId: next.run_id,
-    });
+    setState(stateFromBackend(next));
 
-    if (next.status === 'complete' || next.status === 'failed') {
+    if (isTerminalStatus(next.status)) {
       stopPolling();
     }
   }, [stopPolling]);
@@ -103,6 +112,7 @@ export function useTrainingRun() {
         data_path: normalizedDataPath,
       });
       setState(prev => ({ ...prev, runId: created.run_id }));
+      runIdRef.current = created.run_id;
       await poll(created.run_id);
       pollRef.current = setInterval(() => {
         void poll(created.run_id).catch((error: unknown) => {
@@ -125,8 +135,32 @@ export function useTrainingRun() {
 
   const reset = useCallback(() => {
     stopPolling();
+    runIdRef.current = null;
     setState(makeInitialState());
   }, [stopPolling]);
 
-  return { state, start, reset };
+  const cancel = useCallback(async () => {
+    const runId = runIdRef.current ?? state.runId;
+    if (!runId || isTerminalStatus(state.status)) {
+      return;
+    }
+
+    setState(prev => ({ ...prev, status: 'cancelling' }));
+    try {
+      const next = await cancelRun(runId);
+      setState(stateFromBackend(next));
+      if (isTerminalStatus(next.status)) {
+        stopPolling();
+      }
+    } catch (error) {
+      setState(prev => ({
+        ...prev,
+        status: 'failed',
+        error: error instanceof Error ? error.message : String(error),
+      }));
+      stopPolling();
+    }
+  }, [state.runId, state.status, stopPolling]);
+
+  return { state, start, reset, cancel };
 }

--- a/ml-agent-frontend/src/hooks/useTrainingSimulation.ts
+++ b/ml-agent-frontend/src/hooks/useTrainingSimulation.ts
@@ -267,5 +267,22 @@ export function useTrainingSimulation() {
     });
   }, []);
 
-  return { state, start, reset };
+  const cancel = useCallback(() => {
+    clearTimers();
+    setState(prev => ({
+      ...prev,
+      status: prev.status === 'running' ? 'cancelled' : prev.status,
+      logs: [
+        {
+          time: new Date().toLocaleTimeString('en-US', { hour12: false }),
+          component: 'Manager',
+          message: 'Run cancelled',
+          type: 'warning',
+        },
+        ...prev.logs,
+      ],
+    }));
+  }, []);
+
+  return { state, start, reset, cancel };
 }

--- a/ml-agent-frontend/src/types.ts
+++ b/ml-agent-frontend/src/types.ts
@@ -2,6 +2,7 @@ export type StageStatus = 'pending' | 'in-progress' | 'complete';
 export type TaskType = 'classification' | 'regression' | 'fine-tuning';
 export type LogType = 'default' | 'success' | 'warning' | 'error';
 export type IterationStatus = 'KEPT' | 'REVERTED' | 'PENDING';
+export type RunStatus = 'idle' | 'running' | 'cancelling' | 'cancelled' | 'complete' | 'failed';
 
 export type StartTraining = (
   prompt: string,
@@ -57,7 +58,7 @@ export interface RunArtifacts {
 }
 
 export interface TrainingState {
-  status: 'idle' | 'running' | 'complete' | 'failed';
+  status: RunStatus;
   stage: number;
   prompt: string;
   budget: number;

--- a/src/autoresearch/autoresearch.py
+++ b/src/autoresearch/autoresearch.py
@@ -19,7 +19,7 @@ import anthropic
 
 from src.autoresearch.config import TrainingConfig
 from src.observability.observability import log_event
-from src.runtime_context import resolve_output_path
+from src.runtime_context import raise_if_cancelled, resolve_output_path
 from src.tinker_api.sft_runner import (
     DEFAULT_LIVE_SMOKE_STEPS,
     DEFAULT_TINKER_MODEL,
@@ -152,7 +152,9 @@ def invoke_autoresearch_graph(
         "should_stop": False,
     }
 
+    raise_if_cancelled()
     final_state = graph.invoke(initial_state)
+    raise_if_cancelled()
 
     total_cost = sum(r["cost_usd"] for r in final_state["diary"])
     termination = "budget_limit" if final_state["should_stop"] else "training_complete"
@@ -177,6 +179,7 @@ def invoke_autoresearch_graph(
 
 def init_node(state: AutoResearchState) -> dict:
     """LangGraph node. Calls create_eval_suite(). Returns: { eval_suite, current_script, current_config, iteration: 0 }."""
+    raise_if_cancelled()
     task_analysis: TaskAnalysis = {
         "task_type": state["config"]["training_procedure"]["task_type"],
         "modality": "text",
@@ -230,6 +233,7 @@ def init_node(state: AutoResearchState) -> dict:
 
 def baseline_node(state: AutoResearchState) -> dict:
     """LangGraph node. Submits and evaluates the unmodified baseline script. Returns: { baseline_score, best_score }."""
+    raise_if_cancelled()
     log_event(
         AgentName.AUTORESEARCH,
         LogLevel.INFO,
@@ -242,6 +246,7 @@ def baseline_node(state: AutoResearchState) -> dict:
         max_steps=_max_steps_from_state(state),
         output_dir=str(_experiments_output_dir()),
     )
+    raise_if_cancelled()
     baseline_score = run_evals(experiment["model_path"], state["eval_suite"])
 
     log_event(
@@ -261,6 +266,7 @@ def baseline_node(state: AutoResearchState) -> dict:
 
 def propose_node(state: AutoResearchState) -> dict:
     """LangGraph node. Calls propose_hypothesis() and apply_patch(). Returns: { current_script, current_patch, last_description, original_content }."""
+    raise_if_cancelled()
     task_analysis: TaskAnalysis = {
         "task_type": state["config"]["training_procedure"]["task_type"],
         "modality": "text",
@@ -285,6 +291,7 @@ def propose_node(state: AutoResearchState) -> dict:
         task_analysis,
         allowed_params=allowed_params,
     )
+    raise_if_cancelled()
 
     # Bug fix: patch the config JSON, not the training script (.py files are not patchable).
     original_content = apply_patch(str(_config_path()), hypothesis["patch"])
@@ -312,6 +319,7 @@ def propose_node(state: AutoResearchState) -> dict:
 
 def run_node(state: AutoResearchState) -> dict:
     """LangGraph node. Runs a bounded SDK-native Tinker experiment. Returns: { last_result }."""
+    raise_if_cancelled()
     log_event(
         AgentName.AUTORESEARCH,
         LogLevel.INFO,
@@ -332,12 +340,14 @@ def run_node(state: AutoResearchState) -> dict:
         f"RUN: job {result['job_id']} finished — status={result['status']}",
         metadata={"job_id": result["job_id"], "cost_usd": result["cost_usd"]},
     )
+    raise_if_cancelled()
 
     return {"last_result": result}
 
 
 def revert_and_continue_node(state: AutoResearchState) -> dict:
     """LangGraph node (early stop path). Calls revert_patch(), logs REVERTED, increments iteration. Returns: { current_script, diary, iteration }."""
+    raise_if_cancelled()
     revert_patch(str(_config_path()), state["original_content"])
 
     log_event(
@@ -376,6 +386,7 @@ def revert_and_continue_node(state: AutoResearchState) -> dict:
 
 def evaluate_node(state: AutoResearchState) -> dict:
     """LangGraph node. Calls run_evals(), compare_scores(), flag_regression(). Returns: { last_score, last_delta }."""
+    raise_if_cancelled()
     last_score = run_evals(state["last_result"]["model_path"], state["eval_suite"])
     last_delta = compare_scores(last_score, state["baseline_score"])
     regressed = flag_regression(last_delta)
@@ -407,6 +418,7 @@ def evaluate_node(state: AutoResearchState) -> dict:
 
 def keep_node(state: AutoResearchState) -> dict:
     """LangGraph node. Updates best_score and best_script. Resets no_improve_streak. Returns: { best_score, best_script, no_improve_streak: 0 }."""
+    raise_if_cancelled()
     log_event(
         AgentName.AUTORESEARCH,
         LogLevel.INFO,
@@ -429,6 +441,7 @@ def keep_node(state: AutoResearchState) -> dict:
 
 def revert_node(state: AutoResearchState) -> dict:
     """LangGraph node. Calls revert_patch(). Increments no_improve_streak. Returns: { current_script, no_improve_streak }."""
+    raise_if_cancelled()
     revert_patch(str(_config_path()), state["original_content"])
 
     new_streak = state["no_improve_streak"] + 1
@@ -447,6 +460,7 @@ def revert_node(state: AutoResearchState) -> dict:
 
 def log_node(state: AutoResearchState) -> dict:
     """LangGraph node. Calls log_iteration(). Calls adapt_eval_suite() every 10 iters. Returns: { diary, eval_suite, iteration }."""
+    raise_if_cancelled()
     iteration_number = state["iteration"] + 1
 
     # revert_and_continue_node already logged its entry and updated state["diary"].
@@ -528,6 +542,7 @@ def decision_edge(state: AutoResearchState) -> Literal["keep", "revert"]:
 
 def continue_edge(state: AutoResearchState) -> Literal["propose", "__end__"]:
     """After log_node. Returns '__end__' if budget exhausted / convergence, else 'propose' to loop."""
+    raise_if_cancelled()
     if state["should_stop"]:
         return "__end__"
 

--- a/src/manager/manager.py
+++ b/src/manager/manager.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from src.data_sources import looks_like_local_data_path, normalize_hf_dataset_source
-from src.runtime_context import get_output_root
+from src.runtime_context import get_output_root, raise_if_cancelled
 from src.types import (
     DatasetResult,
     ManagerState,
@@ -65,7 +65,9 @@ def invoke_manager_graph(
         "config": None,
         "result": None,
     }
+    raise_if_cancelled()
     final_state = graph.invoke(initial_state)
+    raise_if_cancelled()
     return final_state["result"]
 
 
@@ -73,6 +75,7 @@ def invoke_manager_graph(
 
 def query_data_node(state: ManagerState) -> dict:
     """LangGraph node. Calls query_user_for_data(). Returns: { has_data, data_path }."""
+    raise_if_cancelled()
     existing_path = state.get("data_path")
     if existing_path:
         expanded_path = Path(existing_path).expanduser()
@@ -95,12 +98,15 @@ def query_data_node(state: ManagerState) -> dict:
 
 def reason_node(state: ManagerState) -> dict:
     """LangGraph node. Calls reason_about_task() via Claude API. Returns: { task_reasoning }."""
+    raise_if_cancelled()
     reasoning = reason_about_task(state["prompt"], state["budget"], state["has_data"])
+    raise_if_cancelled()
     return {"task_reasoning": reasoning}
 
 
 def build_config_node(state: ManagerState) -> dict:
     """LangGraph node. Builds OrchestrationConfig and logs the decision. Returns: { config }."""
+    raise_if_cancelled()
     config = build_orchestration_config(
         state["task_reasoning"],
         state["prompt"],
@@ -112,6 +118,7 @@ def build_config_node(state: ManagerState) -> dict:
         rationale=state["task_reasoning"]["notes"],
         config=config,
     )
+    raise_if_cancelled()
     return {"config": config}
 
 
@@ -128,14 +135,18 @@ def orchestrate_node(state: ManagerState) -> dict:
     budget = config["compute_budget"]
 
     # ── 1. Data acquisition ──────────────────────────────────────────────────
+    raise_if_cancelled()
     log_event(AgentName.MANAGER, LogLevel.INFO, "Starting DataGen sub-agent", {})
     handoff = invoke_data_generator_graph(config, state.get("data_path"))
+    raise_if_cancelled()
     dataset = _handoff_to_dataset_result(handoff)
     _ensure_dataset_is_trainable(dataset)
 
     # ── 2. Decision Engine — pick model, estimate cost, write training script
+    raise_if_cancelled()
     log_event(AgentName.MANAGER, LogLevel.INFO, "Running Decision Engine", {})
     plan = run_decision_engine(config, dataset)
+    raise_if_cancelled()
     log_decision(
         step="orchestrate",
         rationale=f"strategy={plan['strategy']} model={plan['base_model']} "
@@ -147,8 +158,10 @@ def orchestrate_node(state: ManagerState) -> dict:
     cost_manager = CostManager(budget)
 
     # ── 4. AutoResearch loop ─────────────────────────────────────────────────
+    raise_if_cancelled()
     log_event(AgentName.MANAGER, LogLevel.INFO, "Launching AutoResearch loop", {})
     result = invoke_autoresearch_graph(plan, config, cost_manager)
+    raise_if_cancelled()
 
     log_event(
         AgentName.MANAGER,

--- a/src/observability/observability.py
+++ b/src/observability/observability.py
@@ -17,6 +17,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+from src.runtime_context import resolve_output_path
 from src.types import LogEntry
 
 # ANSI color codes by agent name
@@ -41,7 +42,7 @@ def log_event(
     level: str,
     message: str,
     metadata: dict = {},
-    log_path: str = "outputs/logs/run.jsonl",
+    log_path: str | Path | None = None,
 ) -> None:
     """Central logging function called by every agent. Writes JSON to disk and colored line to stdout."""
     entry: LogEntry = {
@@ -52,7 +53,12 @@ def log_event(
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
     emit_cli(entry)
-    write_json_log(entry, log_path)
+    path = Path(log_path) if log_path is not None else resolve_output_path(
+        "outputs/logs/run.jsonl",
+        "logs",
+        "run.jsonl",
+    )
+    write_json_log(entry, path)
 
 
 def format_cli_line(entry: LogEntry) -> str:
@@ -72,7 +78,7 @@ def emit_cli(entry: LogEntry) -> None:
     print(format_cli_line(entry), file=sys.stdout, flush=True)
 
 
-def write_json_log(entry: LogEntry, log_path: str) -> None:
+def write_json_log(entry: LogEntry, log_path: str | Path) -> None:
     """Appends the LogEntry as a JSON line to the structured log file."""
     path = Path(log_path)
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/runtime_context.py
+++ b/src/runtime_context.py
@@ -6,13 +6,36 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from pathlib import Path
+from threading import Event
+from typing import MutableSet
 
 _OUTPUT_ROOT: ContextVar[Path | None] = ContextVar("output_root", default=None)
+_CANCEL_EVENT: ContextVar[Event | None] = ContextVar("cancel_event", default=None)
+_ACTIVE_TINKER_JOBS: ContextVar[MutableSet[str] | None] = ContextVar(
+    "active_tinker_jobs",
+    default=None,
+)
+
+
+class RunCancelled(RuntimeError):
+    """Raised when a run has been cancelled by its caller."""
 
 
 def get_output_root() -> Path | None:
     """Return the current run-scoped output root, if one is active."""
     return _OUTPUT_ROOT.get()
+
+
+def cancellation_requested() -> bool:
+    """Return True when the active run has been asked to stop."""
+    event = _CANCEL_EVENT.get()
+    return bool(event and event.is_set())
+
+
+def raise_if_cancelled() -> None:
+    """Abort cooperatively when the active run has been cancelled."""
+    if cancellation_requested():
+        raise RunCancelled("Run cancelled by user")
 
 
 def resolve_output_path(default: str | Path, *run_parts: str) -> Path:
@@ -33,3 +56,31 @@ def output_root(path: str | Path) -> Iterator[Path]:
         yield root
     finally:
         _OUTPUT_ROOT.reset(token)
+
+
+@contextmanager
+def cancellation_context(
+    cancel_event: Event | None,
+    active_tinker_jobs: MutableSet[str] | None = None,
+) -> Iterator[None]:
+    """Make a cancellation signal and active Tinker registry visible in this context."""
+    event_token = _CANCEL_EVENT.set(cancel_event)
+    jobs_token = _ACTIVE_TINKER_JOBS.set(active_tinker_jobs)
+    try:
+        yield
+    finally:
+        _ACTIVE_TINKER_JOBS.reset(jobs_token)
+        _CANCEL_EVENT.reset(event_token)
+
+
+@contextmanager
+def active_tinker_job(job_id: str) -> Iterator[None]:
+    """Register a Tinker job while it is running so callers can cancel it."""
+    jobs = _ACTIVE_TINKER_JOBS.get()
+    if jobs is not None:
+        jobs.add(job_id)
+    try:
+        yield
+    finally:
+        if jobs is not None:
+            jobs.discard(job_id)

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -8,6 +8,7 @@ added later once observability emits run-scoped events.
 from __future__ import annotations
 
 import json
+import math
 import os
 import threading
 import uuid
@@ -22,7 +23,12 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from src.data_sources import looks_like_local_data_path, normalize_hf_dataset_source
 from src.manager.manager import invoke_manager_graph
-from src.runtime_context import output_root
+from src.runtime_context import (
+    RunCancelled,
+    cancellation_context,
+    output_root,
+    raise_if_cancelled,
+)
 from src.server.schemas import (
     ArtifactView,
     IterationView,
@@ -34,6 +40,7 @@ from src.server.schemas import (
     RunRequest,
     RunState,
 )
+from src.tinker_api.tinker_api import cancel_job
 
 
 STAGE_LABELS = [
@@ -81,6 +88,9 @@ class _RunRecord:
     artifact_content_types: dict[str, str] = field(default_factory=dict)
     error: str | None = None
     stages: list[PipelineStage] = field(default_factory=list)
+    cancel_event: threading.Event = field(default_factory=threading.Event)
+    active_tinker_jobs: set[str] = field(default_factory=set)
+    worker_thread: threading.Thread | None = None
 
 
 _RUNS: dict[str, _RunRecord] = {}
@@ -104,6 +114,27 @@ def _append_log(record: _RunRecord, component: str, message: str, kind: str = "d
         LogEntryView(time=_time_label(), component=component, message=message, type=kind),
     )
     record.logs = record.logs[:100]
+
+
+def _is_terminal(record: _RunRecord) -> bool:
+    return record.status in {"cancelled", "complete", "failed"}
+
+
+def _mark_cancelled(record: _RunRecord, message: str = "Run cancelled") -> None:
+    record.status = "cancelled"
+    record.error = None
+    _append_log(record, "Manager", message, "warning")
+
+
+def _request_cancel(record: _RunRecord) -> None:
+    if _is_terminal(record):
+        return
+    record.cancel_event.set()
+    for job_id in list(record.active_tinker_jobs):
+        cancel_job(job_id)
+    if record.status != "cancelling":
+        record.status = "cancelling"
+        _append_log(record, "Manager", "Cancellation requested", "warning")
 
 
 def _copy_request_with_data_path(request: RunRequest, data_path: str | None) -> RunRequest:
@@ -215,6 +246,159 @@ def _iterations_from_diary(path: str | None) -> list[IterationView]:
             )
         )
     return list(reversed(iterations))
+
+
+def _jsonl_rows(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+
+    rows: list[dict[str, Any]] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(row, dict):
+            rows.append(row)
+    return rows
+
+
+def _log_time(timestamp: Any) -> str:
+    if isinstance(timestamp, str) and len(timestamp) >= 19:
+        return timestamp[11:19]
+    return _time_label()
+
+
+def _log_kind(level: Any) -> str:
+    if level == "ERROR":
+        return "error"
+    if level == "WARN":
+        return "warning"
+    return "default"
+
+
+def _logs_from_observability(record: _RunRecord) -> list[LogEntryView]:
+    rows = _jsonl_rows(record.output_dir / "logs" / "run.jsonl")
+    return [
+        LogEntryView(
+            time=_log_time(row.get("timestamp")),
+            component=str(row.get("agent") or "System"),
+            message=str(row.get("message") or ""),
+            type=_log_kind(row.get("level")),
+        )
+        for row in reversed(rows[-100:])
+        if row.get("message")
+    ]
+
+
+def _merge_logs(record: _RunRecord, file_logs: list[LogEntryView]) -> None:
+    if not file_logs:
+        return
+    seen = {(item.time, item.component, item.message, item.type) for item in file_logs}
+    merged = file_logs + [
+        item
+        for item in record.logs
+        if (item.time, item.component, item.message, item.type) not in seen
+    ]
+    record.logs = merged[:100]
+
+
+def _cost_from_diary(path: Path) -> float:
+    return sum(float(row.get("cost_usd") or 0.0) for row in _jsonl_rows(path))
+
+
+def _experiment_dirs(record: _RunRecord) -> list[Path]:
+    root = record.output_dir / "experiments"
+    if not root.is_dir():
+        return []
+    return sorted(
+        [path for path in root.iterdir() if path.is_dir()],
+        key=lambda path: path.stat().st_mtime,
+    )
+
+
+def _latest_experiment_dir(record: _RunRecord) -> Path | None:
+    dirs = _experiment_dirs(record)
+    return dirs[-1] if dirs else None
+
+
+def _metric_point(row: dict[str, Any], iteration: int) -> MetricPoint | None:
+    loss = row.get("val_loss", row.get("train_loss"))
+    score = row.get("primary_metric")
+    try:
+        loss_value = float(loss)
+        score_value = float(score or 0.0)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(loss_value):
+        return None
+    return MetricPoint(loss=loss_value, accuracy=score_value, iteration=iteration)
+
+
+def _metrics_from_experiments(record: _RunRecord) -> list[MetricPoint]:
+    points: list[MetricPoint] = []
+    for run_dir in _experiment_dirs(record):
+        rows = _jsonl_rows(run_dir / "metrics.jsonl")
+        if not rows:
+            metrics = _read_json_if_exists(run_dir / "metrics.json")
+            rows = [metrics] if metrics else []
+        for row in rows:
+            point = _metric_point(row, len(points) + 1)
+            if point:
+                points.append(point)
+    return points[-100:]
+
+
+def _refresh_stage_from_files(record: _RunRecord, latest_experiment: Path | None) -> None:
+    if _is_terminal(record):
+        return
+
+    stage = record.stage
+    if (record.output_dir / "datasets" / "train_data.jsonl").exists():
+        stage = max(stage, 2)
+    if (
+        (record.output_dir / "scripts" / "train.py").exists()
+        or (record.output_dir / "configs" / "current.json").exists()
+    ):
+        stage = max(stage, 3)
+    if latest_experiment and (
+        (latest_experiment / "metrics.jsonl").exists()
+        or (latest_experiment / "metrics.json").exists()
+    ):
+        stage = max(stage, 4)
+
+    if stage > record.stage:
+        _mark_stage(record, stage)
+
+
+def _refresh_record_from_files(record: _RunRecord) -> None:
+    _merge_logs(record, _logs_from_observability(record))
+
+    diary_path = record.output_dir / "logs" / "research_diary.jsonl"
+    if diary_path.exists():
+        record.iterations = _iterations_from_diary(str(diary_path))
+        record.cost_spent = max(record.cost_spent, _cost_from_diary(diary_path))
+
+    metrics = _metrics_from_experiments(record)
+    if metrics:
+        record.metrics = metrics
+
+    latest_experiment = _latest_experiment_dir(record)
+    _refresh_stage_from_files(record, latest_experiment)
+    if latest_experiment and record.result is None:
+        record.artifacts = _artifacts_from_result(
+            record,
+            {
+                "weights_path": str(latest_experiment),
+                "research_diary_path": str(diary_path) if diary_path.exists() else None,
+            },
+        )
 
 
 def _read_json_if_exists(path: Path | None) -> dict[str, Any] | None:
@@ -340,19 +524,34 @@ def _run_manager(record: _RunRecord) -> None:
         _append_log(record, "Manager", "Manager graph is running")
 
     try:
-        with output_root(record.output_dir):
+        with output_root(record.output_dir), cancellation_context(
+            record.cancel_event,
+            record.active_tinker_jobs,
+        ):
+            raise_if_cancelled()
             result = invoke_manager_graph(
                 record.request.prompt,
                 record.request.budget,
                 record.request.data_path,
             )
+            raise_if_cancelled()
+    except RunCancelled:
+        with _LOCK:
+            _refresh_record_from_files(record)
+            _mark_cancelled(record)
+        return
     except Exception as exc:  # surfaced to the browser as a failed run state
         with _LOCK:
+            _refresh_record_from_files(record)
             _fail_current_stage(record, str(exc))
         return
 
     with _LOCK:
-        _store_manager_result(record, dict(result))
+        _refresh_record_from_files(record)
+        if record.cancel_event.is_set():
+            _mark_cancelled(record)
+        else:
+            _store_manager_result(record, dict(result))
 
 
 def _to_state(record: _RunRecord) -> RunState:
@@ -397,6 +596,7 @@ def create_run(request: RunRequest) -> RunCreated:
         _RUNS[run_id] = record
 
     thread = threading.Thread(target=_run_manager, args=(record,), daemon=True)
+    record.worker_thread = thread
     thread.start()
     return RunCreated(run_id=run_id, status="running")
 
@@ -407,6 +607,18 @@ def get_run(run_id: str) -> RunState:
         record = _RUNS.get(run_id)
         if record is None:
             raise HTTPException(status_code=404, detail="run not found")
+        _refresh_record_from_files(record)
+        return _to_state(record)
+
+
+@app.post("/api/runs/{run_id}/cancel", response_model=RunState)
+def cancel_run(run_id: str) -> RunState:
+    with _LOCK:
+        record = _RUNS.get(run_id)
+        if record is None:
+            raise HTTPException(status_code=404, detail="run not found")
+        _request_cancel(record)
+        _refresh_record_from_files(record)
         return _to_state(record)
 
 
@@ -418,6 +630,7 @@ def get_run_artifact(run_id: str, artifact_name: str) -> FileResponse:
             raise HTTPException(status_code=404, detail="run not found")
         if artifact_name not in ARTIFACT_DEFINITIONS:
             raise HTTPException(status_code=404, detail="artifact not found")
+        _refresh_record_from_files(record)
         path = record.artifact_paths.get(artifact_name)
         content_type = record.artifact_content_types.get(artifact_name)
 

--- a/src/server/schemas.py
+++ b/src/server/schemas.py
@@ -67,7 +67,7 @@ class RunArtifactsView(BaseModel):
 
 class RunState(BaseModel):
     run_id: str
-    status: Literal["running", "complete", "failed"]
+    status: Literal["running", "cancelling", "cancelled", "complete", "failed"]
     stage: int
     prompt: str
     budget: float

--- a/src/tinker_api/sft_runner.py
+++ b/src/tinker_api/sft_runner.py
@@ -18,10 +18,12 @@ from uuid import uuid4
 
 from src.tinker_api.tinker_api import (
     TinkerAPIError,
+    cancel_job,
     get_cumulative_spend,
     is_cancelled,
     record_tokens,
 )
+from src.runtime_context import active_tinker_job, cancellation_requested
 from src.types import DatasetResult, ExperimentResult, TrainingMetrics
 
 if TYPE_CHECKING:
@@ -88,42 +90,45 @@ def run_tinker_sft_experiment(
         metrics_path = run_dir / "metrics.jsonl"
         status = "COMPLETED"
 
-        for step in range(target_steps):
-            if is_cancelled(run_name):
-                status = "CANCELLED"
-                break
+        with active_tinker_job(run_name):
+            for step in range(target_steps):
+                if cancellation_requested():
+                    cancel_job(run_name)
+                if is_cancelled(run_name):
+                    status = "CANCELLED"
+                    break
 
-            batch_conversations = _conversation_batch(conversations, cfg.batch_size, step)
-            batch = [
-                supervised_data.conversation_to_datum(
-                    conversation,
-                    renderer,
-                    cfg.max_seq_length,
-                    train_on_what,
-                )
-                for conversation in batch_conversations
-            ]
+                batch_conversations = _conversation_batch(conversations, cfg.batch_size, step)
+                batch = [
+                    supervised_data.conversation_to_datum(
+                        conversation,
+                        renderer,
+                        cfg.max_seq_length,
+                        train_on_what,
+                    )
+                    for conversation in batch_conversations
+                ]
 
-            adam_params = tinker_types.AdamParams(learning_rate=cfg.learning_rate)
-            fwd_future = training_client.forward_backward(batch, loss_fn="cross_entropy")
-            optim_future = training_client.optim_step(adam_params)
-            fwd_result = _future_result(fwd_future)
-            optim_result = _future_result(optim_future)
+                adam_params = tinker_types.AdamParams(learning_rate=cfg.learning_rate)
+                fwd_future = training_client.forward_backward(batch, loss_fn="cross_entropy")
+                optim_future = training_client.optim_step(adam_params)
+                fwd_result = _future_result(fwd_future)
+                optim_result = _future_result(optim_future)
 
-            tokens = sum(_datum_token_count(datum) for datum in batch)
-            record_tokens(run_name, tokens)
-            loss = _extract_loss(fwd_result, optim_result)
-            step_metrics = {
-                "step": step + 1,
-                "train_loss": loss,
-                "val_loss": loss,
-                "test_loss": loss,
-                "primary_metric": _score_from_loss(loss),
-                "tokens": tokens,
-            }
-            metrics_history.append(step_metrics)
-            with open(metrics_path, "a") as fh:
-                fh.write(json.dumps(step_metrics) + "\n")
+                tokens = sum(_datum_token_count(datum) for datum in batch)
+                record_tokens(run_name, tokens)
+                loss = _extract_loss(fwd_result, optim_result)
+                step_metrics = {
+                    "step": step + 1,
+                    "train_loss": loss,
+                    "val_loss": loss,
+                    "test_loss": loss,
+                    "primary_metric": _score_from_loss(loss),
+                    "tokens": tokens,
+                }
+                metrics_history.append(step_metrics)
+                with open(metrics_path, "a") as fh:
+                    fh.write(json.dumps(step_metrics) + "\n")
 
         checkpoints, sampling_client = _save_final_artifacts(training_client, run_name)
         sample_payload = _sample_once(

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -9,6 +9,7 @@ from src.observability.observability import (
     write_json_log,
     get_budget_display,
 )
+from src.runtime_context import output_root
 from src.types import AgentName, LogLevel
 
 
@@ -59,3 +60,16 @@ def test_log_event_writes_to_disk(tmp_path):
     assert parsed["agent"] == AgentName.DATA_GEN
     assert parsed["message"] == "dataset found"
     assert "timestamp" in parsed
+
+
+def test_log_event_uses_active_output_root(tmp_path):
+    run_root = tmp_path / "run-123"
+
+    with output_root(run_root):
+        log_event(AgentName.MANAGER, LogLevel.INFO, "run scoped")
+
+    log_file = run_root / "logs" / "run.jsonl"
+    assert log_file.is_file()
+    parsed = json.loads(log_file.read_text().splitlines()[0])
+    assert parsed["message"] == "run scoped"
+    assert not (tmp_path / "outputs" / "logs" / "run.jsonl").exists()

--- a/tests/test_runtime_context.py
+++ b/tests/test_runtime_context.py
@@ -3,13 +3,20 @@
 from __future__ import annotations
 
 import json
+import threading
 from pathlib import Path
 
 from src.autoresearch import autoresearch as ar
 from src.data_generator.curation import curate_handoff_to_dataset_result
 from src.decision_engine.decision_engine import write_finetune_script
 from src.manager.manager import build_orchestration_config, log_decision
-from src.runtime_context import output_root
+from src.runtime_context import (
+    RunCancelled,
+    active_tinker_job,
+    cancellation_context,
+    output_root,
+    raise_if_cancelled,
+)
 
 
 def test_output_root_routes_manager_datagen_decision_and_autoresearch(
@@ -92,3 +99,21 @@ def test_output_root_routes_manager_datagen_decision_and_autoresearch(
 
     diary_line = (run_root / "logs" / "research_diary.jsonl").read_text().strip()
     assert json.loads(diary_line)["decision"] == "PENDING"
+
+
+def test_cancellation_context_signals_and_tracks_active_tinker_jobs():
+    event = threading.Event()
+    jobs: set[str] = set()
+
+    with cancellation_context(event, jobs):
+        with active_tinker_job("job-123"):
+            assert jobs == {"job-123"}
+            event.set()
+            try:
+                raise_if_cancelled()
+            except RunCancelled as exc:
+                assert "cancelled" in str(exc)
+            else:
+                raise AssertionError("raise_if_cancelled should raise after cancellation")
+
+    assert jobs == set()

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import threading
 import time
 from pathlib import Path
 
@@ -225,6 +226,159 @@ def test_create_run_surfaces_artifacts_and_allowlisted_downloads(tmp_path, monke
 
     missing_response = client.get(f"/api/runs/{run_id}/artifacts/not-real")
     assert missing_response.status_code == 404
+
+
+def test_running_run_refreshes_logs_iterations_metrics_and_artifacts(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    ready = threading.Event()
+    release = threading.Event()
+
+    def fake_invoke(prompt, budget, data_path=None):
+        root = get_output_root()
+        assert root is not None
+
+        from src.observability.observability import log_event
+        from src.types import AgentName, LogLevel
+
+        log_event(AgentName.DATA_GEN, LogLevel.INFO, "dataset found", {})
+        diary_path = root / "logs" / "research_diary.jsonl"
+        diary_path.parent.mkdir(parents=True, exist_ok=True)
+        diary_path.write_text(
+            json.dumps(
+                {
+                    "iteration": 1,
+                    "hypothesis": "Increase learning rate",
+                    "patch": "- learning_rate: 0.0001\n+ learning_rate: 0.0005",
+                    "metrics": {"val_loss": 0.4, "primary_metric": 0.714},
+                    "decision": "PENDING",
+                    "cost_usd": 0.42,
+                }
+            )
+            + "\nnot-json-yet",
+            encoding="utf-8",
+        )
+        run_dir = root / "experiments" / "live-progress"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "metrics.jsonl").write_text(
+            json.dumps({"step": 1, "val_loss": 0.4, "primary_metric": 0.714}) + "\n",
+            encoding="utf-8",
+        )
+        (run_dir / "manifest.json").write_text(
+            json.dumps({"run_id": "live-progress", "checkpoints": {"state_path": "tinker://state/progress"}}),
+            encoding="utf-8",
+        )
+        ready.set()
+        assert release.wait(timeout=5)
+        return _fake_model(root, total_cost=0.5, with_artifacts=True)
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune while surfacing live progress",
+            "budget": 25,
+            "task_type": "fine-tuning",
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    assert ready.wait(timeout=5)
+
+    state = client.get(f"/api/runs/{run_id}").json()
+    assert state["status"] == "running"
+    assert state["stage"] >= 4
+    assert state["costSpent"] == 0.42
+    assert state["logs"][0]["component"] == "DataGen"
+    assert state["iterations"][0]["status"] == "PENDING"
+    assert state["metrics"][0]["loss"] == 0.4
+    assert state["artifacts"]["checkpoints"]["state_path"] == "tinker://state/progress"
+
+    metrics_log = client.get(f"/api/runs/{run_id}/artifacts/metrics_log")
+    assert metrics_log.status_code == 200
+    assert '"step": 1' in metrics_log.text
+
+    release.set()
+    assert _wait_for_status(client, run_id, "complete")["status"] == "complete"
+
+
+def test_cancel_running_run_stops_at_safe_boundary(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    entered = threading.Event()
+
+    def fake_invoke(prompt, budget, data_path=None):
+        root = get_output_root()
+        assert root is not None
+
+        from src.runtime_context import active_tinker_job, cancellation_requested
+
+        with active_tinker_job("server-active-job"):
+            entered.set()
+            while not cancellation_requested():
+                time.sleep(0.01)
+        return _fake_model(root, total_cost=99.0, with_artifacts=True)
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune a cancellable support assistant",
+            "budget": 25,
+            "task_type": "fine-tuning",
+        },
+    )
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    assert entered.wait(timeout=5)
+
+    cancel_response = client.post(f"/api/runs/{run_id}/cancel")
+    assert cancel_response.status_code == 200
+    assert cancel_response.json()["status"] == "cancelling"
+
+    from src.tinker_api.tinker_api import is_cancelled
+
+    assert is_cancelled("server-active-job")
+    state = _wait_for_status(client, run_id, "cancelled")
+    assert state["status"] == "cancelled"
+    assert state["result"] is None
+    assert any("cancel" in item["message"].lower() for item in state["logs"])
+
+
+def test_cancel_missing_run_returns_404():
+    client = TestClient(server_app.app)
+    response = client.post("/api/runs/not-a-run/cancel")
+    assert response.status_code == 404
+
+
+def test_cancel_completed_run_is_idempotent(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def fake_invoke(prompt, budget, data_path=None):
+        root = get_output_root()
+        assert root is not None
+        return _fake_model(root, total_cost=0.5)
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune and finish before cancel",
+            "budget": 25,
+            "task_type": "fine-tuning",
+        },
+    )
+
+    run_id = response.json()["run_id"]
+    _wait_for_status(client, run_id, "complete")
+    cancel_response = client.post(f"/api/runs/{run_id}/cancel")
+    assert cancel_response.status_code == 200
+    assert cancel_response.json()["status"] == "complete"
 
 
 def test_create_run_passes_existing_local_data_path(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- route observability logs into the active API run output root and refresh polled API state from run-local logs, AutoResearch diary, and Tinker experiment metrics/artifacts
- add cooperative cancellation context across the server, Manager, AutoResearch, and Tinker SFT runner, with active Tinker job cancellation
- add `POST /api/runs/{run_id}/cancel` plus frontend Cancel/Cancelling/Cancelled states so Reset no longer hides a live backend run

## Validation
- python3 -m compileall src tests/test_server_api.py tests/test_runtime_context.py tests/test_observability.py
- uv run --with pytest --with fastapi --with httpx --with anthropic --with langgraph python -m pytest tests/test_server_api.py tests/test_runtime_context.py tests/test_observability.py tests/test_tinker_runner.py -q
- uv run --with pytest --with anthropic --with langgraph --with fastapi --with httpx --with datasets --with huggingface-hub --with requests python -m pytest tests -q --ignore=tests/data_generator/test_mode_b_hf_retrieval.py
- npm ci
- npm run lint
- npm run build
- Browser sanity: Vite UI at http://127.0.0.1:5183, simulation run displayed Cancel, then Cancelled terminal state and reset action

## Notes
- cancellation is cooperative: provider calls are not interrupted mid-request, but the pipeline stops at the next checked boundary and Tinker SFT loops check between steps
- progress refresh is tolerant of partial JSONL writes and only serves artifacts under the run output directory