### PR TITLE
[codex] add dry-run Tinker SFT backend

### DIFF
--- a/src/tinker_api/sft_runner.py
+++ b/src/tinker_api/sft_runner.py
@@ -3,7 +3,9 @@ SDK-native Tinker supervised fine-tuning runner.
 
 This module is intentionally lazy about importing ``tinker`` and
 ``tinker_cookbook`` so the regular unit suite can run without live SDK
-dependencies installed.
+dependencies installed. Set ``TINKER_BACKEND=dry_run`` to exercise the same
+chat/SFT JSONL artifact contract without importing or constructing live Tinker
+SDK clients.
 """
 
 from __future__ import annotations
@@ -30,6 +32,8 @@ if TYPE_CHECKING:
 
 DEFAULT_TINKER_MODEL = "Qwen/Qwen3.5-9B"
 DEFAULT_LIVE_SMOKE_STEPS = 5
+TINKER_BACKEND_ENV = "TINKER_BACKEND"
+TINKER_DRY_RUN_BACKEND = "dry_run"
 QWEN35_9B_RENDERER = "qwen3_5_disable_thinking"
 SUPPORTED_TINKER_TUNABLES: frozenset[str] = frozenset(
     {"learning_rate", "batch_size", "max_seq_length", "lora_rank", "num_epochs"}
@@ -60,7 +64,9 @@ def run_tinker_sft_experiment(
 
     ``dataset`` may be a repo ``DatasetResult``, a JSONL path, or an in-memory
     sequence of JSON-like records. Metrics and manifest artifacts are written
-    under ``output_dir/run_id``.
+    under ``output_dir/run_id``. Set ``TINKER_BACKEND=dry_run`` to write the
+    same artifact contract with deterministic synthetic metrics and no live
+    Tinker client construction.
     """
     cfg = _coerce_training_config(config)
     run_name = run_id or f"tinker-sft-{int(time.time())}-{uuid4().hex[:8]}"
