### PR TITLE
[codex] Preserve streamed terminal metrics

### DIFF
--- a/src/manager/manager.py
+++ b/src/manager/manager.py
@@ -163,10 +163,17 @@ def orchestrate_node(state: ManagerState) -> dict:
     result = invoke_autoresearch_graph(plan, config, cost_manager)
     raise_if_cancelled()
 
+    termination = result["cost"].get("termination_reason")
+    if termination == "budget_limit" and result["n_iterations"] == 0:
+        summary = "Training skipped by budget guard"
+    elif termination == "budget_limit":
+        summary = "Training stopped at budget limit"
+    else:
+        summary = "Training complete"
     log_event(
         AgentName.MANAGER,
         LogLevel.INFO,
-        f"Training complete — {result['n_iterations']} iterations, "
+        f"{summary} — {result['n_iterations']} iterations, "
         f"cost=${result['cost']['total_usd']:.2f}",
         {},
     )

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -229,6 +229,9 @@ def _iterations_from_diary(path: str | None) -> list[IterationView]:
         except json.JSONDecodeError:
             continue
 
+        if _is_budget_preflight_skip(row):
+            continue
+
         metrics = row.get("metrics") or {}
         iteration = int(row.get("iteration") or len(iterations) + 1)
         decision = row.get("decision") or "PENDING"
@@ -313,6 +316,15 @@ def _cost_from_diary(path: Path) -> float:
     return sum(float(row.get("cost_usd") or 0.0) for row in _jsonl_rows(path))
 
 
+def _is_budget_preflight_skip(row: dict[str, Any] | None) -> bool:
+    if not row:
+        return False
+    if row.get("budget_preflight_skipped") is True:
+        return True
+    note = str(row.get("notes") or row.get("reason") or "").lower()
+    return "budget preflight" in note and "skipped" in note
+
+
 def _experiment_dirs(record: _RunRecord) -> list[Path]:
     root = record.output_dir / "experiments"
     if not root.is_dir():
@@ -359,11 +371,16 @@ def _metric_point(row: dict[str, Any], iteration: int) -> MetricPoint | None:
 def _metrics_from_experiments(record: _RunRecord) -> list[MetricPoint]:
     points: list[MetricPoint] = []
     for run_dir in _experiment_dirs(record):
+        manifest = _read_json_if_exists(run_dir / "manifest.json")
+        if _is_budget_preflight_skip(manifest):
+            continue
         rows = _jsonl_rows(run_dir / "metrics.jsonl")
         if not rows:
             metrics = _read_json_if_exists(run_dir / "metrics.json")
             rows = [metrics] if metrics else []
         for row in rows:
+            if _is_budget_preflight_skip(row):
+                continue
             point = _metric_point(row, len(points) + 1)
             if point:
                 points.append(point)

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -524,7 +524,8 @@ def _store_manager_result(record: _RunRecord, result: dict[str, Any]) -> None:
     record.status = "complete"
     record.cost_spent = float((result.get("cost") or {}).get("total_usd") or 0.0)
     metric = _metric_from_result(result)
-    record.metrics = [metric] if metric else []
+    if not record.metrics:
+        record.metrics = [metric] if metric else []
     record.iterations = _iterations_from_diary(result.get("research_diary_path"))
     record.artifacts = _artifacts_from_result(record, result)
     _complete_all_stages(record)

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -553,8 +553,30 @@ def _budget_preflight_skip_reason_from_result(
     return reason or "budget preflight skipped the Tinker launch"
 
 
+def _selected_training_terminal_state(
+    record: _RunRecord,
+    result: dict[str, Any],
+) -> tuple[str | None, str | None]:
+    model_path = _resolve_reported_path(record, result.get("weights_path"))
+    manifest = _read_json_if_exists(model_path / "manifest.json") if model_path else None
+    status = str((manifest or {}).get("status") or "").strip().upper()
+    if status not in {"FAILED", "CANCELLED"}:
+        return None, None
+
+    reason = str(
+        (manifest or {}).get("error")
+        or (manifest or {}).get("reason")
+        or (manifest or {}).get("status_reason")
+        or ""
+    ).strip()
+    if not reason:
+        reason = f"selected training artifact reported status {status}"
+    return status.lower(), reason
+
+
 def _store_manager_result(record: _RunRecord, result: dict[str, Any]) -> None:
     budget_skip_reason = _budget_preflight_skip_reason_from_result(record, result)
+    terminal_status, terminal_reason = _selected_training_terminal_state(record, result)
     record.result = result
     record.cost_spent = float((result.get("cost") or {}).get("total_usd") or 0.0)
     metric = _metric_from_result(result)
@@ -571,6 +593,15 @@ def _store_manager_result(record: _RunRecord, result: dict[str, Any]) -> None:
             "Manager",
             f"Training skipped by budget guard: {budget_skip_reason}",
             "warning",
+        )
+    elif terminal_status:
+        record.status = terminal_status
+        record.error = terminal_reason
+        _append_log(
+            record,
+            "Manager",
+            f"Training artifact ended with status {terminal_status}: {terminal_reason}",
+            "error" if terminal_status == "failed" else "warning",
         )
     else:
         record.status = "complete"

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -536,17 +536,45 @@ def _artifacts_from_result(record: _RunRecord, result: dict[str, Any]) -> RunArt
     )
 
 
