### PR TITLE
[codex] add local Manager reasoning fallback

### DIFF
--- a/src/manager/manager.py
+++ b/src/manager/manager.py
@@ -22,6 +22,7 @@ from src.types import (
 )
 
 LOG_PATH = os.environ.get("DECISIONS_LOG", "decisions.jsonl")
+_MANAGER_REASONER_ENV = "MANAGER_REASONER"
 
 
 def build_manager_graph():
@@ -192,7 +193,10 @@ def log_decision(step: str, rationale: str, config: OrchestrationConfig) -> None
 
 
 def reason_about_task(prompt: str, budget: float, has_data: bool) -> TaskReasoning:
-    """Calls Claude API to infer task type, training type, base model, and starting hyperparams."""
+    """Infer task type, training type, base model, and starting hyperparams."""
+    if _use_local_reasoner():
+        return _local_task_reasoning(prompt, budget, has_data)
+
     import anthropic
 
     client = anthropic.Anthropic()
@@ -220,6 +224,84 @@ def reason_about_task(prompt: str, budget: float, has_data: bool) -> TaskReasoni
     )
     raw_text = message.content[0].text
     return _parse_task_reasoning_response(raw_text)
+
+
+def _manager_reasoner_mode() -> str:
+    raw = os.getenv(_MANAGER_REASONER_ENV, "auto").strip().lower()
+    if raw in {"", "auto"}:
+        return "auto"
+    if raw in {"local", "offline", "heuristic"}:
+        return "local"
+    if raw in {"claude", "anthropic", "live", "required"}:
+        return "claude"
+    raise ValueError(f"{_MANAGER_REASONER_ENV} must be one of: auto, local, claude")
+
+
+def _use_local_reasoner() -> bool:
+    mode = _manager_reasoner_mode()
+    if mode == "local":
+        return True
+    if mode == "claude":
+        return False
+    if os.getenv("NO_SPEND", "").strip().lower() in {"1", "true", "yes", "on"}:
+        return True
+    return not bool(os.getenv("ANTHROPIC_API_KEY"))
+
+
+def _local_task_reasoning(prompt: str, budget: float, has_data: bool) -> TaskReasoning:
+    """Deterministic fallback planner for no-live Manager runs."""
+    task_type = _infer_local_task_type(prompt)
+    data_format = (
+        "jsonl with messages or input/output fields"
+        if has_data
+        else "generated jsonl with messages or input/output fields"
+    )
+    hyperparameters = {
+        "learning_rate": 1e-4,
+        "batch_size": 4,
+        "epochs": 1,
+        "num_epochs": 1,
+        "max_seq_len": 512,
+        "max_seq_length": 512,
+        "lora_rank": 8,
+        "max_steps": 5,
+    }
+    return TaskReasoning(
+        task_type=task_type,
+        data_format=data_format,
+        training_type="SFT",
+        suggested_base_model=None,
+        hyperparameters=hyperparameters,
+        notes=(
+            "Local deterministic planner used because live Manager reasoning "
+            "was not enabled."
+        ),
+    )
+
+
+def _infer_local_task_type(prompt: str) -> str:
+    text = prompt.lower()
+    if any(term in text for term in ("translate", "translation")):
+        return "translation"
+    if any(term in text for term in ("summarize", "summarise", "summary")):
+        return "summarization"
+    if any(term in text for term in ("question answering", "question-answering", "qa")):
+        return "question-answering"
+    if any(
+        term in text
+        for term in (
+            "classify",
+            "classification",
+            "sentiment",
+            "label",
+            "category",
+            "categorize",
+            "categorise",
+            "intent",
+        )
+    ):
+        return "text-classification"
+    return "custom"
 
 
 def _parse_task_reasoning_response(raw_text: str) -> TaskReasoning:

--- a/src/manager/manager.py
+++ b/src/manager/manager.py
@@ -254,11 +254,11 @@ def _use_local_reasoner() -> bool:
     mode = _manager_reasoner_mode()
     if _env_flag_enabled("NO_SPEND"):
         return True
-    if mode == "local":
+    if mode in {"auto", "local"}:
         return True
     if mode == "claude":
         return False
-    return not bool(os.getenv("ANTHROPIC_API_KEY"))
+    return True
 
 
 def _env_flag_enabled(name: str) -> bool:

--- a/src/manager/manager.py
+++ b/src/manager/manager.py
@@ -239,13 +239,17 @@ def _manager_reasoner_mode() -> str:
 
 def _use_local_reasoner() -> bool:
     mode = _manager_reasoner_mode()