@@ -70,6 +76,16 @@ def run_tinker_sft_experiment(
     conversations = load_conversations(dataset)
     if not conversations:
         raise ValueError("No valid chat/SFT examples found for Tinker training.")
+
+    if _use_dry_run_backend():
+        return _run_dry_run_sft_experiment(
+            cfg=cfg,
+            dataset=dataset,
+            conversations=conversations,
+            run_name=run_name,
+            run_dir=run_dir,
+            max_steps=max_steps,
+        )
 
     try:
         tinker, tinker_types, model_info, renderers, supervised_data, tokenizer_utils = (
@@ -99,6 +115,7 @@ def run_tinker_sft_experiment(
         )
         metrics_history: list[dict[str, Any]] = []
         metrics_path = run_dir / "metrics.jsonl"
+        metrics_path.touch()
         status = "COMPLETED"
 
         for step in range(target_steps):
@@ -423,6 +440,169 @@ def _load_tinker_deps() -> tuple[Any, Any, Any, Any, Any, Any]:
             "tinker and tinker-cookbook are required for live Tinker SFT runs"
         ) from exc
     return tinker, tinker_types, model_info, renderers, supervised_data, tokenizer_utils
+
+
+def _use_dry_run_backend() -> bool:
+    backend = os.getenv(TINKER_BACKEND_ENV, "").strip().lower().replace("-", "_")
+    return backend == TINKER_DRY_RUN_BACKEND
+
+
+def _run_dry_run_sft_experiment(
+    *,
+    cfg: TrainingConfig,
+    dataset: DatasetResult | str | os.PathLike[str] | Sequence[Mapping[str, Any]],
+    conversations: list[list[dict[str, str]]],
+    run_name: str,
+    run_dir: Path,
+    max_steps: int | None,
+) -> ExperimentResult:
+    model_name = cfg.model_name or DEFAULT_TINKER_MODEL
+    splits = _split_conversations(dataset, conversations)
+    training_conversations = _expand_assistant_training_targets(splits.train)
+    if not training_conversations:
+        raise ValueError("No assistant targets found after a user message.")
+
+    metrics_history: list[dict[str, Any]] = []
+    metrics_path = run_dir / "metrics.jsonl"
+    metrics_path.touch()
+    status = "COMPLETED"
+    target_steps = _resolve_target_steps(
+        num_examples=len(training_conversations),
+        batch_size=cfg.batch_size,
+        num_epochs=cfg.num_epochs,
+        max_steps=max_steps,
+    )
+
+    for step in range(target_steps):
+        if is_cancelled(run_name):
+            status = "CANCELLED"
+            break
+
+        batch_conversations = _conversation_batch(
+            training_conversations,
+            cfg.batch_size,
+            step,
+        )
+        tokens = sum(_dry_run_token_count(conversation) for conversation in batch_conversations)
+        record_tokens(run_name, tokens)
+        loss = _dry_run_batch_loss(batch_conversations, step)
+        step_metrics = {
+            "step": step + 1,
+            "train_loss": loss,
+            "val_loss": loss,
+            "test_loss": loss,
+            "primary_metric": _score_from_loss(loss),
+            "tokens": tokens,
+        }
+        metrics_history.append(step_metrics)
+        with open(metrics_path, "a") as fh:
+            fh.write(json.dumps(step_metrics, allow_nan=False) + "\n")
+
+    val_loss = _dry_run_holdout_loss(splits.val)
+    test_loss = _dry_run_holdout_loss(splits.test)
+    final_metrics = _final_metrics(
+        metrics_history,
+        status,
+        val_loss=val_loss,
+        test_loss=test_loss,
+    )
+    checkpoints = {
+        "state_path": f"dry-run://state/{run_name}-final-state",
+        "sampler_path": f"dry-run://sampler/{run_name}-final-sampler",
+    }
+    manifest = {
+        "run_id": run_name,
+        "status": status,
+        "backend": TINKER_DRY_RUN_BACKEND,
+        "model_name": model_name,
+        "renderer_name": "dry_run_chat",
+        "train_on_what": "last_assistant_message",
+        "dataset_path": _dataset_path_for_manifest(dataset),
+        "training_examples": len(training_conversations),
+        "split_examples": {
+            "train": len(splits.train),
+            "val": len(splits.val),
+            "test": len(splits.test),
+        },
+        "heldout_eval": {
+            "val_loss": val_loss,
+            "test_loss": test_loss,
+        },
+        "max_steps": max_steps,
+        "completed_steps": len(metrics_history),
+        "checkpoints": checkpoints,
+    }
+    _write_json(run_dir / "sample.json", _dry_run_sample(conversations))
+    _write_json(run_dir / "manifest.json", manifest)
+    _write_json(run_dir / "metrics.json", final_metrics)
+
+    return {
+        "job_id": run_name,
+        "status": status,
+        "metrics": final_metrics,
+        "model_path": str(run_dir),
+        "cost_usd": get_cumulative_spend(run_name),
+        "logs_path": str(metrics_path),
+    }
+
+
+def _dry_run_batch_loss(
+    conversations: Sequence[Sequence[dict[str, str]]],
+    step: int,
+) -> float:
+    if not conversations:
+        return 0.0
+    base_loss = sum(_dry_run_conversation_loss(conversation) for conversation in conversations)
+    mean_loss = base_loss / len(conversations)
+    return max(0.000001, mean_loss / math.sqrt(step + 1))
+
+
+def _dry_run_holdout_loss(conversations: Sequence[Sequence[dict[str, str]]]) -> float | None:
+    targets = _expand_assistant_training_targets(conversations)
+    if not targets:
+        return None
+    return sum(_dry_run_conversation_loss(conversation) for conversation in targets) / len(targets)
+
+
+def _dry_run_conversation_loss(conversation: Sequence[dict[str, str]]) -> float:
+    assistant_chars = sum(
+        len(message["content"]) for message in conversation if message["role"] == "assistant"
+    )
+    context_chars = sum(
+        len(message["content"]) for message in conversation if message["role"] != "assistant"
+    )
+    turns = max(1, len(conversation))
+    loss = 0.35 + (assistant_chars % 101) / 200.0 + (context_chars % 67) / 335.0
+    loss += turns / 1000.0
+    return float(loss)
+
+
+def _dry_run_token_count(conversation: Sequence[dict[str, str]]) -> int:
+    total = 0
+    for message in conversation:
+        total += max(1, len(message["content"].split()))
+    return total
+
+
+def _dry_run_sample(conversations: list[list[dict[str, str]]]) -> dict[str, Any]:
+    prompt_messages = [message for message in conversations[0] if message["role"] != "assistant"]
+    if not prompt_messages:
+        prompt_messages = [{"role": "user", "content": conversations[0][0]["content"]}]
+
+    first_answer = next(
+        (
+            message["content"]
+            for message in conversations[0]
+            if message["role"] == "assistant"
+        ),
+        "",
+    )
+    return {
+        "prompt": prompt_messages,
+        "text": first_answer,
+        "tokens": [len(first_answer)],
+        "backend": TINKER_DRY_RUN_BACKEND,
+    }
 
 
 def _resolve_target_steps(

--- a/src/tinker_api/sft_runner.py
+++ b/src/tinker_api/sft_runner.py
@@ -3,9 +3,9 @@ SDK-native Tinker supervised fine-tuning runner.
 
 This module is intentionally lazy about importing ``tinker`` and
 ``tinker_cookbook`` so the regular unit suite can run without live SDK
-dependencies installed. Set ``TINKER_BACKEND=dry_run`` to exercise the same
-chat/SFT JSONL artifact contract without importing or constructing live Tinker
-SDK clients.
+dependencies installed. Set ``TINKER_BACKEND=dry_run`` or ``NO_SPEND=1`` to
+exercise the same chat/SFT JSONL artifact contract without importing or
+constructing live Tinker SDK clients.
 """
 
 from __future__ import annotations
@@ -34,6 +34,7 @@ DEFAULT_TINKER_MODEL = "Qwen/Qwen3.5-9B"
 DEFAULT_LIVE_SMOKE_STEPS = 5
 TINKER_BACKEND_ENV = "TINKER_BACKEND"
 TINKER_DRY_RUN_BACKEND = "dry_run"
+NO_SPEND_ENV = "NO_SPEND"
 QWEN35_9B_RENDERER = "qwen3_5_disable_thinking"
 SUPPORTED_TINKER_TUNABLES: frozenset[str] = frozenset(
     {"learning_rate", "batch_size", "max_seq_length", "lora_rank", "num_epochs"}
@@ -64,9 +65,9 @@ def run_tinker_sft_experiment(
 
     ``dataset`` may be a repo ``DatasetResult``, a JSONL path, or an in-memory
     sequence of JSON-like records. Metrics and manifest artifacts are written
-    under ``output_dir/run_id``. Set ``TINKER_BACKEND=dry_run`` to write the
-    same artifact contract with deterministic synthetic metrics and no live
-    Tinker client construction.
+    under ``output_dir/run_id``. Set ``TINKER_BACKEND=dry_run`` or
+    ``NO_SPEND=1`` to write the same artifact contract with deterministic
+    synthetic metrics and no live Tinker client construction.
     """
     cfg = _coerce_training_config(config)
     run_name = run_id or f"tinker-sft-{int(time.time())}-{uuid4().hex[:8]}"
@@ -443,8 +444,14 @@ def _load_tinker_deps() -> tuple[Any, Any, Any, Any, Any, Any]:
 
 
 def _use_dry_run_backend() -> bool:
+    if _env_flag_enabled(NO_SPEND_ENV):
+        return True
     backend = os.getenv(TINKER_BACKEND_ENV, "").strip().lower().replace("-", "_")
     return backend == TINKER_DRY_RUN_BACKEND
+
+
+def _env_flag_enabled(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _run_dry_run_sft_experiment(

--- a/tests/integration/test_tinker_live_smoke.py
+++ b/tests/integration/test_tinker_live_smoke.py
@@ -17,7 +17,13 @@ from src.tinker_api.sft_runner import (
 )
 
 
+def _env_truthy(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 def test_live_tinker_chat_sft_smoke(tmp_path):
+    if _env_truthy("NO_SPEND"):
+        pytest.skip("NO_SPEND=1 disables live Tinker smoke tests")
     if os.getenv("RUN_LIVE_TINKER") != "1":
         pytest.skip("set RUN_LIVE_TINKER=1 to run the live Tinker smoke test")
     if not os.getenv("TINKER_API_KEY"):

--- a/tests/test_tinker_runner.py
+++ b/tests/test_tinker_runner.py
@@ -132,6 +132,163 @@ def test_run_tinker_sft_experiment_writes_artifacts(tmp_path, monkeypatch):
     }
 
 
+def test_run_tinker_sft_experiment_dry_run_uses_real_dataset_without_sdk(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("TINKER_BACKEND", "dry_run")
+    from src.tinker_api import sft_runner
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    def fail_load_tinker_deps():
+        raise AssertionError("dry_run should not import Tinker SDK dependencies")
+
+    class FailingServiceClient:
+        def create_lora_training_client(self, *args, **kwargs):
+            raise AssertionError("dry_run should not construct live training clients")
+
+    monkeypatch.setattr(sft_runner, "_load_tinker_deps", fail_load_tinker_deps)
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [
+            {"input": "train one", "output": "alpha"},
+            {
+                "messages": [
+                    {"role": "user", "content": "train two"},
+                    {"role": "assistant", "content": "beta"},
+                ]
+            },
+            {"input": "validation", "output": "gamma"},
+            {"input": "test", "output": "delta"},
+        ],
+    )
+    dataset_result = {
+        "dataset": {
+            "path": str(data_path),
+            "train_size": 2,
+            "val_size": 1,
+            "test_size": 1,
+        },
+        "next_agent": "decision_engine",
+    }
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=2),
+        dataset_result,
+        run_id="dry-run",
+        max_steps=3,
+        output_dir=str(tmp_path / "experiments"),
+        service_client=FailingServiceClient(),
+    )
+
+    run_dir = tmp_path / "experiments" / "dry-run"
+    metrics = _assert_strict_json_file(run_dir / "metrics.json")
+    manifest = _assert_strict_json_file(run_dir / "manifest.json")
+    sample = _assert_strict_json_file(run_dir / "sample.json")
+    rows = [
+        _strict_json(line)
+        for line in (run_dir / "metrics.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+
+    assert result["status"] == "COMPLETED"
+    assert manifest["backend"] == "dry_run"
+    assert manifest["split_examples"] == {"train": 2, "val": 1, "test": 1}
+    assert manifest["training_examples"] == 2
+    assert manifest["completed_steps"] == 3
+    assert manifest["checkpoints"]["state_path"].startswith("dry-run://state/")
+    assert manifest["heldout_eval"]["val_loss"] is not None
+    assert manifest["heldout_eval"]["test_loss"] is not None
+    assert len(rows) == 3
+    assert [row["step"] for row in rows] == [1, 2, 3]
+    assert all(math.isfinite(row["train_loss"]) for row in rows)
+    assert all(math.isfinite(metrics[key]) for key in metrics)
+    assert sample["text"] == "alpha"
+    assert sample["backend"] == "dry_run"
+
+
+def test_run_tinker_sft_experiment_dry_run_cancels_before_steps(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("TINKER_BACKEND", "dry_run")
+    from src.tinker_api import sft_runner, tinker_api
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    monkeypatch.setattr(
+        sft_runner,
+        "_load_tinker_deps",
+        lambda: pytest.fail("dry_run should not load Tinker SDK dependencies"),
+    )
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [{"input": "Question", "output": "Answer"}],
+    )
+    tinker_api.cancel_job("dry-cancel-before-run")
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=1),
+        str(data_path),
+        run_id="dry-cancel-before-run",
+        max_steps=2,
+        output_dir=str(tmp_path / "experiments"),
+    )
+
+    run_dir = tmp_path / "experiments" / "dry-cancel-before-run"
+    metrics = _assert_strict_json_file(run_dir / "metrics.json")
+    manifest = _assert_strict_json_file(run_dir / "manifest.json")
+
+    assert result["status"] == "CANCELLED"
+    assert manifest["status"] == "CANCELLED"
+    assert manifest["completed_steps"] == 0
+    assert (run_dir / "metrics.jsonl").exists()
+    assert (run_dir / "metrics.jsonl").read_text() == ""
+    assert (run_dir / "sample.json").exists()
+    assert all(math.isfinite(metrics[key]) for key in metrics)
+
+
+def test_run_tinker_sft_experiment_dry_run_cancels_between_steps(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("TINKER_BACKEND", "dry_run")
+    from src.tinker_api import sft_runner, tinker_api
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    original_record_tokens = tinker_api.record_tokens
+
+    def cancel_after_first_step(job_id: str, n_tokens: int) -> None:
+        original_record_tokens(job_id, n_tokens)
+        tinker_api.cancel_job(job_id)
+
+    monkeypatch.setattr(sft_runner, "record_tokens", cancel_after_first_step)
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [{"input": "Question", "output": "Answer"}],
+    )
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=1),
+        str(data_path),
+        run_id="dry-cancel-between-steps",
+        max_steps=3,
+        output_dir=str(tmp_path / "experiments"),
+    )
+
+    run_dir = tmp_path / "experiments" / "dry-cancel-between-steps"
+    manifest = _assert_strict_json_file(run_dir / "manifest.json")
+    rows = [
+        _strict_json(line)
+        for line in (run_dir / "metrics.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+
+    assert result["status"] == "CANCELLED"
+    assert manifest["status"] == "CANCELLED"
+    assert manifest["completed_steps"] == 1
+    assert len(rows) == 1
+
+
 def test_run_tinker_sft_experiment_writes_strict_json_for_nonfinite_training_loss(
     tmp_path,
     monkeypatch,
@@ -525,6 +682,105 @@ def test_autoresearch_run_node_calls_tinker_runner(monkeypatch, tmp_path):
     assert captured["max_steps"] == 5
     assert captured["dataset"]["dataset"]["path"] == str(data_path)
     assert captured["config"].model_name == "Qwen/Qwen3.5-9B"
+
+
+def test_autoresearch_graph_uses_dry_run_tinker_backend_without_sdk(
+    monkeypatch,
+    tmp_path,
+):
+    pytest.importorskip("langgraph", reason="langgraph not installed")
+
+    import src.autoresearch.autoresearch as ar
+    import src.tinker_api.sft_runner as sft_runner
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("TINKER_BACKEND", "dry_run")
+    monkeypatch.setenv("AUTORESEARCH_PROPOSER", "claude")
+    monkeypatch.delenv("TINKER_API_KEY", raising=False)
+
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [
+            {"input": "question one", "output": "answer one"},
+            {"input": "question two", "output": "answer two"},
+        ],
+    )
+    config_path = tmp_path / "configs" / "current.json"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "model_name": "Qwen/Qwen3.5-9B",
+                "learning_rate": 1e-4,
+                "batch_size": 1,
+                "max_steps": 1,
+            }
+        )
+    )
+
+    monkeypatch.setattr(ar, "_CONFIG_PATH", config_path)
+    monkeypatch.setattr(
+        ar,
+        "_DIARY_PATH",
+        tmp_path / "outputs" / "logs" / "diary.jsonl",
+    )
+    monkeypatch.setattr(ar, "_MAX_ITERATIONS", 1)
+
+    def fail_if_live_sdk_loads():
+        raise AssertionError("dry-run graph should not load Tinker SDK dependencies")
+
+    monkeypatch.setattr(sft_runner, "_load_tinker_deps", fail_if_live_sdk_loads)
+
+    proposed_allowed_params = []
+
+    def fake_propose_hypothesis(current_config, diary, task, allowed_params=None):
+        proposed_allowed_params.append(allowed_params)
+        return {
+            "description": "Nudge learning_rate upward for a dry-run graph smoke.",
+            "patch": json.dumps({"learning_rate": 2e-4}),
+            "expected_effect": "Dry-run loss should remain finite.",
+            "search_strategy": "local",
+        }
+
+    monkeypatch.setattr(ar, "propose_hypothesis", fake_propose_hypothesis)
+    plan = _autoresearch_state(str(data_path))["plan"]
+    config = _autoresearch_state(str(data_path))["config"]
+    config["compute_budget"] = 10.0
+    config["training_procedure"]["hyperparameters"] = {
+        "learning_rate": 1e-4,
+        "batch_size": 1,
+        "max_steps": 1,
+    }
+
+    trained_model = ar.invoke_autoresearch_graph(plan, config, cost_manager=None)
+
+    experiment_dirs = sorted((tmp_path / "outputs" / "experiments").iterdir())
+    manifests = [
+        _assert_strict_json_file(experiment_dir / "manifest.json")
+        for experiment_dir in experiment_dirs
+    ]
+    diary_path = tmp_path / "outputs" / "logs" / "diary.jsonl"
+    diary_rows = [
+        _strict_json(line)
+        for line in diary_path.read_text().splitlines()
+        if line.strip()
+    ]
+
+    assert len(experiment_dirs) == 2
+    assert {manifest["backend"] for manifest in manifests} == {"dry_run"}
+    assert all(manifest["completed_steps"] == 1 for manifest in manifests)
+    assert all(
+        (experiment_dir / "metrics.json").exists()
+        for experiment_dir in experiment_dirs
+    )
+    assert all(
+        (experiment_dir / "sample.json").exists()
+        for experiment_dir in experiment_dirs
+    )
+    assert len(diary_rows) == 1
+    assert trained_model["n_iterations"] == 1
+    assert trained_model["metrics"]["scalar"] > 0
+    assert proposed_allowed_params == [sorted(sft_runner.SUPPORTED_TINKER_TUNABLES)]
 
 
 def _write_jsonl(path: Path, rows: list[dict]) -> Path:

