### PR TITLE
[codex] canonicalize Tinker hyperparameter aliases

### DIFF
--- a/src/autoresearch/autoresearch.py
+++ b/src/autoresearch/autoresearch.py
@@ -55,6 +55,10 @@ _MAX_ITERATIONS = 20  # hard cap on total iterations regardless of improvement
 _MIN_RELATIVE_IMPROVEMENT_PCT = 1.0
 _MIN_ABSOLUTE_IMPROVEMENT = 1e-9
 _EXPERIMENT_CACHE: dict[str, ExperimentResult] = {}
+_TINKER_HYPERPARAMETER_ALIASES = {
+    "epochs": "num_epochs",
+    "max_seq_len": "max_seq_length",
+}
 
 
 def _patch_to_diff(patch_dict: dict, current_config: dict) -> str:
@@ -65,6 +69,26 @@ def _patch_to_diff(patch_dict: dict, current_config: dict) -> str:
         lines.append(f"- {key}: {old_val}")
         lines.append(f"+ {key}: {new_val}")
     return "\n".join(lines)
+
+
+def _canonicalize_tinker_hyperparameters(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Return Tinker V1 hyperparameters with legacy Manager aliases removed."""
+    canonical = dict(config)
+    for legacy_key, canonical_key in _TINKER_HYPERPARAMETER_ALIASES.items():
+        if legacy_key in canonical and canonical_key not in canonical:
+            canonical[canonical_key] = canonical[legacy_key]
+        canonical.pop(legacy_key, None)
+    return canonical
+
+
+def _current_config_for_plan(
+    plan: TrainingPlan,
+    config: OrchestrationConfig,
+) -> dict[str, Any]:
+    current_config = dict(config["training_procedure"]["hyperparameters"])
+    if plan.get("backend") == "tinker_sft":
+        return _canonicalize_tinker_hyperparameters(current_config)
+    return current_config
 
 
 # ─── GRAPH BUILDER ────────────────────────────────────────────────────────────
@@ -132,7 +156,7 @@ def invoke_autoresearch_graph(
         "cost_manager": cost_manager,
         "eval_suite": None,
         "current_script": plan["training_script_path"],
-        "current_config": config["training_procedure"]["hyperparameters"],
+        "current_config": _current_config_for_plan(plan, config),
         "current_patch": None,
         "last_description": None,
         "original_content": None,
@@ -194,7 +218,7 @@ def init_node(state: AutoResearchState) -> dict:
     return {
         "eval_suite": eval_suite,
         "current_script": state["plan"]["training_script_path"],
-        "current_config": state["config"]["training_procedure"]["hyperparameters"],
+        "current_config": _current_config_for_plan(state["plan"], state["config"]),
         "iteration": 0,
     }
 
@@ -383,6 +407,8 @@ def keep_node(state: AutoResearchState) -> dict:
     # call to propose_hypothesis() sees the real current state, not the original baseline.
     patch_dict = json.loads(state.get("current_patch", "{}"))
     updated_config = {**state["current_config"], **patch_dict}
+    if state["plan"].get("backend") == "tinker_sft":
+        updated_config = _canonicalize_tinker_hyperparameters(updated_config)
 
     return {
         "best_score": state["last_score"],
@@ -623,6 +649,11 @@ def propose_hypothesis(
     """Calls Claude API (claude-haiku-4-5-20251001) to generate a single testable hypothesis as a code/config diff."""
     client = anthropic.Anthropic()
     recent = diary[-5:] if len(diary) > 5 else diary
+    prompt_config = (
+        _canonicalize_tinker_hyperparameters(current_config)
+        if allowed_params
+        else current_config
+    )
 
     system = (
         "You are an ML hyperparameter optimization assistant for the AutoResearch Loop. "
@@ -647,7 +678,7 @@ def propose_hypothesis(
             "warmup_steps [0, 2000], dropout [0, 0.5]."
         )
     user = f"""Current training configuration:
-{json.dumps(current_config, indent=2)}
+{json.dumps(prompt_config, indent=2)}
 
 Task:
 - type: {task['task_type']}
@@ -687,6 +718,7 @@ Respond with this JSON object and nothing else:
     parsed = json.loads(raw)
     patch = parsed["patch"]
     if allowed_params:
+        patch = _canonicalize_tinker_hyperparameters(patch)
         unsupported = [key for key in patch if key not in set(allowed_params)]
         if unsupported:
             raise ValueError(
@@ -790,12 +822,12 @@ def _training_config_from_state(
     *,
     include_pending_patch: bool = False,
 ) -> TrainingConfig:
-    data: dict[str, Any] = dict(state["current_config"])
+    data: dict[str, Any] = (
+        _canonicalize_tinker_hyperparameters(state["current_config"])
+        if state["plan"].get("backend") == "tinker_sft"
+        else dict(state["current_config"])
+    )
     data.setdefault("model_name", state["plan"].get("base_model") or DEFAULT_TINKER_MODEL)
-    if "max_seq_len" in data and "max_seq_length" not in data:
-        data["max_seq_length"] = data["max_seq_len"]
-    if "epochs" in data and "num_epochs" not in data:
-        data["num_epochs"] = data["epochs"]
     lora = state["plan"].get("lora_config")
     if lora and "lora_rank" not in data:
         data["lora_rank"] = lora["rank"]

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -470,6 +470,163 @@ def test_run_node_preflight_skips_unaffordable_candidate(monkeypatch, tmp_path):
     assert manifest["budget_preflight_skipped"] is True
 
 
+def test_invoke_autoresearch_graph_canonicalizes_tinker_initial_config(monkeypatch):
+    import src.autoresearch.autoresearch as ar
+
+    captured = {}
+
+    class FakeGraph:
+        def invoke(self, initial_state):
+            captured.update(initial_state["current_config"])
+            return {
+                **initial_state,
+                "baseline_result": {
+                    "job_id": "baseline",
+                    "status": "COMPLETED",
+                    "metrics": {"train_loss": 0.5, "val_loss": 0.5,
+                                "test_loss": 0.5, "primary_metric": 0.5},
+                    "model_path": "baseline-model",
+                    "cost_usd": 0.0,
+                    "logs_path": "baseline.jsonl",
+                },
+                "baseline_score": {"scalar": 0.5, "metrics": {}, "critique": ""},
+                "best_score": {"scalar": 0.5, "metrics": {}, "critique": ""},
+                "best_script": "baseline-model",
+            }
+
+    monkeypatch.setattr(ar, "build_autoresearch_graph", lambda: FakeGraph())
+    state = _make_state()
+    plan = {
+        **state["plan"],
+        "base_model": "Qwen/Qwen3.5-9B",
+        "backend": "tinker_sft",
+        "eval_metric": "primary_metric",
+    }
+    config = {
+        **state["config"],
+        "training_procedure": {
+            **state["config"]["training_procedure"],
+            "base_model": "Qwen/Qwen3.5-9B",
+            "hyperparameters": {
+                "learning_rate": 1e-4,
+                "epochs": 2,
+                "max_seq_len": 256,
+            },
+        },
+    }
+
+    ar.invoke_autoresearch_graph(plan, config, None)
+
+    assert captured["learning_rate"] == 1e-4
+    assert captured["num_epochs"] == 2
+    assert captured["max_seq_length"] == 256
+    assert "epochs" not in captured
+    assert "max_seq_len" not in captured
+
+
+def test_propose_hypothesis_canonicalizes_tinker_alias_patch(monkeypatch):
+    import src.autoresearch.autoresearch as ar
+
+    captured = {}
+
+    class FakeContent:
+        text = json.dumps(
+            {
+                "description": "Increase epochs for a longer bounded run.",
+                "patch": {"epochs": 5, "max_seq_len": 1024},
+                "expected_effect": "Improve validation loss.",
+                "search_strategy": "local",
+            }
+        )
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return type("FakeMessage", (), {"content": [FakeContent()]})()
+
+    class FakeAnthropic:
+        def __init__(self):
+            self.messages = FakeMessages()
+
+    monkeypatch.setattr(ar.anthropic, "Anthropic", FakeAnthropic)
+
+    hypothesis = ar.propose_hypothesis(
+        {"learning_rate": 1e-4, "epochs": 3, "max_seq_len": 512},
+        [],
+        _minimal_task(),
+        allowed_params=["learning_rate", "max_seq_length", "num_epochs"],
+    )
+
+    assert json.loads(hypothesis["patch"]) == {
+        "num_epochs": 5,
+        "max_seq_length": 1024,
+    }
+    assert '"num_epochs": 3' in captured["messages"][0]["content"]
+    assert '"max_seq_length": 512' in captured["messages"][0]["content"]
+    assert '"max_seq_len":' not in captured["messages"][0]["content"]
+
+
+def test_propose_hypothesis_still_rejects_unsupported_tinker_patch(monkeypatch):
+    import src.autoresearch.autoresearch as ar
+
+    class FakeContent:
+        text = json.dumps(
+            {
+                "description": "Change dropout.",
+                "patch": {"dropout": 0.2},
+                "expected_effect": "Improve validation loss.",
+                "search_strategy": "local",
+            }
+        )
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            return type("FakeMessage", (), {"content": [FakeContent()]})()
+
+    class FakeAnthropic:
+        def __init__(self):
+            self.messages = FakeMessages()
+
+    monkeypatch.setattr(ar.anthropic, "Anthropic", FakeAnthropic)
+
+    with pytest.raises(ValueError, match="Unsupported Tinker SFT hyperparameter"):
+        ar.propose_hypothesis(
+            {"learning_rate": 1e-4},
+            [],
+            _minimal_task(),
+            allowed_params=["learning_rate", "num_epochs"],
+        )
+
+
+def test_keep_node_canonicalizes_tinker_alias_patch():
+    import src.autoresearch.autoresearch as ar
+
+    state = _make_state(
+        plan={"training_script_path": "train.py", "base_model": "Qwen/Qwen3.5-9B",
+              "lora_config": None, "estimated_cost": 0.0,
+              "estimated_time_min": 5, "eval_metric": "primary_metric",
+              "backend": "tinker_sft"},
+        current_config={"learning_rate": 1e-4, "epochs": 2},
+        current_patch=json.dumps({"epochs": 3}),
+        last_score={"scalar": 0.6, "metrics": {}, "critique": ""},
+        best_score={"scalar": 0.5, "metrics": {}, "critique": ""},
+        last_result={
+            "job_id": "candidate",
+            "status": "COMPLETED",
+            "metrics": {"train_loss": 0.4, "val_loss": 0.4,
+                        "test_loss": 0.4, "primary_metric": 0.6},
+            "model_path": "candidate-model",
+            "cost_usd": 0.01,
+            "logs_path": "candidate.jsonl",
+        },
+    )
+
+    out = ar.keep_node(state)
+
+    assert out["current_config"]["num_epochs"] == 3
+    assert "epochs" not in out["current_config"]
+
+
 # ─── continue_edge ────────────────────────────────────────────────────────────
 
 def _make_state(**overrides):


### PR DESCRIPTION
## Summary
- canonicalize Manager/DecisionEngine legacy Tinker hyperparameter aliases (`epochs`, `max_seq_len`) into `num_epochs` / `max_seq_length` before AutoResearch proposal/search state sees them
- canonicalize alias patches returned by the proposer so the persisted config, diary state, and next Tinker run use supported V1 names
- keep unsupported Tinker knobs rejected after alias normalization

## Validation
- `python3 -m compileall src tests/test_autoresearch.py`
- `uv run --with pytest --with anthropic --with langgraph --with fastapi --with httpx python -m pytest tests/test_autoresearch.py -q`
- `uv run --with pytest --with anthropic --with langgraph --with datasets --with huggingface-hub --with requests python -m pytest tests/test_autoresearch.py tests/test_tinker_runner.py tests/test_e2e_propose.py -q`
- `uv run --with pytest --with anthropic --with langgraph --with fastapi --with httpx --with datasets --with huggingface-hub --with requests python -m pytest tests -q --ignore=tests/data_generator/test_mode_b_hf_retrieval.py`

## Notes
- I intentionally stopped a broad branch run without the `--ignore` after it entered the older ungated live Hugging Face retrieval test on this branch base. The dedicated no-live rerun above passed.
- This fixes the live API failure observed after the baseline Tinker run: `Unsupported Tinker SFT hyperparameter(s): ['epochs']`.