+def _budget_preflight_skip_reason_from_result(
+    record: _RunRecord,
+    result: dict[str, Any],
+) -> str | None:
+    cost = result.get("cost") or {}
+    if cost.get("termination_reason") != "budget_limit":
+        return None
+
+    model_path = _resolve_reported_path(record, result.get("weights_path"))
+    manifest = _read_json_if_exists(model_path / "manifest.json") if model_path else None
+    if not _is_budget_preflight_skip(manifest):
+        return None
+
+    reason = str((manifest or {}).get("budget_skip_reason") or "").strip()
+    return reason or "budget preflight skipped the Tinker launch"
+
+
 def _store_manager_result(record: _RunRecord, result: dict[str, Any]) -> None:
+    budget_skip_reason = _budget_preflight_skip_reason_from_result(record, result)
     record.result = result
-    record.status = "complete"
     record.cost_spent = float((result.get("cost") or {}).get("total_usd") or 0.0)
     metric = _metric_from_result(result)
-    if not record.metrics:
+    if not budget_skip_reason and not record.metrics:
         record.metrics = [metric] if metric else []
     record.iterations = _iterations_from_diary(result.get("research_diary_path"))
     record.artifacts = _artifacts_from_result(record, result)
     _complete_all_stages(record)
-    _append_log(record, "Manager", "Training pipeline complete", "success")
+    if budget_skip_reason:
+        record.status = "cancelled"
+        record.error = budget_skip_reason
+        _append_log(
+            record,
+            "Manager",
+            f"Training skipped by budget guard: {budget_skip_reason}",
+            "warning",
+        )
+    else:
+        record.status = "complete"
+        _append_log(record, "Manager", "Training pipeline complete", "success")
 
 
 def _run_manager(record: _RunRecord) -> None:

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -65,6 +65,41 @@ def _write_tinker_artifacts(
     )
 
 
