### PR TITLE
[codex] guard optional eval suite adaptation

### DIFF
--- a/src/autoresearch/__main__.py
+++ b/src/autoresearch/__main__.py
@@ -47,6 +47,10 @@ _RED    = "\033[31m"
 _BLUE   = "\033[34m"
 
 
+def _env_truthy(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 # ─── Claude strategy wrapper ──────────────────────────────────────────────────
 
 class ClaudeProposalStrategy(ProposalStrategy):
@@ -65,6 +69,8 @@ class ClaudeProposalStrategy(ProposalStrategy):
         }
 
     def propose(self, config: TrainingConfig, history: list[IterationRecord]) -> Proposal:
+        if _env_truthy("NO_SPEND"):
+            raise RuntimeError("Claude proposal strategy is disabled when NO_SPEND=1")
         from src.autoresearch.autoresearch import propose_hypothesis
         hypothesis = propose_hypothesis(config.to_dict(), history, self._task)
         patch_dict = json.loads(hypothesis["patch"])
@@ -225,6 +231,10 @@ def main() -> None:
         return
 
     if args.strategy == "claude":
+        if _env_truthy("NO_SPEND"):
+            print(f"{_RED}Error: --strategy claude is disabled when NO_SPEND=1.{_RESET}")
+            print("Use --strategy local or --strategy random, or unset NO_SPEND for a live run.")
+            sys.exit(1)
         if not os.getenv("ANTHROPIC_API_KEY"):
             print(f"{_RED}Error: ANTHROPIC_API_KEY is not set.{_RESET}")
             print(f"Export it and re-run:")

--- a/src/autoresearch/autoresearch.py
+++ b/src/autoresearch/autoresearch.py
@@ -70,6 +70,11 @@ def _env_truthy(name: str) -> bool:
     return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _raise_if_no_spend_live_llm(operation: str) -> None:
+    if _env_truthy(_NO_SPEND_ENV):
+        raise RuntimeError(f"{operation} is disabled when {_NO_SPEND_ENV}=1")
+
+
 def _patch_to_diff(patch_dict: dict, current_config: dict) -> str:
     """Build a human-readable diff string from a patch dict and the pre-patch config."""
     lines = []
@@ -691,6 +696,7 @@ def propose_hypothesis(
     allowed_params: list[str] | None = None,
 ) -> Hypothesis:
     """Calls Claude API (claude-haiku-4-5-20251001) to generate a single testable hypothesis as a code/config diff."""
