### PR TITLE
[codex] make offline Mode B rows trainable

### DIFF
--- a/src/data_generator/mode_b.py
+++ b/src/data_generator/mode_b.py
@@ -70,10 +70,10 @@ def fetch_hf_datasets(candidates: list[HFCandidate]) -> RawData:
     Acquisition step for Mode B:
     fetch explicit HF datasets and return combined raw records.
 
-    Set DATA_GENERATOR_OFFLINE=1 for deterministic local test runs.
+    Set DATA_GENERATOR_OFFLINE=1 or NO_SPEND=1 for deterministic local test runs.
     """
     records: list[dict] = []
-    offline = os.getenv("DATA_GENERATOR_OFFLINE", "").strip().lower() in {"1", "true", "yes"}
+    offline = _env_flag_enabled("DATA_GENERATOR_OFFLINE") or _env_flag_enabled("NO_SPEND")
     max_rows_per_dataset = _read_optional_int_env("DATA_GENERATOR_MAX_ROWS_PER_DATASET")
     max_total_records = _read_optional_int_env("DATA_GENERATOR_MAX_TOTAL_RECORDS")
 
@@ -247,6 +247,10 @@ def _normalize_hf_dataset_id(value: str) -> str | None:
     if not re.fullmatch(r"[A-Za-z0-9._-]+", right):
         return None
     return f"{left}/{right}"
+
+
+def _env_flag_enabled(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _fetch_with_hf_datasets(dataset_id: str, max_rows_per_dataset: int | None) -> list[dict]:

--- a/src/data_generator/mode_b.py
+++ b/src/data_generator/mode_b.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from src.types import HFCandidate, OrchestrationConfig, RawData
 
+_OFFLINE_SPLITS = ("train", "validation", "test")
+
 
 def parse_explicit_hf_dataset_ids(config: OrchestrationConfig, data_path: str | None = None) -> list[str]:
     """Extract explicit HF dataset IDs from config/prompt/path."""
@@ -77,14 +79,14 @@ def fetch_hf_datasets(candidates: list[HFCandidate]) -> RawData:
 
     if offline:
         for candidate in candidates:
-            records.append(
-                {
-                    "source": candidate["name"],
-                    "content": f"offline_placeholder: acquired metadata for {candidate['name']}",
-                }
-            )
+            for record in _build_offline_trainable_records(candidate, max_rows_per_dataset):
+                if max_total_records is not None and len(records) >= max_total_records:
+                    break
+                records.append(record)
+            if max_total_records is not None and len(records) >= max_total_records:
+                break
         return {
-            "records": records or [{"source": "none", "content": "offline_empty"}],
+            "records": records or [_offline_empty_record()],
             "format_meta": {"modality": "text", "file_type": "hf_bundle", "encoding": "utf-8"},
         }
 
@@ -94,7 +96,12 @@ def fetch_hf_datasets(candidates: list[HFCandidate]) -> RawData:
         try:
             dataset_records = _fetch_with_hf_datasets(dataset_id, max_rows_per_dataset)
             if dataset_records:
-                records.extend(dataset_records)
+                if max_total_records is None:
+                    records.extend(dataset_records)
+                else:
+                    remaining = max_total_records - len(records)
+                    if remaining > 0:
+                        records.extend(dataset_records[:remaining])
             else:
                 records.append(
                     {
@@ -120,6 +127,70 @@ def fetch_hf_datasets(candidates: list[HFCandidate]) -> RawData:
         "records": records,
         "format_meta": {"modality": "text", "file_type": "hf_bundle", "encoding": "utf-8"},
     }
+
+
+def _build_offline_trainable_records(
+    candidate: HFCandidate,
+    max_rows_per_dataset: int | None,
+) -> list[dict]:
+    dataset_id = str(candidate.get("name") or candidate.get("id") or "unknown").strip() or "unknown"
+    task_type = _candidate_task_type(candidate)
+    row_count = len(_OFFLINE_SPLITS)
+    if max_rows_per_dataset is not None:
+        row_count = min(row_count, max_rows_per_dataset)
+
+    records: list[dict] = []
+    for idx, split in enumerate(_OFFLINE_SPLITS[:row_count]):
+        label = _offline_label(task_type, idx)
+        input_text = (
+            f"Offline Mode B sample {idx + 1} from {dataset_id} "
+            f"for {task_type} ({split} split)."
+        )
+        records.append(
+            {
+                "source": dataset_id,
+                "dataset_id": dataset_id,
+                "split": split,
+                "input": input_text,
+                "output": label,
+                "label": label,
+                "content": input_text,
+                "metadata": {
+                    "offline": True,
+                    "dataset_id": dataset_id,
+                    "candidate_id": candidate.get("id"),
+                    "row_index": idx,
+                },
+            }
+        )
+    return records
+
+
+def _offline_empty_record() -> dict:
+    input_text = "Offline Mode B run received no explicit Hugging Face dataset candidates."
+    return {
+        "source": "none",
+        "dataset_id": "none",
+        "split": "train",
+        "input": input_text,
+        "output": "no_dataset_candidates",
+        "label": "no_dataset_candidates",
+        "content": input_text,
+        "metadata": {"offline": True, "dataset_id": "none", "row_index": 0},
+    }
+
+
+def _candidate_task_type(candidate: HFCandidate) -> str:
+    task_categories = candidate.get("task_categories")
+    if isinstance(task_categories, list) and task_categories:
+        return str(task_categories[0]).strip() or "text_classification"
+    return "text_classification"
+
+
+def _offline_label(task_type: str, idx: int) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9]+", "_", task_type.strip().lower()).strip("_")
+    prefix = normalized or "text_classification"
+    return f"{prefix}_label_{idx % 2}"
 
 
 def _split_tokens(value: str) -> list[str]:
@@ -204,6 +275,7 @@ def _fetch_with_hf_datasets(dataset_id: str, max_rows_per_dataset: int | None) -
                 continue
             rec = {
                 "source": dataset_id,
+                "dataset_id": dataset_id,
                 "split": str(split_name),
                 "input": text_val[:1000],
                 "label": label_val,

--- a/src/data_generator/nodes.py
+++ b/src/data_generator/nodes.py
@@ -178,6 +178,7 @@ def _normalize_single_record(mode: str, record: dict[str, Any], index: int) -> d
     metadata = {
         "mode": mode,
         "source": record.get("source"),
+        "dataset_id": record.get("dataset_id"),
         "source_type": record.get("source_type"),
         "source_path": record.get("source_path") or record.get("path"),
         "url": record.get("url"),

--- a/tests/data_generator/test_mode_b_hf_retrieval.py
+++ b/tests/data_generator/test_mode_b_hf_retrieval.py
@@ -722,6 +722,40 @@ def test_offline_hf_fetch_returns_trainable_records_and_honors_caps(monkeypatch)
     assert "offline_placeholder" not in json.dumps(records)
 
 
+@pytest.mark.parametrize("flag_name", ["NO_SPEND", "DATA_GENERATOR_OFFLINE"])
+@pytest.mark.parametrize("flag_value", ["1", "on"])
+def test_mode_b_no_spend_or_offline_flags_skip_hf_loader(
+    monkeypatch,
+    flag_name: str,
+    flag_value: str,
+) -> None:
+    import src.data_generator.mode_b as mode_b
+    from src.data_generator.mode_b import (
+        build_explicit_hf_candidates,
+        fetch_hf_datasets,
+    )
+
+    monkeypatch.setenv(flag_name, flag_value)
+    monkeypatch.delenv(
+        "DATA_GENERATOR_OFFLINE" if flag_name == "NO_SPEND" else "NO_SPEND",
+        raising=False,
+    )
+    monkeypatch.setenv("DATA_GENERATOR_MAX_ROWS_PER_DATASET", "1")
+    monkeypatch.setattr(
+        mode_b,
+        "_fetch_with_hf_datasets",
+        lambda *_args, **_kwargs: pytest.fail("offline Mode B should not load HF datasets"),
+    )
+
+    raw_data = fetch_hf_datasets(
+        build_explicit_hf_candidates(["SetFit/sst2"], "text_classification")
+    )
+
+    assert raw_data["records"][0]["dataset_id"] == "SetFit/sst2"
+    assert raw_data["records"][0]["input"]
+    assert raw_data["records"][0]["output"]
+
+
 def test_offline_mode_b_curation_produces_trainable_rows_and_keeps_splits(
     monkeypatch,
     tmp_path: Path,

--- a/tests/data_generator/test_mode_b_hf_retrieval.py
+++ b/tests/data_generator/test_mode_b_hf_retrieval.py
@@ -14,6 +14,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from src.data_generator.artifacts import save_subagent2_artifacts
+from src.data_generator.curation import curate_handoff_to_dataset_result
 from src.data_generator.graph import invoke_data_generator_graph
 
 EXAMPLE_REPORT_PATH = (
@@ -685,6 +686,97 @@ def test_parse_hf_dataset_ids_keeps_explicit_sources_and_urls() -> None:
         "mteb/banking77",
         "SetFit/sst2",
     ]
+
+
+def test_offline_hf_fetch_returns_trainable_records_and_honors_caps(monkeypatch) -> None:
+    from src.data_generator.mode_b import (
+        build_explicit_hf_candidates,
+        fetch_hf_datasets,
+    )
+
+    monkeypatch.setenv("DATA_GENERATOR_OFFLINE", "1")
+    monkeypatch.setenv("DATA_GENERATOR_MAX_ROWS_PER_DATASET", "2")
+    monkeypatch.setenv("DATA_GENERATOR_MAX_TOTAL_RECORDS", "3")
+
+    candidates = build_explicit_hf_candidates(
+        ["SetFit/sst2", "mteb/banking77"],
+        "text_classification",
+    )
+
+    raw_data = fetch_hf_datasets(candidates)
+
+    records = raw_data["records"]
+    assert len(records) == 3
+    assert [record["dataset_id"] for record in records] == [
+        "SetFit/sst2",
+        "SetFit/sst2",
+        "mteb/banking77",
+    ]
+    assert [record["split"] for record in records] == [
+        "train",
+        "validation",
+        "train",
+    ]
+    assert all(record["input"] and record["output"] for record in records)
+    assert all(record["source"] == record["dataset_id"] for record in records)
+    assert "offline_placeholder" not in json.dumps(records)
+
+
+def test_offline_mode_b_curation_produces_trainable_rows_and_keeps_splits(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("DATA_GENERATOR_OFFLINE", "1")
+    monkeypatch.delenv("DATA_GENERATOR_MAX_ROWS_PER_DATASET", raising=False)
+    monkeypatch.delenv("DATA_GENERATOR_MAX_TOTAL_RECORDS", raising=False)
+    monkeypatch.setenv("DATA_GENERATOR_ARTIFACT_DIR", str(tmp_path / "artifacts"))
+
+    config = {
+        "data": False,
+        "prompt": "Build an offline Mode B dataset.",
+        "hf_dataset_ids": ["SetFit/sst2", "mteb/banking77"],
+        "compute_budget": 10.0,
+        "training_procedure": {
+            "task_type": "text_classification",
+            "data_format": "jsonl",
+            "training_type": "SFT",
+            "base_model": None,
+            "hyperparameters": {},
+            "notes": "offline unit test",
+        },
+    }
+
+    handoff = invoke_data_generator_graph(config=config, data_path=None)
+    result = curate_handoff_to_dataset_result(handoff, output_dir=str(tmp_path))
+
+    assert result["validation_report"]["passed"] is True
+    assert result["dataset"]["train_size"] == 2
+    assert result["dataset"]["val_size"] == 2
+    assert result["dataset"]["test_size"] == 2
+
+    curation_records = handoff["curation_payload"]["records"]
+    assert len(curation_records) == 6
+    assert {
+        record["metadata"]["dataset_id"]
+        for record in curation_records
+    } == {"SetFit/sst2", "mteb/banking77"}
+    assert {record["metadata"]["source"] for record in curation_records} == {
+        "SetFit/sst2",
+        "mteb/banking77",
+    }
+    assert {record["metadata"]["split"] for record in curation_records} == {
+        "train",
+        "validation",
+        "test",
+    }
+
+    rows = [
+        json.loads(line)
+        for line in open(result["dataset"]["path"], encoding="utf-8").read().splitlines()
+        if line.strip()
+    ]
+    assert len(rows) == 6
+    assert all(row["input"] and row["output"] for row in rows)
 
 
 def test_live_hf_retrieval_requires_explicit_opt_in(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Make `DATA_GENERATOR_OFFLINE=1` Mode B emit deterministic trainable `input`/`output` rows instead of metadata-only placeholders
- Preserve `source`, `dataset_id`, split metadata, and row caps across offline HF candidates
- Preserve `dataset_id` in normalized curation metadata

## Why
Offline Mode B previously produced targetless placeholder records that curation dropped, so local no-live Mode B paths failed before DecisionEngine/Tinker.

## Validation
- `python3 -m compileall src/data_generator tests/data_generator/test_mode_b_hf_retrieval.py tests/test_data_curation.py`
- `uv run --with pytest python -m pytest tests/data_generator/test_handoff_contract_consistency.py tests/data_generator/test_deployment_style_handoff_artifacts.py tests/data_generator/test_mode_b_hf_retrieval.py tests/test_data_curation.py -q` -> 26 passed, 2 skipped

No live service spend.