### PR TITLE
[codex] Pass API task type hint into Manager planning

### DIFF
--- a/src/manager/manager.py
+++ b/src/manager/manager.py
@@ -53,6 +53,8 @@ def invoke_manager_graph(
     prompt: str,
     budget: float,
     data_path: str | None = None,
+    *,
+    task_type_hint: str | None = None,
 ) -> TrainedModel:
     """Main entry point for the entire system. Builds and invokes the Manager graph."""
     graph = build_manager_graph()
@@ -61,6 +63,7 @@ def invoke_manager_graph(
         "budget": budget,
         "data_path": data_path,
         "has_data": data_path is not None,
+        "task_type_hint": task_type_hint,
         "task_reasoning": None,
         "config": None,
         "result": None,
@@ -99,7 +102,12 @@ def query_data_node(state: ManagerState) -> dict:
 def reason_node(state: ManagerState) -> dict:
     """LangGraph node. Calls reason_about_task() via Claude API. Returns: { task_reasoning }."""
     raise_if_cancelled()
-    reasoning = reason_about_task(state["prompt"], state["budget"], state["has_data"])
+    reasoning = reason_about_task(
+        state["prompt"],
+        state["budget"],
+        state["has_data"],
+        task_type_hint=state.get("task_type_hint"),
+    )
     raise_if_cancelled()
     return {"task_reasoning": reasoning}
 
@@ -210,10 +218,17 @@ def _decision_log_path() -> Path:
     return Path(os.environ.get("DECISIONS_LOG", LOG_PATH))
 
 
-def reason_about_task(prompt: str, budget: float, has_data: bool) -> TaskReasoning:
+def reason_about_task(
+    prompt: str,
+    budget: float,
+    has_data: bool,
+    *,
+    task_type_hint: str | None = None,
+) -> TaskReasoning:
     """Calls Claude API to infer task type, training type, base model, and starting hyperparams."""
     import anthropic
 
+    hint = _normalize_task_type_hint(task_type_hint)
     client = anthropic.Anthropic()
     system = (
         "You are an ML infrastructure planner. Given a task description and budget, "
@@ -224,6 +239,10 @@ def reason_about_task(prompt: str, budget: float, has_data: bool) -> TaskReasoni
         "  suggested_base_model: str or null (HuggingFace model ID, e.g. 'bert-base-uncased')\n"
         "  hyperparameters: dict with keys learning_rate, batch_size, epochs, max_seq_len\n"
         "  notes: str (one sentence reasoning summary)\n"
+        "If a requested UI task type is provided, treat it as an operator hint: "
+        "classification usually maps to text-classification, regression may be "
+        "a custom supervised task, and fine-tuning means infer the concrete task "
+        "from the objective and data.\n"
         "Respond with raw JSON only. No markdown, no explanation."
     )
     user_msg = (
@@ -231,6 +250,8 @@ def reason_about_task(prompt: str, budget: float, has_data: bool) -> TaskReasoni
         f"Budget: ${budget:.2f}\n"
         f"User has existing data: {has_data}"
     )
+    if hint:
+        user_msg += f"\nRequested UI task type: {hint}"
     message = client.messages.create(
         model="claude-haiku-4-5",
         max_tokens=512,
@@ -238,6 +259,13 @@ def reason_about_task(prompt: str, budget: float, has_data: bool) -> TaskReasoni
         messages=[{"role": "user", "content": user_msg}],
     )
     return json.loads(message.content[0].text)
+
+
+def _normalize_task_type_hint(task_type_hint: str | None) -> str | None:
+    if task_type_hint is None:
+        return None
+    value = str(task_type_hint).strip().lower()
+    return value if value in {"classification", "regression", "fine-tuning"} else None
 
 
 def _handoff_to_dataset_result(handoff: dict) -> DatasetResult:

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -549,6 +549,7 @@ def _run_manager(record: _RunRecord) -> None:
                 record.request.prompt,
                 record.request.budget,
                 record.request.data_path,
+                task_type_hint=record.request.task_type,
             )
             raise_if_cancelled()
     except RunCancelled:

--- a/src/types.py
+++ b/src/types.py
@@ -6,7 +6,7 @@ See spec-site/content/spec.ts for the canonical definitions.
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 
 # ENUMS
@@ -255,6 +255,7 @@ class ManagerState(TypedDict):
     budget: float
     data_path: str | None
     has_data: bool