+def _write_budget_skip_artifacts(run_dir: Path, *, run_id: str) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    sentinel_metrics = {
+        "train_loss": 1_000_000_000.0,
+        "val_loss": 1_000_000_000.0,
+        "test_loss": 1_000_000_000.0,
+        "primary_metric": 0.0,
+    }
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "run_id": run_id,
+                "status": "CANCELLED",
+                "budget_preflight_skipped": True,
+                "checkpoints": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "metrics.json").write_text(json.dumps(sentinel_metrics), encoding="utf-8")
+    (run_dir / "metrics.jsonl").write_text(
+        json.dumps(
+            {
+                "step": 0,
+                **sentinel_metrics,
+                "budget_preflight_skipped": True,
+                "reason": "estimated run cost exceeds remaining budget",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (run_dir / "sample.json").write_text(json.dumps({"text": ""}), encoding="utf-8")
+
+
 def _fake_model(tmp_path, *, total_cost=1.25, with_artifacts=False):
     diary_path = tmp_path / "diary.jsonl"
     diary_path.write_text(
@@ -257,7 +292,7 @@ def test_running_run_refreshes_logs_iterations_metrics_and_artifacts(tmp_path, m
     ready = threading.Event()
     release = threading.Event()
 
-    def fake_invoke(prompt, budget, data_path=None):
+    def fake_invoke(prompt, budget, data_path=None, **_kwargs):
         root = get_output_root()
         assert root is not None
 
@@ -333,6 +368,99 @@ def test_running_run_refreshes_logs_iterations_metrics_and_artifacts(tmp_path, m
     assert state["status"] == "complete"
     assert [metric["loss"] for metric in state["metrics"]] == [0.52, 0.4]
     assert [metric["accuracy"] for metric in state["metrics"]] == [0.61, 0.714]
+
+
+def test_running_run_hides_budget_skip_sentinel_metrics(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    ready = threading.Event()
+    release = threading.Event()
+
+    def fake_invoke(prompt, budget, data_path=None, **_kwargs):
+        root = get_output_root()
+        assert root is not None
+        diary_path = root / "logs" / "research_diary.jsonl"
+        diary_path.parent.mkdir(parents=True, exist_ok=True)
+        diary_path.write_text(
+            json.dumps(
+                {
+                    "iteration": 1,
+                    "hypothesis": "Increase learning rate",
+                    "patch": "- learning_rate: 0.0001\n+ learning_rate: 0.0002",
+                    "metrics": {"val_loss": 0.42, "primary_metric": 0.704},
+                    "decision": "REVERTED",
+                    "cost_usd": 1.12,
+                }
+            )
+            + "\n"
+            + json.dumps(
+                {
+                    "iteration": 2,
+                    "hypothesis": "Increase batch size",
+                    "patch": "- batch_size: 4\n+ batch_size: 5",
+                    "metrics": {
+                        "train_loss": 1_000_000_000.0,
+                        "val_loss": 1_000_000_000.0,
+                        "primary_metric": 0.0,
+                    },
+                    "decision": "REVERTED",
+                    "cost_usd": 0.0,
+                    "notes": "Skipped: budget preflight rejected the Tinker run",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        _write_tinker_artifacts(
+            root / "experiments" / "completed-run",
+            run_id="completed-run",
+            state_path="tinker://state/completed",
+            val_loss=0.42,
+            primary_metric=0.704,
+            metric_rows=[
+                {"step": 1, "val_loss": 0.6, "primary_metric": 0.625},
+                {"step": 2, "val_loss": 0.42, "primary_metric": 0.704},
+            ],
+        )
+        _write_budget_skip_artifacts(
+            root / "experiments" / "budget-skipped-run",
+            run_id="budget-skipped-run",
+        )
+        ready.set()
+        assert release.wait(timeout=5)
+        result = _fake_model(root, total_cost=1.12)
+        result["research_diary_path"] = str(diary_path)
+        return result
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune while hiding budget skip sentinels",
+            "budget": 2,
+            "task_type": "fine-tuning",
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    assert ready.wait(timeout=5)
+
+    state = client.get(f"/api/runs/{run_id}").json()
+    assert [metric["loss"] for metric in state["metrics"]] == [0.6, 0.42]
+    assert [metric["accuracy"] for metric in state["metrics"]] == [0.625, 0.704]
+    assert [item["experiment"] for item in state["iterations"]] == [
+        "Increase learning rate"
+    ]
+
+    release.set()
+    state = _wait_for_status(client, run_id, "complete")
+    assert [metric["loss"] for metric in state["metrics"]] == [0.6, 0.42]
+    assert [metric["accuracy"] for metric in state["metrics"]] == [0.625, 0.704]
+    assert [item["experiment"] for item in state["iterations"]] == [
+        "Increase learning rate"
+    ]
 
 
 def test_running_run_keeps_previous_artifacts_when_newer_experiment_is_incomplete(

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -25,6 +25,7 @@ def _write_tinker_artifacts(
     test_loss: float = 0.33,
     primary_metric: float = 0.775,
     sample_text: str = "sample completion",
+    metric_rows: list[dict] | None = None,
 ) -> None:
     run_dir.mkdir(parents=True, exist_ok=True)
     checkpoints = {"state_path": state_path}
@@ -51,8 +52,11 @@ def _write_tinker_artifacts(
         ),
         encoding="utf-8",
     )
+    rows = metric_rows or [
+        {"step": 1, "val_loss": val_loss, "primary_metric": primary_metric}
+    ]
     (run_dir / "metrics.jsonl").write_text(
-        json.dumps({"step": 1, "val_loss": val_loss, "primary_metric": primary_metric}) + "\n",
+        "".join(json.dumps(row) + "\n" for row in rows),
         encoding="utf-8",
     )
     (run_dir / "sample.json").write_text(
@@ -284,10 +288,14 @@ def test_running_run_refreshes_logs_iterations_metrics_and_artifacts(tmp_path, m
             val_loss=0.4,
             primary_metric=0.714,
             sample_text="progress sample",
+            metric_rows=[
+                {"step": 1, "val_loss": 0.52, "primary_metric": 0.61},
+                {"step": 2, "val_loss": 0.4, "primary_metric": 0.714},
+            ],
         )
         ready.set()
         assert release.wait(timeout=5)
-        return _fake_model(root, total_cost=0.5, with_artifacts=True)
+        return _fake_model(root, total_cost=0.5)
 
     monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
     client = TestClient(server_app.app)
@@ -311,15 +319,20 @@ def test_running_run_refreshes_logs_iterations_metrics_and_artifacts(tmp_path, m
     assert state["costSpent"] == 0.42
     assert state["logs"][0]["component"] == "DataGen"
     assert state["iterations"][0]["status"] == "PENDING"
-    assert state["metrics"][0]["loss"] == 0.4
+    assert [metric["loss"] for metric in state["metrics"]] == [0.52, 0.4]
+    assert [metric["accuracy"] for metric in state["metrics"]] == [0.61, 0.714]
     assert state["artifacts"]["checkpoints"]["state_path"] == "tinker://state/progress"
 
     metrics_log = client.get(f"/api/runs/{run_id}/artifacts/metrics_log")
     assert metrics_log.status_code == 200
     assert '"step": 1' in metrics_log.text
+    assert '"step": 2' in metrics_log.text
 
     release.set()
-    assert _wait_for_status(client, run_id, "complete")["status"] == "complete"
+    state = _wait_for_status(client, run_id, "complete")
+    assert state["status"] == "complete"
+    assert [metric["loss"] for metric in state["metrics"]] == [0.52, 0.4]
+    assert [metric["accuracy"] for metric in state["metrics"]] == [0.61, 0.714]
 
 
 def test_running_run_keeps_previous_artifacts_when_newer_experiment_is_incomplete(

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -79,6 +79,7 @@ def _write_budget_skip_artifacts(run_dir: Path, *, run_id: str) -> None:
                 "run_id": run_id,
                 "status": "CANCELLED",
                 "budget_preflight_skipped": True,
+                "budget_skip_reason": "estimated run cost exceeds remaining budget",
                 "checkpoints": {},
             }
         ),
@@ -98,6 +99,35 @@ def _write_budget_skip_artifacts(run_dir: Path, *, run_id: str) -> None:
         encoding="utf-8",
     )
     (run_dir / "sample.json").write_text(json.dumps({"text": ""}), encoding="utf-8")
+
+
+def _fake_budget_skipped_model(tmp_path):
+    run_dir = tmp_path / "experiments" / "budget-skipped-run"
+    _write_budget_skip_artifacts(run_dir, run_id="budget-skipped-run")
+    diary_path = tmp_path / "logs" / "research_diary.jsonl"
+    diary_path.parent.mkdir(parents=True, exist_ok=True)
+    diary_path.write_text("", encoding="utf-8")
+    return {
+        "weights_path": str(run_dir),
+        "metrics": {
+            "scalar": 0.0,
+            "metrics": {
+                "train_loss": 1_000_000_000.0,
+                "val_loss": 1_000_000_000.0,
+                "primary_metric": 0.0,
+            },
+            "critique": "budget preflight skipped the Tinker launch",
+        },
+        "cost": {
+            "data_gen_usd": 0.0,
+            "training_usd": 0.0,
+            "llm_calls_usd": 0.0,
+            "total_usd": 0.0,
+            "termination_reason": "budget_limit",
+        },
+        "n_iterations": 0,
+        "research_diary_path": str(diary_path),
+    }
 
 
 def _fake_model(tmp_path, *, total_cost=1.25, with_artifacts=False):
@@ -461,6 +491,45 @@ def test_running_run_hides_budget_skip_sentinel_metrics(tmp_path, monkeypatch):
     assert [item["experiment"] for item in state["iterations"]] == [
         "Increase learning rate"
     ]
+
+
+def test_budget_preflight_skip_is_not_reported_as_complete(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def fake_invoke(prompt, budget, data_path=None, **_kwargs):
+        root = get_output_root()
+        assert root is not None
+        return _fake_budget_skipped_model(root)
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune with a budget too small to start Tinker",
+            "budget": 1,
+            "task_type": "fine-tuning",
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    state = _wait_for_status(client, run_id, "cancelled")
+
+    assert state["status"] == "cancelled"
+    assert state["error"] == "estimated run cost exceeds remaining budget"
+    assert state["costSpent"] == 0.0
+    assert state["metrics"] == []
+    assert state["iterations"] == []
+    assert state["result"]["cost"]["termination_reason"] == "budget_limit"
+    assert state["artifacts"]["modelPath"].endswith("experiments/budget-skipped-run")
+    assert state["artifacts"]["checkpoints"] == {}
+    assert any("budget guard" in item["message"].lower() for item in state["logs"])
+
+    manifest_response = client.get(f"/api/runs/{run_id}/artifacts/manifest")
+    assert manifest_response.status_code == 200
+    assert manifest_response.json()["budget_preflight_skipped"] is True
 
 
 def test_running_run_keeps_previous_artifacts_when_newer_experiment_is_incomplete(

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -26,21 +26,21 @@ def _write_tinker_artifacts(
     primary_metric: float = 0.775,
     sample_text: str = "sample completion",
     metric_rows: list[dict] | None = None,
+    status: str = "COMPLETED",
+    error: str | None = None,
 ) -> None:
     run_dir.mkdir(parents=True, exist_ok=True)
     checkpoints = {"state_path": state_path}
     if sampler_path:
         checkpoints["sampler_path"] = sampler_path
-    (run_dir / "manifest.json").write_text(
-        json.dumps(
-            {
-                "run_id": run_id,
-                "status": "COMPLETED",
-                "checkpoints": checkpoints,
-            }
-        ),
-        encoding="utf-8",
-    )
+    manifest = {
+        "run_id": run_id,
+        "status": status,
+        "checkpoints": checkpoints,
+    }
+    if error:
+        manifest["error"] = error
+    (run_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
     (run_dir / "metrics.json").write_text(
         json.dumps(
             {
@@ -530,6 +530,65 @@ def test_budget_preflight_skip_is_not_reported_as_complete(tmp_path, monkeypatch
     manifest_response = client.get(f"/api/runs/{run_id}/artifacts/manifest")
     assert manifest_response.status_code == 200
     assert manifest_response.json()["budget_preflight_skipped"] is True
+
+
+@pytest.mark.parametrize(
+    ("manifest_status", "api_status", "log_type"),
+    [
+        ("FAILED", "failed", "error"),
+        ("CANCELLED", "cancelled", "warning"),
+    ],
+)
+def test_selected_training_artifact_terminal_status_controls_api_status(
+    tmp_path,
+    monkeypatch,
+    manifest_status,
+    api_status,
+    log_type,
+):
+    monkeypatch.chdir(tmp_path)
+
+    def fake_invoke(prompt, budget, data_path=None, **_kwargs):
+        root = get_output_root()
+        assert root is not None
+        run_dir = root / "experiments" / "terminal-artifact"
+        _write_tinker_artifacts(
+            run_dir,
+            run_id="terminal-artifact",
+            state_path="tinker://state/terminal",
+            status=manifest_status,
+            error="runner reported terminal artifact status",
+        )
+        result = _fake_model(root, total_cost=1.25)
+        result["weights_path"] = str(run_dir)
+        return result
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune with a terminal artifact status",
+            "budget": 10,
+            "task_type": "fine-tuning",
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    state = _wait_for_status(client, run_id, api_status)
+
+    assert state["status"] == api_status
+    assert state["error"] == "runner reported terminal artifact status"
+    assert state["artifacts"]["modelPath"].endswith("experiments/terminal-artifact")
+    assert any(
+        item["type"] == log_type and "terminal artifact status" in item["message"]
+        for item in state["logs"]
+    )
+    manifest_response = client.get(f"/api/runs/{run_id}/artifacts/manifest")
+    assert manifest_response.status_code == 200
+    assert manifest_response.json()["status"] == manifest_status
 
 
 def test_running_run_keeps_previous_artifacts_when_newer_experiment_is_incomplete(


### PR DESCRIPTION
## Summary
- Preserve existing streamed Tinker metric history when storing the terminal manager result.
- Keep the single synthesized summary metric as a fallback when no streamed metrics exist.
- Extend API coverage so completion preserves multiple streamed metrics while existing completion behavior still covers the fallback path.

## Root cause
`_store_manager_result()` always replaced `record.metrics` with `_metric_from_result(result)`, so terminal state collapsed streamed metric history into one summary point.

## Validation
- `python3 -m compileall src/server tests/test_server_api.py`
- `uv run --with-requirements requirements.txt python -m pytest tests/test_server_api.py`