### PR TITLE
[codex] make Manager invocation noninteractive by default

### DIFF
--- a/src/manager/manager.py
+++ b/src/manager/manager.py
@@ -51,14 +51,22 @@ def invoke_manager_graph(
     prompt: str,
     budget: float,
     data_path: str | None = None,
+    *,
+    interactive_data_prompt: bool = False,
 ) -> TrainedModel:
-    """Main entry point for the entire system. Builds and invokes the Manager graph."""
+    """Main entry point for the system.
+
+    Programmatic callers default to no-data Mode C when ``data_path`` is not
+    supplied. CLI-style callers can opt into the legacy stdin prompt with
+    ``interactive_data_prompt=True``.
+    """
     graph = build_manager_graph()
     initial_state: ManagerState = {
         "prompt": prompt,
         "budget": budget,
         "data_path": data_path,
         "has_data": data_path is not None,
+        "interactive_data_prompt": interactive_data_prompt,
         "task_reasoning": None,
         "config": None,
         "result": None,
@@ -76,6 +84,9 @@ def query_data_node(state: ManagerState) -> dict:
         if os.path.exists(existing_path):
             resolved_path = os.path.abspath(existing_path)
             return {"has_data": True, "data_path": resolved_path}
+        return {"has_data": False, "data_path": None}
+
+    if not state.get("interactive_data_prompt", True):
         return {"has_data": False, "data_path": None}
 
     try:

--- a/src/types.py
+++ b/src/types.py
@@ -6,7 +6,7 @@ See spec-site/content/spec.ts for the canonical definitions.
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 
 # ENUMS
@@ -255,6 +255,7 @@ class ManagerState(TypedDict):
     budget: float
     data_path: str | None
     has_data: bool
+    interactive_data_prompt: NotRequired[bool]
     task_reasoning: TaskReasoning | None
     config: OrchestrationConfig | None
     result: TrainedModel | None

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -9,6 +9,7 @@ from src.manager.manager import (
     _parse_task_reasoning_response,
     build_manager_graph,
     build_orchestration_config,
+    invoke_manager_graph,
     log_decision,
     orchestrate_node,
     query_data_node,
@@ -151,6 +152,63 @@ def test_query_data_node_treats_eof_as_no_data(monkeypatch):
     )
 
     assert out == {"has_data": False, "data_path": None}
+
+
+def test_query_data_node_can_skip_interactive_prompt(monkeypatch):
+    def fail_input(_prompt):
+        raise AssertionError("query_data_node should not prompt in noninteractive mode")
+
+    monkeypatch.setattr("builtins.input", fail_input)
+
+    out = query_data_node(
+        {
+            "prompt": "build an assistant",
+            "budget": 5.0,
+            "data_path": None,
+            "has_data": False,
+            "interactive_data_prompt": False,
+            "task_reasoning": None,
+            "config": None,
+            "result": None,
+        }
+    )
+
+    assert out == {"has_data": False, "data_path": None}
+
+
+def test_invoke_manager_graph_defaults_to_noninteractive_mode(monkeypatch):
+    captured = {}
+
+    class FakeGraph:
+        def invoke(self, state):
+            captured.update(state)
+            return {"result": {"weights_path": "model"}}
+
+    monkeypatch.setattr(
+        "src.manager.manager.build_manager_graph",
+        lambda: FakeGraph(),
+    )
+
+    assert invoke_manager_graph("build an assistant", 5.0) == {"weights_path": "model"}
+    assert captured["interactive_data_prompt"] is False
+    assert captured["has_data"] is False
+
+
+def test_invoke_manager_graph_can_opt_into_interactive_prompt(monkeypatch):
+    captured = {}
+
+    class FakeGraph:
+        def invoke(self, state):
+            captured.update(state)
+            return {"result": {"weights_path": "model"}}
+
+    monkeypatch.setattr(
+        "src.manager.manager.build_manager_graph",
+        lambda: FakeGraph(),
+    )
+
+    invoke_manager_graph("build an assistant", 5.0, interactive_data_prompt=True)
+    assert captured["interactive_data_prompt"] is True
 
 
 def test_invoke_manager_graph_returns_trained_model():


### PR DESCRIPTION
## Summary
- make `invoke_manager_graph()` default to no-data Mode C instead of prompting stdin when `data_path` is omitted
- keep the legacy interactive prompt available via `interactive_data_prompt=True`
- add Manager tests for prompt skipping, default invocation state, and explicit interactive opt-in

## Root Cause
The API no-data path calls `invoke_manager_graph(prompt, budget, data_path=None)`. That eventually reached `query_user_for_data()` and printed the old interactive stdin prompt before falling through on EOF in our live API run. In a server or automation context, that prompt is noisy at best and can block depending on stdin behavior.

## Validation
- `python3 -m compileall src/manager src/types.py tests/test_manager.py`
- `uv run --with pytest --with anthropic --with langgraph python -m pytest tests/test_manager.py -q` (`17 passed, 1 skipped`)
- branch no-live suite: `uv run --with pytest --with anthropic --with langgraph python -m pytest tests -q --ignore=tests/integration/test_tinker_live_smoke.py --ignore=tests/data_generator/test_mode_b_hf_retrieval.py` (`176 passed, 7 skipped`)

## Live Context
Found during a live API Mode C/no-data run on the composed stack. The run completed end-to-end, but emitted `Do you have existing training data? (y/n):` from the server path before continuing.