### PR TITLE
[codex] harden Mode C web structuring caps

### DIFF
--- a/src/data_generator/mode_c/structuring.py
+++ b/src/data_generator/mode_c/structuring.py
@@ -60,27 +60,14 @@ def structure_web_sources_for_sft(
 
     target_records = _target_web_structuring_records(config, max_records)
     try:
-        message = client.messages.create(
-            model=teacher_model,
-            max_tokens=max(1600, min(target_records, len(source_pages) * 3) * 320),
-            temperature=0.4,
-            system=(
-                "You convert acquired public web source excerpts into supervised "
-                "fine-tuning examples. Return only valid JSON arrays."
-            ),
-            messages=[
-                {
-                    "role": "user",
-                    "content": _structuring_prompt(
-                        config,
-                        schema,
-                        source_pages,
-                        target_records,
-                    ),
-                }
-            ],
+        records, repair_used = _request_teacher_records(
+            client,
+            config,
+            schema,
+            source_pages,
+            teacher_model,
+            target_records,
         )
-        records = _coerce_teacher_records(_parse_json_array(_message_text(message)))
     except Exception as exc:
         if os.getenv("DATA_GENERATOR_WEB_STRUCTURING_STRICT") == "1":
             raise
@@ -96,6 +83,7 @@ def structure_web_sources_for_sft(
                 "schema": schema,
                 "teacher_model": teacher_model,
                 "teacher_used": True,
+                "teacher_repair_used": repair_used,
                 "source_record_count": len(source_pages),
                 "requested_records": target_records,
             },
@@ -142,6 +130,63 @@ def _target_web_structuring_records(
                     return _positive_int(value, DEFAULT_WEB_STRUCTURING_RECORDS)
 
     return DEFAULT_WEB_STRUCTURING_RECORDS
+
+
+def _request_teacher_records(
+    client: Any,
+    config: Mapping[str, Any],
+    schema: DataSchema,
+    source_pages: Sequence[Mapping[str, Any]],
+    teacher_model: str,
+    target_records: int,
+) -> tuple[list[dict[str, Any]], bool]:
+    max_tokens = max(1600, min(target_records, len(source_pages) * 3) * 320)
+    message = client.messages.create(
+        model=teacher_model,
+        max_tokens=max_tokens,
+        temperature=0.4,
+        system=(
+            "You convert acquired public web source excerpts into supervised "
+            "fine-tuning examples. Return only valid JSON arrays."
+        ),
+        messages=[
+            {
+                "role": "user",
+                "content": _structuring_prompt(
+                    config,
+                    schema,
+                    source_pages,
+                    target_records,
+                ),
+            }
+        ],
+    )
+    text = _message_text(message)
+    try:
+        return _coerce_teacher_records(_parse_json_array(text)), False
+    except Exception as parse_exc:
+        repaired = client.messages.create(
+            model=teacher_model,
+            max_tokens=max_tokens,
+            temperature=0,
+            system=(
+                "You repair JSON for a supervised fine-tuning data pipeline. "
+                "Return only a valid JSON array and no prose."
+            ),
+            messages=[
+                {
+                    "role": "user",
+                    "content": _repair_prompt(text, parse_exc, target_records),
+                }
+            ],
+        )
+        try:
+            return _coerce_teacher_records(_parse_json_array(_message_text(repaired))), True
+        except Exception as repair_exc:
+            raise ValueError(
+                "teacher response was not valid JSON and repair failed: "
+                f"{parse_exc}; repair error: {repair_exc}"
+            ) from repair_exc
 
 
 def _positive_int(value: Any, default: int) -> int:
@@ -266,10 +311,61 @@ def _optional_anthropic_client() -> Any | None:
 
 
 def _parse_json_array(text: str) -> list[Any]:
-    parsed = json.loads(_strip_fences(text))
+    stripped = _strip_fences(text)
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        parsed = json.loads(_extract_first_json_array(stripped))
     if not isinstance(parsed, list):
         raise ValueError("teacher response must be a JSON array")
     return parsed
+
+
+def _extract_first_json_array(text: str) -> str:
+    start: int | None = None
+    depth = 0
+    in_string = False
+    escaped = False
+    for index, char in enumerate(text):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+
+        if char == '"':
+            in_string = True
+        elif char == "[":
+            if depth == 0:
+                start = index
+            depth += 1
+        elif char == "]" and depth:
+            depth -= 1
+            if depth == 0 and start is not None:
+                return text[start:index + 1]
+
+    return text
+
+
+def _repair_prompt(text: str, parse_error: Exception, max_records: int) -> str:
+    clipped = text[:20000]
+    return f"""Repair this teacher response into valid JSON.
+
+Original parse error:
+{parse_error}
+
+Requirements:
+- Return only a JSON array of at most {max_records} objects.
+- Every object must include "input", "output", and "messages".
+- "messages" must include at least one user message and one assistant message.
+- Use double-quoted JSON property names and string values.
+- Do not add markdown fences or explanation.
+
+Invalid response:
+{clipped}"""
 
 
 def _strip_fences(text: str) -> str:

--- a/src/data_generator/mode_c/structuring.py
+++ b/src/data_generator/mode_c/structuring.py
@@ -15,6 +15,8 @@ from src.data_generator.mode_c.synthetic import (
 )
 from src.types import DataSchema, OrchestrationConfig, RawData, ValidationReport
 
+DEFAULT_WEB_STRUCTURING_RECORDS = 24
+
 
 @dataclass(frozen=True)
 class WebStructuringResult:
@@ -30,7 +32,7 @@ def structure_web_sources_for_sft(
     *,
     teacher_client: Any = None,
     teacher_model: str = DEFAULT_TEACHER_MODEL,
-    max_records: int = 24,
+    max_records: int | None = None,
 ) -> WebStructuringResult:
     """Turn raw web pages into trainable chat/SFT records when a teacher exists.
 
@@ -56,10 +58,11 @@ def structure_web_sources_for_sft(
             "Mode C web structuring requires a teacher client or ANTHROPIC_API_KEY.",
         )
 
+    target_records = _target_web_structuring_records(config, max_records)
     try:
         message = client.messages.create(
             model=teacher_model,
-            max_tokens=max(1600, min(max_records, len(source_pages) * 3) * 320),
+            max_tokens=max(1600, min(target_records, len(source_pages) * 3) * 320),
             temperature=0.4,
             system=(
                 "You convert acquired public web source excerpts into supervised "
@@ -68,7 +71,12 @@ def structure_web_sources_for_sft(
             messages=[
                 {
                     "role": "user",
-                    "content": _structuring_prompt(config, schema, source_pages, max_records),
+                    "content": _structuring_prompt(
+                        config,
+                        schema,
+                        source_pages,
+                        target_records,
+                    ),
                 }
             ],
         )
@@ -89,7 +97,7 @@ def structure_web_sources_for_sft(
                 "teacher_model": teacher_model,
                 "teacher_used": True,
                 "source_record_count": len(source_pages),
-                "requested_records": max_records,
+                "requested_records": target_records,
             },
         },
         schema,
@@ -102,6 +110,46 @@ def structure_web_sources_for_sft(
         validation_report=validation,
         teacher_used=True,
     )
+
+
+def _target_web_structuring_records(
+    config: Mapping[str, Any],
+    explicit_max_records: int | None,
+) -> int:
+    if explicit_max_records is not None:
+        return _positive_int(explicit_max_records, DEFAULT_WEB_STRUCTURING_RECORDS)
+
+    for env_name in (
+        "DATA_GENERATOR_WEB_STRUCTURING_MAX_RECORDS",
+        "DATA_GENERATOR_SYNTHETIC_EXAMPLES",
+    ):
+        value = os.getenv(env_name)
+        if value:
+            return _positive_int(value, DEFAULT_WEB_STRUCTURING_RECORDS)
+
+    procedure = config.get("training_procedure", {})
+    if isinstance(procedure, Mapping):
+        hyperparams = procedure.get("hyperparameters", {})
+        if isinstance(hyperparams, Mapping):
+            for key in (
+                "web_structuring_examples",
+                "synthetic_examples",
+                "n_examples",
+                "num_examples",
+            ):
+                value = hyperparams.get(key)
+                if value is not None:
+                    return _positive_int(value, DEFAULT_WEB_STRUCTURING_RECORDS)
+
+    return DEFAULT_WEB_STRUCTURING_RECORDS
+
+
+def _positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
 
 
 def _unstructured_result(

--- a/tests/test_mode_c_web_structuring.py
+++ b/tests/test_mode_c_web_structuring.py
@@ -92,6 +92,66 @@ class _FakeMessages:
         return SimpleNamespace(content=[SimpleNamespace(text=json.dumps(payload))])
 
 
+class _RepairingTeacher:
+    def __init__(self):
+        self.messages = _RepairingMessages()
+
+
+class _RepairingMessages(_FakeMessages):
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        prompt = kwargs["messages"][0]["content"]
+        if "Infer a supervised fine-tuning data schema" in prompt:
+            payload = {
+                "input_format": "support ticket text",
+                "output_format": "one of: urgent, normal",
+                "input_description": "A support ticket.",
+                "output_description": "The urgency label.",
+                "example_pair": {
+                    "input": "The checkout service is down for all users.",
+                    "output": "urgent",
+                },
+            }
+            return SimpleNamespace(content=[SimpleNamespace(text=json.dumps(payload))])
+
+        if "Repair this teacher response into valid JSON" in prompt:
+            payload = [
+                {
+                    "input": "The checkout service is down for all users.",
+                    "output": "urgent",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "The checkout service is down for all users.",
+                        },
+                        {"role": "assistant", "content": "urgent"},
+                    ],
+                    "source_url": "https://example.com/urgency",
+                },
+                {
+                    "input": "A customer asks how to update a profile photo.",
+                    "output": "normal",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "A customer asks how to update a profile photo.",
+                        },
+                        {"role": "assistant", "content": "normal"},
+                    ],
+                    "source_url": "https://example.com/urgency",
+                }
+            ]
+            return SimpleNamespace(content=[SimpleNamespace(text=json.dumps(payload))])
+
+        bad_json = (
+            "[{\"input\": \"The checkout service is down\", "
+            "output: \"urgent\", "
+            "\"messages\": [{\"role\": \"user\", \"content\": \"The checkout service is down\"}, "
+            "{\"role\": \"assistant\", \"content\": \"urgent\"}]}]"
+        )
+        return SimpleNamespace(content=[SimpleNamespace(text=bad_json)])
+
+
 def test_structure_web_sources_with_teacher_returns_trainable_records(monkeypatch):
     monkeypatch.delenv("DATA_GENERATOR_SYNTHETIC_OFFLINE", raising=False)
     teacher = _FakeTeacher()
@@ -115,6 +175,27 @@ def test_structure_web_sources_with_teacher_returns_trainable_records(monkeypatc
     assert all(record["messages"] for record in result.raw_data["records"])
     assert result.raw_data["format_meta"]["requested_records"] == 4
     assert len(teacher.messages.calls) == 2
+
+
+def test_structure_web_sources_repairs_malformed_teacher_json(monkeypatch):
+    monkeypatch.delenv("DATA_GENERATOR_SYNTHETIC_OFFLINE", raising=False)
+    teacher = _RepairingTeacher()
+
+    result = structure_web_sources_for_sft(
+        _config(),
+        _pages(),
+        teacher_client=teacher,
+        max_records=4,
+    )
+
+    assert result.validation_report["passed"] is True
+    assert result.raw_data["format_meta"]["teacher_repair_used"] is True
+    assert len(result.raw_data["records"]) == 2
+    assert result.raw_data["records"][0]["output"] == "urgent"
+    assert len(teacher.messages.calls) == 3
+    repair_call = teacher.messages.calls[-1]
+    assert repair_call["temperature"] == 0
+    assert "at most 4 objects" in repair_call["messages"][0]["content"]
 
 
 def test_structure_web_sources_respects_synthetic_example_cap(monkeypatch):

--- a/tests/test_mode_c_web_structuring.py
+++ b/tests/test_mode_c_web_structuring.py
@@ -113,7 +113,54 @@ def test_structure_web_sources_with_teacher_returns_trainable_records(monkeypatc
         "normal",
     }
     assert all(record["messages"] for record in result.raw_data["records"])
+    assert result.raw_data["format_meta"]["requested_records"] == 4
     assert len(teacher.messages.calls) == 2
+
+
+def test_structure_web_sources_respects_synthetic_example_cap(monkeypatch):
+    monkeypatch.delenv("DATA_GENERATOR_SYNTHETIC_OFFLINE", raising=False)
+    monkeypatch.setenv("DATA_GENERATOR_SYNTHETIC_EXAMPLES", "8")
+    teacher = _FakeTeacher()
+
+    result = structure_web_sources_for_sft(
+        _config(),
+        _pages(),
+        teacher_client=teacher,
+    )
+
+    structuring_call = teacher.messages.calls[-1]
+    assert result.raw_data["format_meta"]["requested_records"] == 8
+    assert "at most 8 objects" in structuring_call["messages"][0]["content"]
+
+
+def test_structure_web_sources_prefers_web_structuring_cap(monkeypatch):
+    monkeypatch.delenv("DATA_GENERATOR_SYNTHETIC_OFFLINE", raising=False)
+    monkeypatch.setenv("DATA_GENERATOR_SYNTHETIC_EXAMPLES", "12")
+    monkeypatch.setenv("DATA_GENERATOR_WEB_STRUCTURING_MAX_RECORDS", "5")
+    teacher = _FakeTeacher()
+
+    result = structure_web_sources_for_sft(
+        _config(),
+        _pages(),
+        teacher_client=teacher,
+    )
+
+    assert result.raw_data["format_meta"]["requested_records"] == 5
+
+
+def test_structure_web_sources_uses_config_example_cap(monkeypatch):
+    monkeypatch.delenv("DATA_GENERATOR_SYNTHETIC_OFFLINE", raising=False)
+    config = _config()
+    config["training_procedure"]["hyperparameters"]["synthetic_examples"] = 9
+    teacher = _FakeTeacher()
+
+    result = structure_web_sources_for_sft(
+        config,
+        _pages(),
+        teacher_client=teacher,
+    )
+
+    assert result.raw_data["format_meta"]["requested_records"] == 9
 
 
 def test_aggregate_web_sources_uses_structured_records_when_required(monkeypatch):


### PR DESCRIPTION
## Summary
- make Mode C web structuring use an explicit target-record budget instead of always requesting 24 examples
- honor `DATA_GENERATOR_WEB_STRUCTURING_MAX_RECORDS`, then `DATA_GENERATOR_SYNTHETIC_EXAMPLES`, then config hyperparameters such as `web_structuring_examples` / `synthetic_examples`
- preserve explicit `max_records=` overrides for direct callers
- add a one-shot teacher JSON repair path for malformed-but-repairable web-structuring responses

## Root Cause
During live API no-data validation I set `DATA_GENERATOR_SYNTHETIC_EXAMPLES=8`, but the web-structuring path still requested up to 24 records and produced 21 trainable rows. A follow-up capped live run then exposed a second reliability issue: the teacher occasionally returned almost-JSON with an unquoted property, causing DataGen to reject the whole web-structured dataset before Tinker launched.

## Validation
- `python3 -m compileall src/data_generator/mode_c tests/test_mode_c_web_structuring.py`
- Focused Mode C suite: `uv run --with pytest --with anthropic --with langgraph python -m pytest tests/test_mode_c_web_structuring.py tests/test_mode_c_web_manager_boundary.py tests/test_mode_c.py -q` (`23 passed`)
- Branch no-live suite: `uv run --with pytest --with fastapi --with httpx --with anthropic --with langgraph --with datasets --with huggingface-hub --with requests --with tavily-python --with trafilatura --with pymupdf python -m pytest tests -q --ignore=tests/integration/test_tinker_live_smoke.py --ignore=tests/data_generator/test_mode_b_hf_retrieval.py` (`199 passed, 6 skipped`)
- Composed-stack no-live suite after merging this leaf into the local draft stack: `260 passed, 6 skipped`

## Live Context
- Failed capped no-data API run found the malformed-teacher-JSON path before Tinker launch.
- After this PR update, capped no-data API rerun completed end to end with requested record caps `[8, 8, 8]`, 5 curated JSONL rows, baseline + one real Tinker candidate, budget preflight skip at `$2.24`, and all five API artifact downloads returning 200.