+    if _env_flag_enabled("NO_SPEND"):
+        return True
     if mode == "local":
         return True
     if mode == "claude":
         return False
-    if os.getenv("NO_SPEND", "").strip().lower() in {"1", "true", "yes", "on"}:
-        return True
     return not bool(os.getenv("ANTHROPIC_API_KEY"))
+
+
+def _env_flag_enabled(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _local_task_reasoning(prompt: str, budget: float, has_data: bool) -> TaskReasoning:

--- a/src/manager/manager.py
+++ b/src/manager/manager.py
@@ -192,10 +192,17 @@ def log_decision(step: str, rationale: str, config: OrchestrationConfig) -> None
         f.write(json.dumps(entry) + "\n")
 
 
-def reason_about_task(prompt: str, budget: float, has_data: bool) -> TaskReasoning:
+def reason_about_task(
+    prompt: str,
+    budget: float,
+    has_data: bool,
+    *,
+    task_type_hint: str | None = None,
+) -> TaskReasoning:
     """Infer task type, training type, base model, and starting hyperparams."""
+    hint = _normalize_task_type_hint(task_type_hint)
     if _use_local_reasoner():
-        return _local_task_reasoning(prompt, budget, has_data)
+        return _local_task_reasoning(prompt, budget, has_data, task_type_hint=hint)
 
     import anthropic
 
@@ -209,6 +216,10 @@ def reason_about_task(prompt: str, budget: float, has_data: bool) -> TaskReasoni
         "  suggested_base_model: str or null (HuggingFace model ID, e.g. 'bert-base-uncased')\n"
         "  hyperparameters: dict with keys learning_rate, batch_size, epochs, max_seq_len\n"
         "  notes: str (one sentence reasoning summary)\n"
+        "If a requested UI task type is provided, treat it as an operator hint: "
+        "classification usually maps to text-classification, regression may be "
+        "a custom supervised task, and fine-tuning means infer the concrete task "
+        "from the objective and data.\n"
         "Respond with raw JSON only. No markdown, no explanation."
     )
     user_msg = (
@@ -216,6 +227,8 @@ def reason_about_task(prompt: str, budget: float, has_data: bool) -> TaskReasoni
         f"Budget: ${budget:.2f}\n"
         f"User has existing data: {has_data}"
     )
