### PR TITLE
Keep DecisionEngine plans on Tinker SFT

### DIFF
--- a/src/decision_engine/decision_engine.py
+++ b/src/decision_engine/decision_engine.py
@@ -63,7 +63,10 @@ def run_decision_engine(
     """Top-level dispatcher. Runs task analysis → model selection → cost estimation → script generation."""
     task = analyze_task(config)
     budget = config["compute_budget"]
+    backend = "tinker_sft"
     model_id = find_base_model(task, budget)
+    if backend == "tinker_sft" and model_id is None:
+        model_id = _tinker_base_model_for_task(task)
     strategy = "fine-tune" if model_id else "pre-train"
     cost = estimate_training_cost(model_id, dataset, strategy)
 
@@ -74,7 +77,6 @@ def run_decision_engine(
         lora = None
         script_path = write_pretrain_script(task, dataset, config)
 
-    backend = "tinker_sft"
     return TrainingPlan(
         strategy=strategy,
         base_model=model_id,
@@ -88,6 +90,11 @@ def run_decision_engine(
         dataset_path=dataset["dataset"]["path"],
         dataset=dataset["dataset"],
     )
+
+
+def _tinker_base_model_for_task(task: TaskAnalysis) -> str:
+    """Return the SDK-native Tinker SFT base model for V1 plans."""
+    return _TASK_TO_BASE_MODEL.get(task["task_type"], DEFAULT_TINKER_MODEL)
 
 
 def estimate_autoresearch_run_cost(

--- a/tests/test_decision_engine.py
+++ b/tests/test_decision_engine.py
@@ -12,6 +12,7 @@ from src.decision_engine.decision_engine import (
     write_finetune_script,
     write_pretrain_script,
 )
+from src.tinker_api.sft_runner import DEFAULT_TINKER_MODEL
 from src.types import DatasetResult, OrchestrationConfig, StandardDataset, ValidationReport
 
 
@@ -142,7 +143,9 @@ def test_run_decision_engine_returns_training_plan(tmp_path, monkeypatch):
     config = _make_config("text-classification", budget=50.0)
     dataset = _make_dataset(train_size=42)
     plan = run_decision_engine(config, dataset)
-    assert plan["strategy"] in ("fine-tune", "pre-train")
+    assert plan["strategy"] == "fine-tune"
+    assert plan["base_model"] == DEFAULT_TINKER_MODEL
+    assert plan["lora_config"] is not None
     assert plan["eval_metric"] == "primary_metric"
     assert plan["backend"] == "tinker_sft"
     assert os.path.exists(plan["training_script_path"])
@@ -150,6 +153,21 @@ def test_run_decision_engine_returns_training_plan(tmp_path, monkeypatch):
     assert plan["estimated_run_cost_usd"] == plan["estimated_cost"]
     assert plan["dataset_path"] == dataset["dataset"]["path"]
     assert plan["dataset"] == dataset["dataset"]
+
+
+def test_run_decision_engine_keeps_low_budget_plan_on_tinker_sft(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config = _make_config("text-classification", budget=0.01)
+    dataset = _make_dataset(train_size=42)
+
+    plan = run_decision_engine(config, dataset)
+
+    assert plan["strategy"] == "fine-tune"
+    assert plan["backend"] == "tinker_sft"
+    assert plan["base_model"] == DEFAULT_TINKER_MODEL
+    assert plan["lora_config"] is not None
+    assert plan["estimated_cost"] > config["compute_budget"]
+    assert "SimpleModel" not in open(plan["training_script_path"]).read()
 
 
 def test_run_decision_engine_sets_bounded_run_cost(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Tinker V1 supports SDK-native chat/SFT, not the old fallback pretraining path. DecisionEngine could still return `strategy="pre-train"` while also setting `backend="tinker_sft"`, which means AutoResearch would ignore the generated pretrain script and run Tinker SFT anyway.

This PR keeps DecisionEngine's executable plan internally consistent:
- Tinker SFT plans always keep a concrete base model, falling back to the default Tinker model when the budget check says the model does not fit
- low budgets are left for the existing budget preflight/spend-floor path to skip or stop, rather than changing the strategy to pretrain
- focused tests assert a low-budget plan remains `strategy="fine-tune"`, `backend="tinker_sft"`, and does not generate the `SimpleModel` pretrain script

## Validation

- `uv run python -m compileall src/decision_engine tests/test_decision_engine.py`
- `uv run --with pytest --with transformers --with peft --with datasets python -m pytest tests/test_decision_engine.py -q`
  - `13 passed`

No live spend.