--- a/tests/test_tinker_runner.py
+++ b/tests/test_tinker_runner.py
@@ -207,6 +207,48 @@ def test_run_tinker_sft_experiment_dry_run_uses_real_dataset_without_sdk(
     assert sample["backend"] == "dry_run"
 
 
+def test_run_tinker_sft_experiment_no_spend_uses_dry_run_without_sdk(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.delenv("TINKER_BACKEND", raising=False)
+    from src.tinker_api import sft_runner
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    class FailingServiceClient:
+        def create_lora_training_client(self, *args, **kwargs):
+            raise AssertionError("NO_SPEND should not construct live training clients")
+
+    monkeypatch.setattr(
+        sft_runner,
+        "_load_tinker_deps",
+        lambda: pytest.fail("NO_SPEND should not load Tinker SDK dependencies"),
+    )
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [{"input": "Question", "output": "Answer"}],
+    )
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=1),
+        str(data_path),
+        run_id="no-spend-dry-run",
+        max_steps=1,
+        output_dir=str(tmp_path / "experiments"),
+        service_client=FailingServiceClient(),
+    )
+
+    run_dir = tmp_path / "experiments" / "no-spend-dry-run"
+    manifest = _assert_strict_json_file(run_dir / "manifest.json")
+    sample = _assert_strict_json_file(run_dir / "sample.json")
+
+    assert result["status"] == "COMPLETED"
+    assert manifest["backend"] == "dry_run"
+    assert manifest["completed_steps"] == 1
+    assert sample["backend"] == "dry_run"
+
+
 def test_run_tinker_sft_experiment_dry_run_cancels_before_steps(
     tmp_path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- Add `TINKER_BACKEND=dry_run` to `run_tinker_sft_experiment`
- Consume real chat/SFT JSONL or `DatasetResult` inputs without importing/constructing live Tinker SDK clients
- Emit the same artifact contract: `metrics.json`, `metrics.jsonl`, `manifest.json`, `sample.json`, checkpoints identifiers, and `ExperimentResult`
- Support deterministic finite metrics, heldout split metadata, row-count based steps, token/cost ledger, and cancellation via existing `cancel_job` flags

## Why
The repo had unit fakes and live Tinker smoke tests, but no real local no-spend backend for product demos or end-to-end API smokes.

## Validation
- `python3 -m compileall src/tinker_api/sft_runner.py tests/test_tinker_runner.py`
- `uv run --with pytest --with anthropic --with langgraph --with requests --with datasets --with huggingface-hub --with transformers --with peft python -m pytest tests/test_tinker_runner.py -q` -> 21 passed

No live service spend.