+    if hint:
+        user_msg += f"\nRequested UI task type: {hint}"
     message = client.messages.create(
         model="claude-haiku-4-5",
         max_tokens=512,
@@ -252,9 +265,23 @@ def _env_flag_enabled(name: str) -> bool:
     return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _local_task_reasoning(prompt: str, budget: float, has_data: bool) -> TaskReasoning:
+def _normalize_task_type_hint(task_type_hint: str | None) -> str | None:
+    if task_type_hint is None:
+        return None
+    value = str(task_type_hint).strip().lower()
+    return value if value in {"classification", "regression", "fine-tuning"} else None
+
+
+def _local_task_reasoning(
+    prompt: str,
+    budget: float,
+    has_data: bool,
+    *,
+    task_type_hint: str | None = None,
+) -> TaskReasoning:
     """Deterministic fallback planner for no-live Manager runs."""
-    task_type = _infer_local_task_type(prompt)
+    hint = _normalize_task_type_hint(task_type_hint)
+    task_type = _infer_local_task_type(prompt, task_type_hint=hint)
     data_format = (
         "jsonl with messages or input/output fields"
         if has_data
@@ -279,11 +306,18 @@ def _local_task_reasoning(prompt: str, budget: float, has_data: bool) -> TaskRea
         notes=(
             "Local deterministic planner used because live Manager reasoning "
             "was not enabled."
+            + (f" Operator task hint: {hint}." if hint else "")
         ),
     )
 
 
-def _infer_local_task_type(prompt: str) -> str:
+def _infer_local_task_type(prompt: str, *, task_type_hint: str | None = None) -> str:
+    hint = _normalize_task_type_hint(task_type_hint)
+    if hint == "classification":
+        return "text-classification"
+    if hint == "regression":
+        return "custom"
+
     text = prompt.lower()
     if any(term in text for term in ("translate", "translation")):
         return "translation"

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -134,6 +134,21 @@ def test_reason_about_task_uses_local_fallback_without_anthropic_key(monkeypatch
     assert "Local deterministic planner" in result["notes"]
 
 
+def test_reason_about_task_auto_mode_is_credential_blind(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "present-but-not-used")
+    monkeypatch.delenv("MANAGER_REASONER", raising=False)
+
+    def fail_anthropic():
+        raise AssertionError("MANAGER_REASONER=auto should not construct Anthropic")
+
+    monkeypatch.setattr("anthropic.Anthropic", fail_anthropic)
+
+    result = reason_about_task("Classify support tickets by urgency", 5.0, False)
+
+    assert result["task_type"] == "text-classification"
+    assert "Local deterministic planner" in result["notes"]
+
+
 def test_reason_about_task_local_mode_overrides_available_key(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "present-but-not-used")
     monkeypatch.setenv("MANAGER_REASONER", "local")

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -130,6 +130,23 @@ def test_reason_about_task_local_mode_overrides_available_key(monkeypatch):
     assert result["data_format"] == "jsonl with messages or input/output fields"
 
 
+def test_reason_about_task_no_spend_overrides_claude_mode(monkeypatch):
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "present-but-not-used")
+    monkeypatch.setenv("MANAGER_REASONER", "claude")
+
+    def fail_anthropic():
+        raise AssertionError("NO_SPEND should not construct Anthropic")
+
+    monkeypatch.setattr("anthropic.Anthropic", fail_anthropic)
+
+    result = reason_about_task("Classify support tickets by urgency", 5.0, False)
+
+    assert result["task_type"] == "text-classification"
+    assert result["training_type"] == "SFT"
+    assert "Local deterministic planner" in result["notes"]
+
+
 def test_reason_about_task_invalid_reasoner_mode_fails(monkeypatch):
     monkeypatch.setenv("MANAGER_REASONER", "maybe")
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -96,6 +96,25 @@ def test_reason_about_task_parses_fenced_json_response(monkeypatch):
     assert result["suggested_base_model"] == "bert-base-uncased"
 
 
+def test_reason_about_task_includes_task_type_hint(monkeypatch):
+    monkeypatch.setenv("MANAGER_REASONER", "claude")
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text=json.dumps(MOCK_REASONING))]
+
+    with patch("anthropic.Anthropic") as MockClient:
+        client = MockClient.return_value
+        client.messages.create.return_value = mock_response
+        reason_about_task(
+            "predict support ticket resolution time",
+            12.5,
+            True,
+            task_type_hint="regression",
+        )
+
+    payload = client.messages.create.call_args.kwargs["messages"][0]["content"]
+    assert "Requested UI task type: regression" in payload
+
+
 def test_reason_about_task_uses_local_fallback_without_anthropic_key(monkeypatch):
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("MANAGER_REASONER", raising=False)
@@ -128,6 +147,63 @@ def test_reason_about_task_local_mode_overrides_available_key(monkeypatch):
 
     assert result["task_type"] == "summarization"
     assert result["data_format"] == "jsonl with messages or input/output fields"
+
+
+def test_local_reasoner_uses_classification_hint(monkeypatch):
+    monkeypatch.setenv("MANAGER_REASONER", "local")
+
+    def fail_anthropic():
+        raise AssertionError("local planner should not construct Anthropic")
+
+    monkeypatch.setattr("anthropic.Anthropic", fail_anthropic)
+
+    result = reason_about_task(
+        "predict support ticket resolution time",
+        5.0,
+        True,
+        task_type_hint="classification",
+    )
+
+    assert result["task_type"] == "text-classification"
+    assert "Operator task hint: classification" in result["notes"]
+
+
+def test_local_reasoner_uses_regression_hint_as_custom_supervised(monkeypatch):
+    monkeypatch.setenv("MANAGER_REASONER", "local")
+
+    def fail_anthropic():
+        raise AssertionError("local planner should not construct Anthropic")
+
+    monkeypatch.setattr("anthropic.Anthropic", fail_anthropic)
+
+    result = reason_about_task(
+        "classify support tickets by sentiment",
+        5.0,
+        True,
+        task_type_hint="regression",
+    )
+
+    assert result["task_type"] == "custom"
+    assert "Operator task hint: regression" in result["notes"]
+
+
+def test_local_reasoner_fine_tuning_hint_keeps_prompt_inference(monkeypatch):
+    monkeypatch.setenv("MANAGER_REASONER", "local")
+
+    def fail_anthropic():
+        raise AssertionError("local planner should not construct Anthropic")
+
+    monkeypatch.setattr("anthropic.Anthropic", fail_anthropic)
+
+    result = reason_about_task(
+        "Summarize customer support transcripts",
+        5.0,
+        True,
+        task_type_hint="fine-tuning",
+    )
+
+    assert result["task_type"] == "summarization"
+    assert "Operator task hint: fine-tuning" in result["notes"]
 
 
 def test_reason_about_task_no_spend_overrides_claude_mode(monkeypatch):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -69,7 +69,8 @@ def test_log_decision_writes_to_disk(tmp_path):
     assert entry["config_snapshot"]["prompt"] == "test task"
 
 
