### PR TITLE
[codex] write strict Tinker metric artifacts

### DIFF
--- a/src/tinker_api/sft_runner.py
+++ b/src/tinker_api/sft_runner.py
@@ -37,6 +37,7 @@ SUPPORTED_TINKER_TUNABLES: frozenset[str] = frozenset(
 
 _INPUT_KEYS = ("input", "prompt", "question", "content")
 _TARGET_KEYS = ("output", "answer", "label", "target")
+_NONFINITE_LOSS_SENTINEL = 1_000_000_000.0
 
 
 @dataclass(frozen=True)
@@ -128,18 +129,25 @@ def run_tinker_sft_experiment(
 
             tokens = sum(_datum_token_count(datum) for datum in batch)
             record_tokens(run_name, tokens)
-            loss = _extract_loss(fwd_result, optim_result)
+            raw_loss = _extract_loss(fwd_result, optim_result)
+            loss, nonfinite_loss = _loss_for_artifact(raw_loss)
             step_metrics = {
                 "step": step + 1,
                 "train_loss": loss,
                 "val_loss": loss,
                 "test_loss": loss,
-                "primary_metric": _score_from_loss(loss),
+                "primary_metric": 0.0 if nonfinite_loss else _score_from_loss(loss),
                 "tokens": tokens,
             }
+            if nonfinite_loss:
+                step_metrics["nonfinite_loss"] = True
+                step_metrics["raw_loss"] = str(raw_loss)
+                status = "FAILED"
             metrics_history.append(step_metrics)
             with open(metrics_path, "a") as fh:
-                fh.write(json.dumps(step_metrics) + "\n")
+                fh.write(json.dumps(step_metrics, allow_nan=False) + "\n")
+            if nonfinite_loss:
+                break
 
         checkpoints, sampling_client = _save_final_artifacts(training_client, run_name)
         sample_payload = _sample_once(
@@ -472,7 +480,7 @@ def _evaluate_holdout_loss(
             for conversation in batch_targets
         ]
         result = _future_result(forward(batch, loss_fn="cross_entropy"))
-        loss = _extract_forward_loss(result, batch)
+        loss, _nonfinite_loss = _loss_for_artifact(_extract_forward_loss(result, batch))
         weight = _batch_loss_weight(batch)
         weighted_loss += loss * weight
         total_weight += weight
@@ -624,6 +632,15 @@ def _score_from_loss(loss: float | None) -> float:
     return 1.0 / (1.0 + loss)
 
 
+def _loss_for_artifact(loss: float | None) -> tuple[float, bool]:
+    if loss is None:
+        return _NONFINITE_LOSS_SENTINEL, True
+    loss = float(loss)
+    if not math.isfinite(loss):
+        return _NONFINITE_LOSS_SENTINEL, True
+    return loss, False
+
+
 def _save_final_artifacts(training_client: Any, run_id: str) -> tuple[dict[str, str], Any]:
     checkpoints: dict[str, str] = {}
     state_result = _call_optional_checkpoint(training_client, "save_state", f"{run_id}-final-state")
@@ -706,22 +723,26 @@ def _final_metrics(
     test_loss: float | None = None,
 ) -> TrainingMetrics:
     if not metrics_history:
-        loss = float("nan") if status == "FAILED" else 0.0
+        loss = _NONFINITE_LOSS_SENTINEL if status == "FAILED" else 0.0
         resolved_val_loss = loss if val_loss is None else val_loss
         resolved_test_loss = loss if test_loss is None else test_loss
+        resolved_val_loss, _ = _loss_for_artifact(resolved_val_loss)
+        resolved_test_loss, _ = _loss_for_artifact(resolved_test_loss)
         return {
             "train_loss": loss,
             "val_loss": resolved_val_loss,
             "test_loss": resolved_test_loss,
             "primary_metric": _score_from_loss(resolved_val_loss),
         }
-    train_loss = _mean_metric(metrics_history, "train_loss")
+    train_loss, _ = _loss_for_artifact(_mean_metric(metrics_history, "train_loss"))
     resolved_val_loss = (
         _mean_metric(metrics_history, "val_loss") if val_loss is None else val_loss
     )
     resolved_test_loss = (
         _mean_metric(metrics_history, "test_loss") if test_loss is None else test_loss
     )
+    resolved_val_loss, _ = _loss_for_artifact(resolved_val_loss)
+    resolved_test_loss, _ = _loss_for_artifact(resolved_test_loss)
     return {
         "train_loss": train_loss,
         "val_loss": resolved_val_loss,
@@ -752,4 +773,4 @@ def _dataset_path_for_manifest(
 def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "w") as fh:
-        json.dump(payload, fh, indent=2, allow_nan=True)
+        json.dump(payload, fh, indent=2, allow_nan=False)

--- a/tests/test_tinker_runner.py
+++ b/tests/test_tinker_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import math
 import sys
 import types
 from pathlib import Path
@@ -10,6 +11,20 @@ from unittest.mock import MagicMock
 import pytest
 
 from src.autoresearch.config import TrainingConfig
+
+
+def _strict_json(text: str):
+    return json.loads(
+        text,
+        parse_constant=lambda value: pytest.fail(f"non-standard JSON constant: {value}"),
+    )
+
+
+def _assert_strict_json_file(path: Path):
+    text = path.read_text()
+    assert "NaN" not in text
+    assert "Infinity" not in text
+    return _strict_json(text)
 
 
 def test_record_to_conversation_accepts_messages():
@@ -115,6 +130,103 @@ def test_run_tinker_sft_experiment_writes_artifacts(tmp_path, monkeypatch):
     assert {call["train_on_what"] for call in state.conversions} == {
         "last_assistant_message"
     }
+
+
+def test_run_tinker_sft_experiment_writes_strict_json_for_nonfinite_training_loss(
+    tmp_path,
+    monkeypatch,
+):
+    _install_fake_tinker_stack(monkeypatch, losses=[float("nan"), 0.25])
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [{"input": "Question", "output": "Answer"}],
+    )
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=1),
+        str(data_path),
+        run_id="nonfinite-training-run",
+        max_steps=2,
+        output_dir=str(tmp_path / "experiments"),
+    )
+
+    run_dir = tmp_path / "experiments" / "nonfinite-training-run"
+    metrics = _assert_strict_json_file(run_dir / "metrics.json")
+    manifest = _assert_strict_json_file(run_dir / "manifest.json")
+    rows = [
+        _strict_json(line)
+        for line in (run_dir / "metrics.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+
+    assert result["status"] == "FAILED"
+    assert manifest["status"] == "FAILED"
+    assert rows[0]["nonfinite_loss"] is True
+    assert rows[0]["train_loss"] == 1_000_000_000.0
+    assert all(
+        math.isfinite(metrics[key])
+        for key in ("train_loss", "val_loss", "test_loss", "primary_metric")
+    )
+    assert all(
+        math.isfinite(result["metrics"][key])
+        for key in ("train_loss", "val_loss", "test_loss", "primary_metric")
+    )
+
+
+def test_run_tinker_sft_experiment_writes_strict_json_for_nonfinite_holdout_loss(
+    tmp_path,
+    monkeypatch,
+):
+    _install_fake_tinker_stack(
+        monkeypatch,
+        losses=[0.5],
+        forward_losses=[float("inf"), float("nan")],
+    )
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [
+            {"input": "train", "output": "a"},
+            {"input": "validation", "output": "b"},
+            {"input": "test", "output": "c"},
+        ],
+    )
+    dataset_result = {
+        "dataset": {
+            "path": str(data_path),
+            "train_size": 1,
+            "val_size": 1,
+            "test_size": 1,
+        },
+        "next_agent": "decision_engine",
+    }
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=1),
+        dataset_result,
+        run_id="nonfinite-holdout-run",
+        max_steps=1,
+        output_dir=str(tmp_path / "experiments"),
+    )
+
+    run_dir = tmp_path / "experiments" / "nonfinite-holdout-run"
+    metrics = _assert_strict_json_file(run_dir / "metrics.json")
+    manifest = _assert_strict_json_file(run_dir / "manifest.json")
+
+    assert result["status"] == "COMPLETED"
+    assert metrics["val_loss"] == 1_000_000_000.0
+    assert metrics["test_loss"] == 1_000_000_000.0
+    assert manifest["heldout_eval"] == {
+        "val_loss": 1_000_000_000.0,
+        "test_loss": 1_000_000_000.0,
+    }
+    assert all(
+        math.isfinite(result["metrics"][key])
+        for key in ("train_loss", "val_loss", "test_loss", "primary_metric")
+    )
 
 
 def test_run_tinker_sft_experiment_splits_multi_assistant_conversations(


### PR DESCRIPTION
## Summary
- sanitize non-finite Tinker training and heldout losses to a finite sentinel before artifact serialization
- write per-step metrics JSONL and final JSON artifacts with `allow_nan=False`
- mark non-finite training-loss runs as failed while preserving strict JSON manifest/metrics/sample artifacts

## Validation
- `python3 -m compileall src/tinker_api tests/test_tinker_runner.py`
- `uv run --with pytest --with anthropic --with langgraph --with datasets --with huggingface-hub --with requests python -m pytest tests/test_tinker_runner.py -q`
- `uv run --with pytest --with anthropic --with langgraph --with datasets --with huggingface-hub --with requests python -m pytest tests/test_tinker_runner.py tests/test_autoresearch.py tests/test_e2e_propose.py -q`

## Notes
- This is the Tinker-runner-side companion to #80. #80 fixes budget-preflight skip artifacts in AutoResearch; this PR fixes live runner artifacts if the SDK ever returns NaN/Infinity.
