### PR TITLE
[codex] fix artifact download links

### DIFF
--- a/src/server/app.py
+++ b/src/server/app.py
@@ -262,7 +262,7 @@ def _artifact_view(
         exists=exists,
         sizeBytes=path.stat().st_size if exists and path is not None else None,
         contentType=content_type,
-        downloadPath=f"/runs/{run_id}/artifacts/{name}" if downloadable else None,
+        downloadPath=f"/api/runs/{run_id}/artifacts/{name}" if downloadable else None,
     )
 
 

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -212,10 +212,10 @@ def test_create_run_surfaces_artifacts_and_allowlisted_downloads(tmp_path, monke
 
     files = {item["name"]: item for item in artifacts["files"]}
     assert files["manifest"]["exists"] is True
-    assert files["manifest"]["downloadPath"] == f"/runs/{run_id}/artifacts/manifest"
+    assert files["manifest"]["downloadPath"] == f"/api/runs/{run_id}/artifacts/manifest"
     assert files["metrics_log"]["contentType"] == "application/x-ndjson"
 
-    manifest_response = client.get(f"/api/runs/{run_id}/artifacts/manifest")
+    manifest_response = client.get(files["manifest"]["downloadPath"])
     assert manifest_response.status_code == 200
     assert manifest_response.json()["checkpoints"]["sampler_path"] == "tinker://sampler/abc"
 


### PR DESCRIPTION
## Summary
- make API-provided artifact `downloadPath` values point at the actual mounted route under `/api/runs/...`
- update the server API test to fetch the artifact through the advertised link, not a manually reconstructed URL

## Validation
- `python3 -m compileall src/server tests/test_server_api.py`
- `uv run --with pytest --with fastapi --with httpx --with anthropic --with langgraph python -m pytest tests/test_server_api.py -q`

## Notes
- Found during live API artifact review: clients following the returned `/runs/...` link would 404 because the FastAPI route is `/api/runs/{run_id}/artifacts/{artifact_name}`.