-def test_reason_about_task_returns_task_reasoning():
+def test_reason_about_task_returns_task_reasoning(monkeypatch):
+    monkeypatch.setenv("MANAGER_REASONER", "claude")
     mock_response = MagicMock()
     mock_response.content = [MagicMock(text=json.dumps(MOCK_REASONING))]
 
@@ -82,7 +83,8 @@ def test_reason_about_task_returns_task_reasoning():
     assert "learning_rate" in result["hyperparameters"]
 
 
-def test_reason_about_task_parses_fenced_json_response():
+def test_reason_about_task_parses_fenced_json_response(monkeypatch):
+    monkeypatch.setenv("MANAGER_REASONER", "claude")
     mock_response = MagicMock()
     mock_response.content = [MagicMock(text=f"```json\n{json.dumps(MOCK_REASONING)}\n```")]
 
@@ -92,6 +94,47 @@ def test_reason_about_task_parses_fenced_json_response():
 
     assert result["task_type"] == "text-classification"
     assert result["suggested_base_model"] == "bert-base-uncased"
+
+
+def test_reason_about_task_uses_local_fallback_without_anthropic_key(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("MANAGER_REASONER", raising=False)
+
+    def fail_anthropic():
+        raise AssertionError("Anthropic should not be constructed in auto mode without a key")
+
+    monkeypatch.setattr("anthropic.Anthropic", fail_anthropic)
+
+    result = reason_about_task("Classify support tickets by urgency", 5.0, False)
+
+    assert result["task_type"] == "text-classification"
+    assert result["training_type"] == "SFT"
+    assert result["suggested_base_model"] is None
+    assert result["hyperparameters"]["num_epochs"] == 1
+    assert result["hyperparameters"]["max_steps"] == 5
+    assert "Local deterministic planner" in result["notes"]
+
+
+def test_reason_about_task_local_mode_overrides_available_key(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "present-but-not-used")
+    monkeypatch.setenv("MANAGER_REASONER", "local")
+
+    def fail_anthropic():
+        raise AssertionError("MANAGER_REASONER=local should not construct Anthropic")
+
+    monkeypatch.setattr("anthropic.Anthropic", fail_anthropic)
+
+    result = reason_about_task("Summarize customer support transcripts", 5.0, True)
+
+    assert result["task_type"] == "summarization"
+    assert result["data_format"] == "jsonl with messages or input/output fields"
+
+
+def test_reason_about_task_invalid_reasoner_mode_fails(monkeypatch):
+    monkeypatch.setenv("MANAGER_REASONER", "maybe")
+
+    with pytest.raises(ValueError, match="MANAGER_REASONER"):
+        reason_about_task("classify movie sentiment", 50.0, False)
 
 
 def test_parse_task_reasoning_response_rejects_missing_keys():


### PR DESCRIPTION
## Summary
- Add `MANAGER_REASONER=auto/local/claude` for Manager task reasoning
- Default `auto` uses a deterministic local planner when `ANTHROPIC_API_KEY` is absent or `NO_SPEND=1` is set
- Preserve explicit `MANAGER_REASONER=claude` for live Anthropic-backed planning

## Why
The real Manager/API entrypoint previously always constructed an Anthropic client before DataGen or Tinker. That meant no-live local product runs could only be tested by bypassing the Manager reasoning node.

## Validation
- `python3 -m compileall src/manager tests/test_manager.py`
- `uv run --with pytest --with anthropic --with langgraph python -m pytest tests/test_manager.py -q` -> 20 passed, 1 skipped
- `uv run --with pytest --with anthropic --with langgraph --with datasets --with huggingface-hub --with requests --with tavily-python --with trafilatura --with pymupdf python -m pytest tests/test_manager.py tests/test_mode_c.py tests/test_data_curation.py -q` -> 42 passed, 1 skipped
- `uv run --with pytest --with fastapi --with httpx --with anthropic --with langgraph --with datasets --with huggingface-hub --with requests --with tavily-python --with trafilatura --with pymupdf python -m pytest tests -q --ignore=tests/integration/test_tinker_live_smoke.py --ignore=tests/data_generator/test_mode_b_hf_retrieval.py` -> 180 passed, 6 skipped

No live service spend.