### PR TITLE
[codex] write finite metrics for budget skips

### DIFF
--- a/src/autoresearch/autoresearch.py
+++ b/src/autoresearch/autoresearch.py
@@ -54,6 +54,7 @@ _MAX_NO_IMPROVE = 3   # halt after this many consecutive non-improving iteration
 _MAX_ITERATIONS = 20  # hard cap on total iterations regardless of improvement
 _MIN_RELATIVE_IMPROVEMENT_PCT = 1.0
 _MIN_ABSOLUTE_IMPROVEMENT = 1e-9
+_BUDGET_SKIPPED_LOSS = 1_000_000_000.0
 _EXPERIMENT_CACHE: dict[str, ExperimentResult] = {}
 _TINKER_HYPERPARAMETER_ALIASES = {
     "epochs": "num_epochs",
@@ -940,11 +941,10 @@ def _budget_limited_experiment_result(
 ) -> ExperimentResult:
     run_dir = Path(output_dir) / run_id
     run_dir.mkdir(parents=True, exist_ok=True)
-    loss = float("inf")
     metrics: TrainingMetrics = {
-        "train_loss": loss,
-        "val_loss": loss,
-        "test_loss": loss,
+        "train_loss": _BUDGET_SKIPPED_LOSS,
+        "val_loss": _BUDGET_SKIPPED_LOSS,
+        "test_loss": _BUDGET_SKIPPED_LOSS,
         "primary_metric": 0.0,
     }
     metrics_row = {
@@ -954,8 +954,8 @@ def _budget_limited_experiment_result(
         "reason": reason,
     }
     metrics_path = run_dir / "metrics.jsonl"
-    metrics_path.write_text(json.dumps(metrics_row) + "\n")
-    (run_dir / "metrics.json").write_text(json.dumps(metrics, indent=2))
+    metrics_path.write_text(json.dumps(metrics_row, allow_nan=False) + "\n")
+    (run_dir / "metrics.json").write_text(json.dumps(metrics, indent=2, allow_nan=False))
     (run_dir / "manifest.json").write_text(
         json.dumps(
             {

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -460,14 +460,23 @@ def test_run_node_preflight_skips_unaffordable_candidate(monkeypatch, tmp_path):
     )
 
     out = ar.run_node(state)
-    manifest = json.loads(
-        (Path(out["last_result"]["model_path"]) / "manifest.json").read_text()
-    )
+    run_dir = Path(out["last_result"]["model_path"])
+    manifest = json.loads((run_dir / "manifest.json").read_text())
+    metrics = json.loads((run_dir / "metrics.json").read_text())
+    metrics_row = json.loads((run_dir / "metrics.jsonl").read_text())
 
     assert out["last_result"]["status"] == "CANCELLED"
     assert out["last_result"]["cost_usd"] == 0.0
     assert out["should_stop"] is True
     assert manifest["budget_preflight_skipped"] is True
+    assert all(
+        math.isfinite(out["last_result"]["metrics"][key])
+        for key in ("train_loss", "val_loss", "test_loss")
+    )
+    assert all(math.isfinite(metrics[key]) for key in ("train_loss", "val_loss", "test_loss"))
+    assert all(math.isfinite(metrics_row[key]) for key in ("train_loss", "val_loss", "test_loss"))
+    json.dumps(metrics, allow_nan=False)
+    json.dumps(metrics_row, allow_nan=False)
 
 
 def test_invoke_autoresearch_graph_canonicalizes_tinker_initial_config(monkeypatch):

--- a/tests/test_tinker_runner.py
+++ b/tests/test_tinker_runner.py
@@ -440,7 +440,7 @@ def test_autoresearch_baseline_preflight_skips_unaffordable_run(monkeypatch, tmp
 
     assert result["baseline_result"]["status"] == "CANCELLED"
     assert result["baseline_result"]["cost_usd"] == 0.0
-    assert result["baseline_score"]["scalar"] == 0.0
+    assert result["baseline_score"]["scalar"] < 1e-8
     assert result["should_stop"] is True
     assert state["cost_manager"].spent_usd == 0.0
     assert (run_dir / "metrics.json").exists()


### PR DESCRIPTION
## Summary
- replace non-standard `Infinity` budget-skip losses with a finite large sentinel
- write skipped-run `metrics.json` and `metrics.jsonl` with `allow_nan=False`
- tighten tests so returned skipped-run metrics and artifact JSON are finite/strict

## Validation
- `python3 -m compileall src tests/test_autoresearch.py tests/test_tinker_runner.py`
- `uv run --with pytest --with anthropic --with langgraph --with fastapi --with httpx python -m pytest tests/test_autoresearch.py -q`
- `uv run --with pytest --with anthropic --with langgraph --with datasets --with huggingface-hub --with requests python -m pytest tests/test_autoresearch.py tests/test_tinker_runner.py tests/test_e2e_propose.py -q`
- `uv run --with pytest --with anthropic --with langgraph --with fastapi --with httpx --with datasets --with huggingface-hub --with requests python -m pytest tests -q --ignore=tests/data_generator/test_mode_b_hf_retrieval.py`

## Notes
- Found during the live API alias rerun: budget preflight artifacts were browser-visible but contained Python JSON extensions (`Infinity`). This PR keeps the budget skip semantics while making artifacts valid JSON/NDJSON.
