### PR TITLE
[codex] Fix frontend artifact download hrefs

### DIFF
--- a/ml-agent-frontend/src/api/runs.ts
+++ b/ml-agent-frontend/src/api/runs.ts
@@ -28,6 +28,37 @@ export function isBackendApiConfigured(): boolean {
   return getApiBaseUrl() !== null;
 }
 
+export function resolveApiHrefFromBase(
+  baseUrl: string | null,
+  downloadPath?: string | null
+): string | null {
+  if (!baseUrl || !downloadPath) return null;
+
+  if (/^https?:\/\//i.test(downloadPath)) {
+    return downloadPath;
+  }
+
+  const path = downloadPath.startsWith('/') ? downloadPath : `/${downloadPath}`;
+  if (path === baseUrl || path.startsWith(`${baseUrl}/`)) {
+    return path;
+  }
+
+  try {
+    const base = new URL(baseUrl);
+    if (path === base.pathname || path.startsWith(`${base.pathname}/`)) {
+      return `${base.origin}${path}`;
+    }
+  } catch {
+    // Relative API base, handled below.
+  }
+
+  return `${baseUrl}${path}`;
+}
+
+export function resolveApiHref(downloadPath?: string | null): string | null {
+  return resolveApiHrefFromBase(getApiBaseUrl(), downloadPath);
+}
+
 async function requestJson<T>(path: string, options?: RequestInit): Promise<T> {
   const baseUrl = getApiBaseUrl();
   if (!baseUrl) {

--- a/ml-agent-frontend/src/components/Dashboard.tsx
+++ b/ml-agent-frontend/src/components/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { getApiBaseUrl } from '../api/runs';
+import { resolveApiHref } from '../api/runs';
 import type { TrainingState } from '../types';
 import PipelineProgress from './PipelineProgress';
 import MetricsGrid from './MetricsGrid';
@@ -67,14 +67,10 @@ function StatusDot({ status }: { status: TrainingState['status'] }) {
 }
 
 function CancelledArtifacts({ state, onReset }: Props) {
-  const apiBaseUrl = getApiBaseUrl();
   const lastMetric = state.metrics[state.metrics.length - 1];
   const bestIter = state.iterations.find(i => i.status === 'KEPT') ?? state.iterations[0];
   const artifactFiles = state.artifacts?.files.filter(file => file.exists) ?? [];
   const checkpointEntries = Object.entries(state.artifacts?.checkpoints ?? {}).filter(([, value]) => value);
-  const artifactHref = (downloadPath?: string | null) => (
-    apiBaseUrl && downloadPath ? `${apiBaseUrl}${downloadPath}` : null
-  );
   const compactPath = (value?: string | null) => {
     if (!value) return '—';
     if (value.length <= 72) return value;
@@ -157,7 +153,7 @@ function CancelledArtifacts({ state, onReset }: Props) {
             </div>
           )}
           {artifactFiles.map(file => {
-            const href = artifactHref(file.downloadPath);
+            const href = resolveApiHref(file.downloadPath);
             return (
               <div
                 key={file.name}

--- a/ml-agent-frontend/src/components/FinalResults.tsx
+++ b/ml-agent-frontend/src/components/FinalResults.tsx
@@ -1,4 +1,4 @@
-import { getApiBaseUrl } from '../api/runs';
+import { resolveApiHref } from '../api/runs';
 import type { TrainingState } from '../types';
 import Tooltip from './Tooltip';
 
@@ -25,7 +25,6 @@ const RESULT_TOOLTIPS: Record<string, { label: string; body: string }> = {
 export default function FinalResults({ state, onReset }: Props) {
   const lastMetric = state.metrics[state.metrics.length - 1];
   const bestIter = state.iterations.find(i => i.status === 'KEPT') ?? state.iterations[0];
-  const apiBaseUrl = getApiBaseUrl();
   const artifactFiles = state.artifacts?.files.filter(file => file.exists) ?? [];
   const checkpointEntries = Object.entries(state.artifacts?.checkpoints ?? {}).filter(([, value]) => value);
 
@@ -56,9 +55,6 @@ export default function FinalResults({ state, onReset }: Props) {
     { label: 'Val Accuracy', value: lastMetric ? `${(lastMetric.accuracy * 100).toFixed(1)}%` : '—' },
     { label: 'Total Cost', value: `$${state.costSpent.toFixed(2)}` },
   ];
-  const artifactHref = (downloadPath?: string | null) => (
-    apiBaseUrl && downloadPath ? `${apiBaseUrl}${downloadPath}` : null
-  );
   const compactPath = (value?: string | null) => {
     if (!value) return '—';
     if (value.length <= 72) return value;
@@ -144,7 +140,7 @@ export default function FinalResults({ state, onReset }: Props) {
               </div>
             )}
             {artifactFiles.map(file => {
-              const href = artifactHref(file.downloadPath);
+              const href = resolveApiHref(file.downloadPath);
               return (
                 <div
                   key={file.name}


### PR DESCRIPTION

## Summary
- Add a shared `resolveApiHref` helper for API artifact links.
- Avoid doubling the `/api` prefix when backend artifact paths already include `/api/runs/...`.
- Use the helper in both final-results artifacts and cancelled-run artifacts.

## Why
The backend advertises artifact `downloadPath` values such as `/api/runs/{run_id}/artifacts/{name}`. The frontend README recommends `VITE_API_BASE_URL=/api`, and the UI previously concatenated those into `/api/api/runs/...`, breaking artifact downloads from the browser.

## Validation
- `npm ci`
- `npm run lint`
- `VITE_API_BASE_URL=/api npm run build`
- `npx --yes tsx -e ...resolveApiHrefFromBase contract check...`
