### PR TITLE
Keep unlabeled Mode A text source-only

### DIFF
--- a/src/data_generator/curation.py
+++ b/src/data_generator/curation.py
@@ -113,6 +113,8 @@ def curate_record(
             raise ValueError("messages must contain a user message")
         if not any(message["role"] == "assistant" for message in normalized):
             raise ValueError("messages must contain an assistant message")
+        if not _has_assistant_target_after_user(normalized):
+            raise ValueError("messages must contain an assistant message after a user message")
         return {"messages": normalized}
 
     user_text = _first_text(record, _INPUT_KEYS)
@@ -186,6 +188,17 @@ def _normalize_messages(messages: Any) -> list[dict[str, str]]:
             raise ValueError("message content cannot be empty")
         normalized.append({"role": role, "content": str(content).strip()})
     return normalized
+
+
+def _has_assistant_target_after_user(messages: Sequence[Mapping[str, str]]) -> bool:
+    seen_user = False
+    for message in messages:
+        role = message["role"]
+        if role == "user":
+            seen_user = True
+        elif role == "assistant" and seen_user:
+            return True
+    return False
 
 
 def _first_text(record: Mapping[str, Any], keys: Sequence[str]) -> str:

--- a/src/data_generator/mode_a.py
+++ b/src/data_generator/mode_a.py
@@ -138,7 +138,7 @@ def _read_parquet_file(path: Path) -> list[dict[str, Any]]:
 
 def _read_text_file(path: Path) -> list[dict[str, str]]:
     text = path.read_text(encoding="utf-8", errors="replace")
-    return [{"input": line.strip(), "output": "unknown"} for line in text.splitlines() if line.strip()]
+    return [{"input": line.strip()} for line in text.splitlines() if line.strip()]
 
 
 def _load_directory_records(path: Path, file_type: str) -> list[dict[str, Any]]:

--- a/src/tinker_api/sft_runner.py
+++ b/src/tinker_api/sft_runner.py
@@ -202,6 +202,8 @@ def record_to_conversation(record: Mapping[str, Any]) -> list[dict[str, str]]:
             raise ValueError("messages must contain at least one user message")
         if not any(message["role"] == "assistant" for message in normalized):
             raise ValueError("messages must contain at least one assistant message")
+        if not _has_assistant_target_after_user(normalized):
+            raise ValueError("messages must contain an assistant message after a user message")
         return normalized
 
     user_text = _first_text(record, _INPUT_KEYS)
@@ -238,6 +240,17 @@ def _expand_assistant_training_targets(
             if copied["role"] == "assistant" and seen_user:
                 targets.append(list(prefix))
     return targets
+
+
+def _has_assistant_target_after_user(messages: Sequence[Mapping[str, str]]) -> bool:
+    seen_user = False
+    for message in messages:
+        role = message["role"]
+        if role == "user":
+            seen_user = True
+        elif role == "assistant" and seen_user:
+            return True
+    return False
 
 
 def resolve_renderer_name(model_name: str, model_info_module: Any | None = None) -> str:

--- a/tests/data_generator/test_handoff_contract_consistency.py
+++ b/tests/data_generator/test_handoff_contract_consistency.py
@@ -99,6 +99,79 @@ def test_mode_a_handoff_preserves_chat_messages_through_curation(tmp_path, monke
     assert dataset["validation_report"]["passed"] is True
 
 
+def test_mode_a_plain_text_is_source_only_and_fails_curation(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    state = {
+        "config": _base_config(),
+        "data_path": "/tmp/notes.txt",
+        "mode": "A",
+        "raw_data": {
+            "records": [
+                {
+                    "input": "unlabeled note",
+                    "source_path": "/tmp/notes.txt",
+                    "row_index": 1,
+                }
+            ],
+            "format_meta": {"modality": "text", "file_type": "txt", "encoding": "utf-8"},
+        },
+        "hf_candidates": [],
+        "selected_candidate": None,
+        "web_plan": None,
+        "web_search_results": [],
+        "human_readable": None,
+    }
+
+    handoff = build_handoff_node(state)["handoff"]
+    curation_record = handoff["curation_payload"]["records"][0]
+    assert curation_record["input"] == "unlabeled note"
+    assert curation_record["output"] == ""
+
+    dataset = curate_handoff_to_dataset_result(handoff)
+
+    assert dataset["dataset"]["train_size"] == 0
+    assert dataset["validation_report"]["passed"] is False
+    assert any("missing target field" in issue for issue in dataset["validation_report"]["issues"])
+    assert any("No valid chat/SFT records" in issue for issue in dataset["validation_report"]["issues"])
+
+
+def test_mode_a_chat_requires_assistant_after_user(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    messages = [
+        {"role": "assistant", "content": "urgent"},
+        {"role": "user", "content": "Payment service is down."},
+    ]
+    state = {
+        "config": _base_config(),
+        "data_path": "/tmp/chat.jsonl",
+        "mode": "A",
+        "raw_data": {
+            "records": [
+                {
+                    "messages": messages,
+                    "source_path": "/tmp/chat.jsonl",
+                    "row_index": 1,
+                }
+            ],
+            "format_meta": {"modality": "text", "file_type": "jsonl", "encoding": "utf-8"},
+        },
+        "hf_candidates": [],
+        "selected_candidate": None,
+        "web_plan": None,
+        "web_search_results": [],
+        "human_readable": None,
+    }
+
+    handoff = build_handoff_node(state)["handoff"]
+    dataset = curate_handoff_to_dataset_result(handoff)
+
+    assert dataset["validation_report"]["passed"] is False
+    assert any(
+        "assistant message after a user" in issue
+        for issue in dataset["validation_report"]["issues"]
+    )
+
+
 def test_mode_b_handoff_keeps_hf_artifacts_and_standardizes_records():
     raw_data = {
         "records": [

--- a/tests/data_generator/test_mode_a_local_data.py
+++ b/tests/data_generator/test_mode_a_local_data.py
@@ -52,8 +52,8 @@ def test_load_raw_data_plain_text(tmp_path: Path):
 
     assert raw["format_meta"]["modality"] == "text"
     assert raw["records"] == [
-        {"input": "first line", "output": "unknown", "source_path": str(text_path), "row_index": 1},
-        {"input": "second line", "output": "unknown", "source_path": str(text_path), "row_index": 2},
+        {"input": "first line", "source_path": str(text_path), "row_index": 1},
+        {"input": "second line", "source_path": str(text_path), "row_index": 2},
     ]
 
 

--- a/tests/test_tinker_runner.py
+++ b/tests/test_tinker_runner.py
@@ -48,6 +48,20 @@ def test_record_to_conversation_rejects_malformed_record():
         record_to_conversation({"input": "No answer"})
 
 
+def test_record_to_conversation_requires_assistant_after_user():
+    from src.tinker_api.sft_runner import record_to_conversation
+
+    with pytest.raises(ValueError, match="assistant message after a user"):
+        record_to_conversation(
+            {
+                "messages": [
+                    {"role": "assistant", "content": "A"},
+                    {"role": "user", "content": "Q"},
+                ]
+            }
+        )
+
+
 def test_load_conversations_returns_empty_for_empty_jsonl(tmp_path):
     from src.tinker_api.sft_runner import load_conversations
 


### PR DESCRIPTION
## Summary

Unlabeled local `.txt` files should not be treated as supervised fine-tuning targets. Mode A was turning every text line into `{"input": ..., "output": "unknown"}`, which let curation and Tinker accept a dataset whose assistant target was just the fabricated string `unknown`.

This PR:
- keeps plain-text Mode A records source-only (`input` plus provenance, no fabricated `output`)
- makes curation reject chat rows unless an assistant target appears after a user message
- applies the same chat-order validation in the Tinker runner so direct JSONL inputs fail clearly before renderer/training setup
- adds coverage for source-only text, curation rejection, and runner parity

## Validation

- `uv run python -m compileall src/data_generator src/tinker_api tests/data_generator/test_mode_a_local_data.py tests/data_generator/test_handoff_contract_consistency.py tests/test_tinker_runner.py`
- `uv run --with pytest --with anthropic --with requests --with datasets --with huggingface-hub --with transformers --with peft python -m pytest tests/data_generator/test_mode_a_local_data.py tests/data_generator/test_handoff_contract_consistency.py tests/test_tinker_runner.py -q`
  - `33 passed`

No live spend.
