### PR TITLE
[codex] Fall back from Mode C auto structuring to synthetic data

### DIFF
--- a/src/data_generator/mode_c/nodes.py
+++ b/src/data_generator/mode_c/nodes.py
@@ -150,7 +150,7 @@ def aggregate_web_sources_node(state: DataGenState) -> dict:
         return unstructured
 
     structured = structure_web_sources_for_sft(state["config"], pages)
-    if structured.validation_report["passed"] or structuring_mode == "required":
+    if structured.validation_report["passed"]:
         structured.raw_data["human_readable"] = report
         structured.raw_data["format_meta"]["mode_c_backend"] = backend
         structured.raw_data["format_meta"]["web_plan"] = web_plan
@@ -162,6 +162,11 @@ def aggregate_web_sources_node(state: DataGenState) -> dict:
             "validation_report": structured.validation_report,
             "human_readable": report,
         }
+
+    if structuring_mode == "required":
+        issues = structured.validation_report.get("issues", [])
+        issue_text = "; ".join(str(issue) for issue in issues) or "validation failed"
+        raise RuntimeError(f"Mode C web structuring required valid SFT rows: {issue_text}")
 
     return _mode_c_synthetic_fallback_output(
         state["config"],

--- a/src/data_generator/mode_c/nodes.py
+++ b/src/data_generator/mode_c/nodes.py
@@ -98,24 +98,14 @@ def aggregate_web_sources_node(state: DataGenState) -> dict:
     backend = _mode_c_backend(state)
 
     if backend == "synthetic" or state.get("mode_c_fallback") == "synthetic":
-        result = build_mode_c_dataset(state["config"])
-        raw_data = result.raw_data
-        raw_data["format_meta"]["mode_c_fallback"] = "synthetic"
-        raw_data["format_meta"]["mode_c_backend"] = backend
-        raw_data["format_meta"]["web_acquisition_error"] = state.get(
-            "web_acquisition_error"
+        return _mode_c_synthetic_fallback_output(
+            state["config"],
+            backend=backend,
+            reason=state.get(
+                "web_acquisition_error",
+                "web acquisition unavailable",
+            ),
         )
-        report = (
-            "Mode C Synthetic Fallback Report\n"
-            f"Reason: {state.get('web_acquisition_error', 'web acquisition unavailable')}\n"
-            f"Records generated: {len(raw_data.get('records', []))}"
-        )
-        return {
-            "schema": result.schema,
-            "raw_data": raw_data,
-            "validation_report": result.validation_report,
-            "human_readable": report,
-        }
 
     report = build_web_human_readable_report(
         web_plan=web_plan,
@@ -173,10 +163,70 @@ def aggregate_web_sources_node(state: DataGenState) -> dict:
             "human_readable": report,
         }
 
-    issues = list(unstructured["validation_report"]["issues"])
-    issues.extend(structured.validation_report.get("issues", []))
-    unstructured["validation_report"]["issues"] = issues
-    return unstructured
+    return _mode_c_synthetic_fallback_output(
+        state["config"],
+        backend=backend,
+        reason="Mode C web structuring produced no trainable records.",
+        web_report=report,
+        web_plan=web_plan,
+        search_results=search_results,
+        pages=pages,
+        structuring_issues=structured.validation_report.get("issues", []),
+    )
+
+
+def _mode_c_synthetic_fallback_output(
+    config,
+    *,
+    backend: str,
+    reason: str | None,
+    web_report: str | None = None,
+    web_plan=None,
+    search_results=None,
+    pages=None,
+    structuring_issues=None,
+) -> dict:
+    result = build_mode_c_dataset(config)
+    raw_data = result.raw_data
+    format_meta = raw_data.setdefault("format_meta", {})
+    format_meta["mode_c_fallback"] = "synthetic"
+    format_meta["mode_c_backend"] = backend
+    format_meta["web_acquisition_error"] = reason
+    if web_plan is not None:
+        format_meta["web_plan"] = web_plan
+    if search_results is not None:
+        format_meta["num_search_results"] = len(search_results)
+        search_urls = [item.get("url") for item in search_results if item.get("url")]
+        if search_urls:
+            format_meta["web_search_urls"] = search_urls
+    if pages is not None:
+        format_meta["num_pages_crawled"] = len(pages)
+        source_urls = [page.get("url") for page in pages if page.get("url")]
+        if source_urls:
+            format_meta["web_source_urls"] = source_urls
+    if structuring_issues:
+        format_meta["web_structuring_issues"] = list(structuring_issues)
+
+    report = (
+        "Mode C Synthetic Fallback Report\n"
+        f"Reason: {reason or 'web acquisition unavailable'}\n"
+        f"Records generated: {len(raw_data.get('records', []))}"
+    )
+    if web_report:
+        report = (
+            f"{report}\n\n"
+            "Web acquisition report retained for provenance:\n"
+            f"{web_report}"
+        )
+    raw_data["human_readable"] = report
+    return {
+        "schema": result.schema,
+        "raw_data": raw_data,
+        "validation_report": result.validation_report,
+        "human_readable": report,
+        "mode_c_fallback": "synthetic",
+        "web_acquisition_error": reason,
+    }
 
 
 def _mode_c_synthetic_fallback_state(

--- a/tests/data_generator/test_deployment_style_handoff_artifacts.py
+++ b/tests/data_generator/test_deployment_style_handoff_artifacts.py
@@ -168,7 +168,11 @@ def test_mode_c_saves_deployment_style_handoff_artifacts(monkeypatch, tmp_path: 
     assert "Mode C Web Acquisition Report" in handoff["human_readable"]
     artifact_dir = _test_artifact_dir("test_mode_c_saves_deployment_style_handoff_artifacts")
     saved_handoff = _assert_saved_artifacts(artifact_dir, "C")
-    assert saved_handoff["curation_payload"]["records"][0]["source_locator"] == "https://example.com/data"
+    assert saved_handoff["curation_payload"]["format_meta"]["mode_c_fallback"] == "synthetic"
+    assert saved_handoff["curation_payload"]["format_meta"]["web_source_urls"] == [
+        "https://example.com/data"
+    ]
+    assert saved_handoff["curation_payload"]["records"][0]["messages"][-1]["role"] == "assistant"
 
     source_report = artifact_dir / "source_human_readable.md"
     assert source_report.exists()

--- a/tests/test_mode_c_web_structuring.py
+++ b/tests/test_mode_c_web_structuring.py
@@ -306,7 +306,7 @@ def test_aggregate_web_sources_uses_structured_records_when_required(monkeypatch
     assert out["raw_data"]["records"][0]["output"] == "urgent"
 
 
-def test_aggregate_web_sources_without_teacher_keeps_raw_web_invalid(monkeypatch):
+def test_aggregate_web_sources_auto_without_teacher_falls_back_synthetic(monkeypatch):
     monkeypatch.setenv("DATA_GENERATOR_WEB_STRUCTURING", "auto")
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
 
@@ -320,9 +320,37 @@ def test_aggregate_web_sources_without_teacher_keeps_raw_web_invalid(monkeypatch
         }
     )
 
+    assert out["validation_report"]["passed"] is True
+    assert out["mode_c_fallback"] == "synthetic"
+    assert out["raw_data"]["format_meta"]["file_type"] == "synthetic_chat_jsonl"
+    assert out["raw_data"]["format_meta"]["mode_c_fallback"] == "synthetic"
+    assert out["raw_data"]["format_meta"]["num_pages_crawled"] == 1
+    assert out["raw_data"]["records"][0]["messages"][0]["role"] == "user"
+    assert out["raw_data"]["records"][0]["messages"][-1]["role"] == "assistant"
+    assert any(
+        "web structuring requires a teacher" in issue
+        for issue in out["raw_data"]["format_meta"]["web_structuring_issues"]
+    )
+    assert "Web acquisition report retained for provenance" in out["human_readable"]
+
+
+def test_aggregate_web_sources_required_without_teacher_keeps_structuring_failure(monkeypatch):
+    monkeypatch.setenv("DATA_GENERATOR_WEB_STRUCTURING", "required")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    out = aggregate_web_sources_node(
+        {
+            "config": _config(),
+            "web_plan": {"planner_backend": "test"},
+            "web_search_results": [{"url": "https://example.com/urgency"}],
+            "web_pages": _pages(),
+            "mode_c_backend": "web",
+        }
+    )
+
     assert out["validation_report"]["passed"] is False
-    assert out["raw_data"]["format_meta"]["file_type"] == "web_aggregated_sources"
-    assert out["raw_data"]["records"][0]["url"] == "https://example.com/urgency"
+    assert out["raw_data"]["format_meta"]["file_type"] == "web_structured_chat_jsonl"
+    assert out["raw_data"]["records"] == []
     assert any(
         "web structuring requires a teacher" in issue
         for issue in out["validation_report"]["issues"]

--- a/tests/test_mode_c_web_structuring.py
+++ b/tests/test_mode_c_web_structuring.py
@@ -1,6 +1,8 @@
 import json
 from types import SimpleNamespace
 
+import pytest
+
 from src.data_generator.mode_c.nodes import aggregate_web_sources_node
 from src.data_generator.mode_c.structuring import (
     WebStructuringResult,
@@ -334,24 +336,75 @@ def test_aggregate_web_sources_auto_without_teacher_falls_back_synthetic(monkeyp
     assert "Web acquisition report retained for provenance" in out["human_readable"]
 
 
-def test_aggregate_web_sources_required_without_teacher_keeps_structuring_failure(monkeypatch):
+def test_aggregate_web_sources_required_without_teacher_raises_structuring_failure(monkeypatch):
     monkeypatch.setenv("DATA_GENERATOR_WEB_STRUCTURING", "required")
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
 
-    out = aggregate_web_sources_node(
-        {
-            "config": _config(),
-            "web_plan": {"planner_backend": "test"},
-            "web_search_results": [{"url": "https://example.com/urgency"}],
-            "web_pages": _pages(),
-            "mode_c_backend": "web",
-        }
+    with pytest.raises(RuntimeError, match="web structuring requires a teacher"):
+        aggregate_web_sources_node(
+            {
+                "config": _config(),
+                "web_plan": {"planner_backend": "test"},
+                "web_search_results": [{"url": "https://example.com/urgency"}],
+                "web_pages": _pages(),
+                "mode_c_backend": "web",
+            }
+        )
+
+
+def test_aggregate_web_sources_required_raises_invalid_teacher_output(monkeypatch):
+    monkeypatch.setenv("DATA_GENERATOR_WEB_STRUCTURING", "required")
+    from src.data_generator.mode_c import nodes as mode_c_nodes
+
+    schema = {
+        "input_format": "support ticket text",
+        "output_format": "one of: urgent, normal",
+        "input_description": "A support ticket.",
+        "output_description": "The urgency label.",
+        "example_pair": {"input": "The site is down.", "output": "urgent"},
+    }
+    structured_raw = {
+        "records": [
+            {
+                "input": "The site is down.",
+                "output": "urgent",
+                "messages": [
+                    {"role": "user", "content": "The site is down."},
+                    {"role": "assistant", "content": "urgent"},
+                ],
+            }
+        ],
+        "format_meta": {
+            "modality": "text",
+            "file_type": "web_structured_chat_jsonl",
+            "encoding": "utf-8",
+            "schema": schema,
+            "teacher_used": True,
+        },
+    }
+
+    monkeypatch.setattr(
+        mode_c_nodes,
+        "structure_web_sources_for_sft",
+        lambda _config, _pages: WebStructuringResult(
+            schema=schema,
+            raw_data=structured_raw,
+            validation_report={
+                "passed": False,
+                "issues": ["Classification-style data should include at least two labels"],
+                "sample_accuracy_estimate": 1.0,
+            },
+            teacher_used=True,
+        ),
     )
 
-    assert out["validation_report"]["passed"] is False
-    assert out["raw_data"]["format_meta"]["file_type"] == "web_structured_chat_jsonl"
-    assert out["raw_data"]["records"] == []
-    assert any(
-        "web structuring requires a teacher" in issue
-        for issue in out["validation_report"]["issues"]
-    )
+    with pytest.raises(RuntimeError, match="at least two labels"):
+        aggregate_web_sources_node(
+            {
+                "config": _config(),
+                "web_plan": {"planner_backend": "test"},
+                "web_search_results": [{"url": "https://example.com/urgency"}],
+                "web_pages": _pages(),
+                "mode_c_backend": "web",
+            }
+        )


### PR DESCRIPTION

## Summary
- In `DATA_GENERATOR_WEB_STRUCTURING=auto`, fall back to trainable synthetic Mode C data when web structuring produces no valid records.
- Preserve web acquisition provenance in the fallback metadata/report, including source URLs and structuring issues.
- Keep `required` strict: teacher/structuring failure still returns an invalid structured result instead of silently falling back.

## Why
Auto mode should keep the no-data path trainable when a teacher model or `ANTHROPIC_API_KEY` is unavailable. Before this change, web acquisition could succeed, structuring could produce zero rows, and curation would reject raw targetless web pages.

## Validation
- `python3 -m compileall src/data_generator/mode_c tests/test_mode_c_web_structuring.py tests/test_mode_c.py tests/test_mode_c_web_manager_boundary.py`
- `uv run --with pytest --with anthropic --with langgraph --with requests --with tavily-python --with trafilatura --with pymupdf python -m pytest tests/test_mode_c_web_structuring.py tests/test_mode_c.py tests/test_mode_c_web_manager_boundary.py tests/data_generator/test_deployment_style_handoff_artifacts.py -q`
- `uv run --with pytest --with fastapi --with httpx --with anthropic --with langgraph --with datasets --with huggingface-hub --with requests --with tavily-python --with trafilatura --with pymupdf python -m pytest tests -q --ignore=tests/integration/test_tinker_live_smoke.py --ignore=tests/data_generator/test_mode_b_hf_retrieval.py`