+    task_type_hint: NotRequired[str | None]
     task_reasoning: TaskReasoning | None
     config: OrchestrationConfig | None
     result: TrainedModel | None

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -80,6 +80,24 @@ def test_reason_about_task_returns_task_reasoning():
     assert "learning_rate" in result["hyperparameters"]
 
 
+def test_reason_about_task_includes_task_type_hint():
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text=json.dumps(MOCK_REASONING))]
+
+    with patch("anthropic.Anthropic") as MockClient:
+        client = MockClient.return_value
+        client.messages.create.return_value = mock_response
+        reason_about_task(
+            "predict support ticket resolution time",
+            12.5,
+            True,
+            task_type_hint="regression",
+        )
+
+    payload = client.messages.create.call_args.kwargs["messages"][0]["content"]
+    assert "Requested UI task type: regression" in payload
+
+
 def test_query_data_node_uses_programmatic_data_path_without_input(tmp_path, monkeypatch):
     data_path = tmp_path / "train.jsonl"
     data_path.write_text('{"input":"x","output":"y"}\n', encoding="utf-8")

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -142,8 +142,8 @@ def test_create_run_completes_with_manager_result(tmp_path, monkeypatch):
     calls = []
     roots = []
 
-    def fake_invoke(prompt, budget, data_path=None):
-        calls.append((prompt, budget, data_path))
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
+        calls.append((prompt, budget, data_path, task_type_hint))
         root = get_output_root()
         assert root is not None
         roots.append(root)
@@ -187,7 +187,7 @@ def test_create_run_completes_with_manager_result(tmp_path, monkeypatch):
     state = _wait_for_status(client, run_id, "complete")
 
     assert calls == [
-        ("Fine tune a small chat assistant on support tickets", 25.0, None)
+        ("Fine tune a small chat assistant on support tickets", 25.0, None, "fine-tuning")
     ]
     assert len(roots) == 1
     assert roots[0] == Path("outputs/api-runs") / run_id