+    _raise_if_no_spend_live_llm("Claude hypothesis proposal")
     client = anthropic.Anthropic()
     recent = diary[-5:] if len(diary) > 5 else diary
     prompt_config = (
@@ -1274,6 +1280,7 @@ def create_eval_suite(task: TaskAnalysis, dataset: DatasetResult) -> EvalSuite:
 
 def adapt_eval_suite(suite: EvalSuite, weaknesses: list[str]) -> EvalSuite:
     """Adds harder eval examples targeting systematic weaknesses detected across recent iterations."""
+    _raise_if_no_spend_live_llm("Claude eval suite adaptation")
     client = anthropic.Anthropic()
 
     user = f"""You are an ML evaluation expert reviewing an AutoResearch experiment loop.

--- a/src/autoresearch/autoresearch.py
+++ b/src/autoresearch/autoresearch.py
@@ -62,6 +62,12 @@ _TINKER_HYPERPARAMETER_ALIASES = {
     "max_seq_len": "max_seq_length",
 }
 _EVAL_ADAPTATION_ENV = "AUTORESEARCH_EVAL_ADAPTATION"
+_NO_SPEND_ENV = "NO_SPEND"
+
+
+def _env_truthy(name: str) -> bool:
+    """Return True for conventional truthy environment flag values."""
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _patch_to_diff(patch_dict: dict, current_config: dict) -> str:
@@ -103,6 +109,8 @@ def _eval_adaptation_skip_reason() -> str | None:
     setting = _eval_adaptation_setting()
     if setting == "off":
         return f"{_EVAL_ADAPTATION_ENV}=off"
+    if _env_truthy(_NO_SPEND_ENV):
+        return f"{_NO_SPEND_ENV}=1"
     if setting == "auto" and not os.getenv("ANTHROPIC_API_KEY"):
         return "ANTHROPIC_API_KEY is not configured"
     return None

--- a/src/autoresearch/autoresearch.py
+++ b/src/autoresearch/autoresearch.py
@@ -116,8 +116,8 @@ def _eval_adaptation_skip_reason() -> str | None:
         return f"{_EVAL_ADAPTATION_ENV}=off"
     if _env_truthy(_NO_SPEND_ENV):
         return f"{_NO_SPEND_ENV}=1"
-    if setting == "auto" and not os.getenv("ANTHROPIC_API_KEY"):
-        return "ANTHROPIC_API_KEY is not configured"
+    if setting == "auto":
+        return f"{_EVAL_ADAPTATION_ENV}=auto"
     return None
 
 

--- a/src/autoresearch/autoresearch.py
+++ b/src/autoresearch/autoresearch.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import math
+import os
 from pathlib import Path
 from typing import Any, Literal, Mapping
 from uuid import uuid4
@@ -60,6 +61,7 @@ _TINKER_HYPERPARAMETER_ALIASES = {
     "epochs": "num_epochs",
     "max_seq_len": "max_seq_length",
 }
+_EVAL_ADAPTATION_ENV = "AUTORESEARCH_EVAL_ADAPTATION"
 
 
 def _patch_to_diff(patch_dict: dict, current_config: dict) -> str:
@@ -80,6 +82,30 @@ def _canonicalize_tinker_hyperparameters(config: Mapping[str, Any]) -> dict[str,
             canonical[canonical_key] = canonical[legacy_key]
         canonical.pop(legacy_key, None)
     return canonical
+
+
+def _eval_adaptation_setting() -> Literal["auto", "off", "required"]:
+    """Return the configured eval-suite adaptation mode."""
+    raw = os.getenv(_EVAL_ADAPTATION_ENV, "auto").strip().lower()
+    if raw in {"", "auto"}:
+        return "auto"
+    if raw in {"0", "false", "no", "off", "disabled"}:
+        return "off"
+    if raw in {"1", "true", "yes", "on", "required"}:
+        return "required"
+    raise ValueError(
+        f"{_EVAL_ADAPTATION_ENV} must be one of: auto, off, required"
+    )
+
+
+def _eval_adaptation_skip_reason() -> str | None:
+    """Return None when LLM eval adaptation may run, otherwise a skip reason."""
+    setting = _eval_adaptation_setting()
+    if setting == "off":
+        return f"{_EVAL_ADAPTATION_ENV}=off"
+    if setting == "auto" and not os.getenv("ANTHROPIC_API_KEY"):
+        return "ANTHROPIC_API_KEY is not configured"
+    return None
 
 
 def _current_config_for_plan(
@@ -491,13 +517,22 @@ def log_node(state: AutoResearchState) -> dict:
         ]
         if recent_reverts:
             weaknesses = [r["notes"] for r in recent_reverts]
-            updated_suite = adapt_eval_suite(state["eval_suite"], weaknesses)
-            log_event(
-                AgentName.AUTORESEARCH,
-                LogLevel.INFO,
-                f"ADAPT: eval suite updated after {iteration_number} iterations",
-                metadata={"weaknesses": weaknesses},
-            )
+            skip_reason = _eval_adaptation_skip_reason()
+            if skip_reason:
+                log_event(
+                    AgentName.AUTORESEARCH,
+                    LogLevel.WARN,
+                    f"ADAPT: skipped eval suite update after {iteration_number} iterations",
+                    metadata={"reason": skip_reason, "weaknesses": weaknesses},
+                )
+            else:
+                updated_suite = adapt_eval_suite(state["eval_suite"], weaknesses)
+                log_event(
+                    AgentName.AUTORESEARCH,
+                    LogLevel.INFO,
+                    f"ADAPT: eval suite updated after {iteration_number} iterations",
+                    metadata={"weaknesses": weaknesses},
+                )
 
     return {
         "diary": updated_diary,

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -457,6 +457,63 @@ def test_log_node_skips_eval_adaptation_without_anthropic_key(monkeypatch, tmp_p
         ar._DIARY_PATH = original_path
 
 
+def test_log_node_no_spend_skips_eval_adaptation_even_when_required(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    def fail_adapt_eval_suite(*args, **kwargs):
+        raise AssertionError("Eval adaptation should not run when NO_SPEND=1")
+
+    events = []
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-present")
+    monkeypatch.setenv("AUTORESEARCH_EVAL_ADAPTATION", "required")
+    monkeypatch.setattr(ar, "adapt_eval_suite", fail_adapt_eval_suite)
+    monkeypatch.setattr(
+        ar,
+        "log_event",
+        lambda agent, level, message, metadata=None, **kwargs: events.append(
+            {"level": level, "message": message, "metadata": metadata or {}}
+        ),
+    )
+
+    original_path = ar._DIARY_PATH
+    ar._DIARY_PATH = tmp_path / "diary.jsonl"
+    suite = {"primary_metric": "accuracy", "metrics": ["accuracy"],
+             "test_split_path": "", "use_llm_grading": False}
+    try:
+        state = _make_state(
+            eval_suite=suite,
+            diary=[
+                {"iteration": i, "hypothesis": "", "patch": "", "cost_usd": 0.0,
+                 "metrics": {}, "decision": "REVERTED", "notes": f"revert {i}"}
+                for i in range(1, 10)
+            ],
+            iteration=9,
+            current_config={"learning_rate": 1e-4},
+            current_patch=json.dumps({"learning_rate": 2e-4}),
+            last_description="Increase learning rate.",
+            last_delta={"absolute": -0.01, "relative_pct": -2.0, "improved": False},
+            last_result={
+                "job_id": "candidate",
+                "status": "COMPLETED",
+                "metrics": {"train_loss": 0.4, "val_loss": 0.5,
+                            "test_loss": 0.6, "primary_metric": 0.65},
+                "model_path": "candidate-model",
+                "cost_usd": 0.01,
+                "logs_path": "candidate.jsonl",
+            },
+        )
+
+        out = ar.log_node(state)
+
+        assert out["iteration"] == 10
+        assert out["eval_suite"] == suite
+        assert any("skipped eval suite update" in event["message"] for event in events)
+        assert events[-1]["metadata"]["reason"] == "NO_SPEND=1"
+    finally:
+        ar._DIARY_PATH = original_path
+
+
 def test_log_node_required_eval_adaptation_calls_adaptor(monkeypatch, tmp_path):
     import src.autoresearch.autoresearch as ar
 

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -401,6 +401,113 @@ def test_log_node_labels_budget_preflight_skip(tmp_path):
         ar._DIARY_PATH = original_path
 
 
+def test_log_node_skips_eval_adaptation_without_anthropic_key(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    def fail_anthropic():
+        raise AssertionError("Anthropic should not be constructed in auto mode without a key")
+
+    events = []
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("AUTORESEARCH_EVAL_ADAPTATION", raising=False)
+    monkeypatch.setattr(ar.anthropic, "Anthropic", fail_anthropic)
+    monkeypatch.setattr(
+        ar,
+        "log_event",
+        lambda agent, level, message, metadata=None, **kwargs: events.append(
+            {"level": level, "message": message, "metadata": metadata or {}}
+        ),
+    )
+
+    original_path = ar._DIARY_PATH
+    ar._DIARY_PATH = tmp_path / "diary.jsonl"
+    suite = {"primary_metric": "accuracy", "metrics": ["accuracy"],
+             "test_split_path": "", "use_llm_grading": False}
+    try:
+        state = _make_state(
+            eval_suite=suite,
+            diary=[
+                {"iteration": i, "hypothesis": "", "patch": "", "cost_usd": 0.0,
+                 "metrics": {}, "decision": "REVERTED", "notes": f"revert {i}"}
+                for i in range(1, 10)
+            ],
+            iteration=9,
+            current_config={"learning_rate": 1e-4},
+            current_patch=json.dumps({"learning_rate": 2e-4}),
+            last_description="Increase learning rate.",
+            last_delta={"absolute": -0.01, "relative_pct": -2.0, "improved": False},
+            last_result={
+                "job_id": "candidate",
+                "status": "COMPLETED",
+                "metrics": {"train_loss": 0.4, "val_loss": 0.5,
+                            "test_loss": 0.6, "primary_metric": 0.65},
+                "model_path": "candidate-model",
+                "cost_usd": 0.01,
+                "logs_path": "candidate.jsonl",
+            },
+        )
+
+        out = ar.log_node(state)
+
+        assert out["iteration"] == 10
+        assert out["eval_suite"] == suite
+        assert any("skipped eval suite update" in event["message"] for event in events)
+        assert events[-1]["metadata"]["reason"] == "ANTHROPIC_API_KEY is not configured"
+    finally:
+        ar._DIARY_PATH = original_path
+
+
+def test_log_node_required_eval_adaptation_calls_adaptor(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    calls = []
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("AUTORESEARCH_EVAL_ADAPTATION", "required")
+    monkeypatch.setattr(ar, "log_event", lambda *args, **kwargs: None)
+
+    def fake_adapt_eval_suite(suite, weaknesses):
+        calls.append({"suite": suite, "weaknesses": weaknesses})
+        return {**suite, "metrics": suite["metrics"] + ["hard_case"]}
+
+    monkeypatch.setattr(ar, "adapt_eval_suite", fake_adapt_eval_suite)
+
+    original_path = ar._DIARY_PATH
+    ar._DIARY_PATH = tmp_path / "diary.jsonl"
+    suite = {"primary_metric": "accuracy", "metrics": ["accuracy"],
+             "test_split_path": "", "use_llm_grading": False}
+    try:
+        state = _make_state(
+            eval_suite=suite,
+            diary=[
+                {"iteration": i, "hypothesis": "", "patch": "", "cost_usd": 0.0,
+                 "metrics": {}, "decision": "REVERTED", "notes": f"revert {i}"}
+                for i in range(1, 10)
+            ],
+            iteration=9,
+            current_config={"learning_rate": 1e-4},
+            current_patch=json.dumps({"learning_rate": 2e-4}),
+            last_description="Increase learning rate.",
+            last_delta={"absolute": -0.01, "relative_pct": -2.0, "improved": False},
+            last_result={
+                "job_id": "candidate",
+                "status": "COMPLETED",
+                "metrics": {"train_loss": 0.4, "val_loss": 0.5,
+                            "test_loss": 0.6, "primary_metric": 0.65},
+                "model_path": "candidate-model",
+                "cost_usd": 0.01,
+                "logs_path": "candidate.jsonl",
+            },
+        )
+
+        out = ar.log_node(state)
+
+        assert calls
+        assert calls[0]["weaknesses"][-1] == "-2.0% \u2014 no improvement"
+        assert out["eval_suite"]["metrics"] == ["accuracy", "hard_case"]
+    finally:
+        ar._DIARY_PATH = original_path
+
+
 def test_completed_high_finite_sft_loss_flows_to_evaluate():
     import src.autoresearch.autoresearch as ar
 

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -2,6 +2,7 @@
 
 import json
 import math
+import sys
 from pathlib import Path
 
 import pytest
@@ -739,6 +740,19 @@ def test_propose_hypothesis_canonicalizes_tinker_alias_patch(monkeypatch):
     assert '"max_seq_len":' not in captured["messages"][0]["content"]
 
 
+def test_propose_hypothesis_no_spend_blocks_anthropic_client(monkeypatch):
+    import src.autoresearch.autoresearch as ar
+
+    def fail_client():
+        raise AssertionError("Anthropic client should not be constructed")
+
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.setattr(ar.anthropic, "Anthropic", fail_client)
+
+    with pytest.raises(RuntimeError, match="NO_SPEND=1"):
+        ar.propose_hypothesis({"learning_rate": 1e-4}, [], _minimal_task())
+
+
 def test_propose_hypothesis_still_rejects_unsupported_tinker_patch(monkeypatch):
     import src.autoresearch.autoresearch as ar
 
@@ -769,6 +783,42 @@ def test_propose_hypothesis_still_rejects_unsupported_tinker_patch(monkeypatch):
             _minimal_task(),
             allowed_params=["learning_rate", "num_epochs"],
         )
+
+
+def test_adapt_eval_suite_no_spend_blocks_anthropic_client(monkeypatch):
+    import src.autoresearch.autoresearch as ar
+
+    def fail_client():
+        raise AssertionError("Anthropic client should not be constructed")
+
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.setattr(ar.anthropic, "Anthropic", fail_client)
+
+    suite = {
+        "primary_metric": "accuracy",
+        "metrics": ["accuracy"],
+        "test_split_path": "",
+        "use_llm_grading": False,
+    }
+    with pytest.raises(RuntimeError, match="NO_SPEND=1"):
+        ar.adapt_eval_suite(suite, ["weakness"])
+
+
+def test_cli_no_spend_rejects_claude_strategy_before_api_key_check(monkeypatch):
+    import src.autoresearch.__main__ as cli
+
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "present-but-no-spend")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["python -m src.autoresearch", "--strategy", "claude", "--n-iters", "1"],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main()
+
+    assert exc_info.value.code == 1
 
 
 def test_keep_node_canonicalizes_tinker_alias_patch():

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -453,7 +453,62 @@ def test_log_node_skips_eval_adaptation_without_anthropic_key(monkeypatch, tmp_p
         assert out["iteration"] == 10
         assert out["eval_suite"] == suite
         assert any("skipped eval suite update" in event["message"] for event in events)
-        assert events[-1]["metadata"]["reason"] == "ANTHROPIC_API_KEY is not configured"
+        assert events[-1]["metadata"]["reason"] == "AUTORESEARCH_EVAL_ADAPTATION=auto"
+    finally:
+        ar._DIARY_PATH = original_path
+
+
+def test_log_node_auto_eval_adaptation_ignores_available_key(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    def fail_adapt_eval_suite(*args, **kwargs):
+        raise AssertionError("auto eval adaptation should not run live because a key exists")
+
+    events = []
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "present-but-not-used")
+    monkeypatch.delenv("AUTORESEARCH_EVAL_ADAPTATION", raising=False)
+    monkeypatch.setattr(ar, "adapt_eval_suite", fail_adapt_eval_suite)
+    monkeypatch.setattr(
+        ar,
+        "log_event",
+        lambda agent, level, message, metadata=None, **kwargs: events.append(
+            {"level": level, "message": message, "metadata": metadata or {}}
+        ),
+    )
+
+    original_path = ar._DIARY_PATH
+    ar._DIARY_PATH = tmp_path / "diary.jsonl"
+    suite = {"primary_metric": "accuracy", "metrics": ["accuracy"],
+             "test_split_path": "", "use_llm_grading": False}
+    try:
+        state = _make_state(
+            eval_suite=suite,
+            diary=[
+                {"iteration": i, "hypothesis": "", "patch": "", "cost_usd": 0.0,
+                 "metrics": {}, "decision": "REVERTED", "notes": f"revert {i}"}
+                for i in range(1, 10)
+            ],
+            iteration=9,
+            current_config={"learning_rate": 1e-4},
+            current_patch=json.dumps({"learning_rate": 2e-4}),
+            last_description="Increase learning rate.",
+            last_delta={"absolute": -0.01, "relative_pct": -2.0, "improved": False},
+            last_result={
+                "job_id": "candidate",
+                "status": "COMPLETED",
+                "metrics": {"train_loss": 0.4, "val_loss": 0.5,
+                            "test_loss": 0.6, "primary_metric": 0.65},
+                "model_path": "candidate-model",
+                "cost_usd": 0.01,
+                "logs_path": "candidate.jsonl",
+            },
+        )
+
+        out = ar.log_node(state)
+
+        assert out["eval_suite"] == suite
+        assert any("skipped eval suite update" in event["message"] for event in events)
+        assert events[-1]["metadata"]["reason"] == "AUTORESEARCH_EVAL_ADAPTATION=auto"
     finally:
         ar._DIARY_PATH = original_path
 

--- a/tests/test_e2e_propose.py
+++ b/tests/test_e2e_propose.py
@@ -47,9 +47,13 @@ from src.autoresearch.proposer import (
 
 # ─── Markers ─────────────────────────────────────────────────────────────────
 
+def _env_truthy(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 integration = pytest.mark.skipif(
-    not os.getenv("ANTHROPIC_API_KEY"),
-    reason="ANTHROPIC_API_KEY not set — skipping live API test",
+    _env_truthy("NO_SPEND") or not os.getenv("ANTHROPIC_API_KEY"),
+    reason="NO_SPEND=1 or ANTHROPIC_API_KEY not set — skipping live API test",
 )
 
 


### PR DESCRIPTION
## Summary
- Gate AutoResearch eval-suite adaptation behind AUTORESEARCH_EVAL_ADAPTATION=auto/off/required
- Default auto mode skips the Anthropic-backed adaptation when ANTHROPIC_API_KEY is not configured
- Preserve explicit required mode for live LLM adaptation and log clear skip reasons otherwise

## Why
AutoResearch previously attempted Anthropic-backed eval-suite adaptation every 10 iterations after recent reverts. That made offline or no-live runs unexpectedly require credentials and could spend money mid-loop.

## Validation
- python3 -m compileall src/autoresearch tests/test_autoresearch.py
- uv run --with pytest --with anthropic --with langgraph python -m pytest tests/test_autoresearch.py -q
- uv run --with pytest --with fastapi --with httpx --with anthropic --with langgraph --with datasets --with huggingface-hub --with requests --with tavily-python --with trafilatura --with pymupdf python -m pytest tests -q --ignore=tests/integration/test_tinker_live_smoke.py --ignore=tests/data_generator/test_mode_b_hf_retrieval.py