@@ -204,7 +204,7 @@ def test_create_run_completes_with_manager_result(tmp_path, monkeypatch):
 def test_create_run_surfaces_artifacts_and_allowlisted_downloads(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
-    def fake_invoke(prompt, budget, data_path=None):
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
         root = get_output_root()
         assert root is not None
         return _fake_model(root, total_cost=0.5, with_artifacts=True)
@@ -253,7 +253,7 @@ def test_running_run_refreshes_logs_iterations_metrics_and_artifacts(tmp_path, m
     ready = threading.Event()
     release = threading.Event()
 
-    def fake_invoke(prompt, budget, data_path=None):
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
         root = get_output_root()
         assert root is not None
 
@@ -332,7 +332,7 @@ def test_running_run_keeps_previous_artifacts_when_newer_experiment_is_incomplet
     incomplete_ready = threading.Event()
     release = threading.Event()
 
-    def fake_invoke(prompt, budget, data_path=None):
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
         root = get_output_root()
         assert root is not None
         _write_tinker_artifacts(
@@ -402,7 +402,7 @@ def test_running_run_switches_artifacts_after_newer_experiment_completes(
     second_ready = threading.Event()
     release = threading.Event()
 
-    def fake_invoke(prompt, budget, data_path=None):
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
         root = get_output_root()
         assert root is not None
         _write_tinker_artifacts(
@@ -463,7 +463,7 @@ def test_cancel_running_run_stops_at_safe_boundary(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     entered = threading.Event()
 
-    def fake_invoke(prompt, budget, data_path=None):
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
         root = get_output_root()
         assert root is not None
 
@@ -512,7 +512,7 @@ def test_cancel_missing_run_returns_404():
 def test_cancel_completed_run_is_idempotent(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
-    def fake_invoke(prompt, budget, data_path=None):
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
         root = get_output_root()
         assert root is not None
         return _fake_model(root, total_cost=0.5)
@@ -542,8 +542,8 @@ def test_create_run_passes_existing_local_data_path(tmp_path, monkeypatch):
     data_path.write_text('{"input":"great","output":"positive"}\n', encoding="utf-8")
     calls = []
 
-    def fake_invoke(prompt, budget, data_path=None):
-        calls.append((prompt, budget, data_path))
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
+        calls.append((prompt, budget, data_path, task_type_hint))
         root = get_output_root()
         assert root is not None
         return _fake_model(root, total_cost=0.25)
@@ -564,6 +564,7 @@ def test_create_run_passes_existing_local_data_path(tmp_path, monkeypatch):
     assert response.status_code == 200
     state = _wait_for_status(client, response.json()["run_id"], "complete")
     assert calls[0][2] == str(data_path.resolve())
+    assert calls[0][3] == "fine-tuning"
     assert state["dataPath"] == str(data_path.resolve())
     assert any("Dataset source:" in item["message"] for item in state["logs"])
 
@@ -580,8 +581,8 @@ def test_create_run_accepts_hugging_face_data_sources(tmp_path, monkeypatch, sub
     monkeypatch.chdir(tmp_path)
     calls = []
 
-    def fake_invoke(prompt, budget, data_path=None):
-        calls.append((prompt, budget, data_path))
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
+        calls.append((prompt, budget, data_path, task_type_hint))
         root = get_output_root()
         assert root is not None
         return _fake_model(root, total_cost=0.2)
@@ -602,13 +603,14 @@ def test_create_run_accepts_hugging_face_data_sources(tmp_path, monkeypatch, sub
     assert response.status_code == 200
     state = _wait_for_status(client, response.json()["run_id"], "complete")
     assert calls[0][2] == expected
+    assert calls[0][3] == "classification"
     assert state["dataPath"] == expected
 
 
 def test_create_run_surfaces_manager_failure(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
-    def fail_invoke(prompt, budget, data_path=None):
+    def fail_invoke(prompt, budget, data_path=None, task_type_hint=None):
         assert get_output_root() is not None
         raise RuntimeError("DataGen did not produce a trainable dataset")
 
@@ -633,7 +635,7 @@ def test_create_run_surfaces_manager_failure(tmp_path, monkeypatch):
 def test_missing_data_path_is_rejected_before_background_run(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
-    def fail_invoke(prompt, budget, data_path=None):
+    def fail_invoke(prompt, budget, data_path=None, task_type_hint=None):
         raise AssertionError("manager should not be called for missing data_path")
 
     monkeypatch.setattr(server_app, "invoke_manager_graph", fail_invoke)
@@ -656,7 +658,7 @@ def test_missing_data_path_is_rejected_before_background_run(tmp_path, monkeypat
 def test_missing_relative_data_path_is_not_treated_as_hf_source(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
-    def fail_invoke(prompt, budget, data_path=None):
+    def fail_invoke(prompt, budget, data_path=None, task_type_hint=None):
         raise AssertionError("manager should not be called for missing data_path")
 
     monkeypatch.setattr(server_app, "invoke_manager_graph", fail_invoke)
@@ -679,7 +681,7 @@ def test_missing_relative_data_path_is_not_treated_as_hf_source(tmp_path, monkey
 def test_unsupported_remote_data_path_is_rejected(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
-    def fail_invoke(prompt, budget, data_path=None):
+    def fail_invoke(prompt, budget, data_path=None, task_type_hint=None):
         raise AssertionError("manager should not be called for unsupported data_path")
 
     monkeypatch.setattr(server_app, "invoke_manager_graph", fail_invoke)


### PR DESCRIPTION

## Summary
- Pass the frontend/API `task_type` selection into `invoke_manager_graph` as an optional planner hint.
- Include the hint in the Manager reasoning prompt after normalization instead of treating it as a hard override.
- Cover API forwarding and Manager prompt behavior with tests.

## Why
The UI exposes classification/regression/fine-tuning, but the backend previously discarded that field before planning. This made the control look wired while having no effect on the run. The Manager still infers the concrete ML task from the prompt and data; the UI value now acts as operator context.

## Validation
- `python3 -m compileall src/server src/manager src/types.py tests/test_server_api.py tests/test_manager.py`
- `uv run --with pytest --with fastapi --with httpx --with anthropic --with langgraph python -m pytest tests/test_server_api.py tests/test_manager.py -q`
- `uv run --with pytest --with fastapi --with httpx --with anthropic --with langgraph --with datasets --with huggingface-hub --with requests --with tavily-python --with trafilatura --with pymupdf python -m pytest tests -q --ignore=tests/integration/test_tinker_live_smoke.py --ignore=tests/data_generator/test_mode_b_hf_retrieval.py`
