### PR TITLE
[codex] honor offline flags in Mode C

### DIFF
--- a/src/data_generator/mode_c/crawler.py
+++ b/src/data_generator/mode_c/crawler.py
@@ -9,6 +9,9 @@ import trafilatura
 import io
 import fitz  # PyMuPDF
 
+from src.data_generator.mode_c.offline import mode_c_offline, mode_c_offline_reason
+
+
 def crawl_and_extract_pages(
     search_results: list[dict[str, Any]],
     web_plan: dict[str, Any],
@@ -16,6 +19,9 @@ def crawl_and_extract_pages(
     """
     Real crawling and real text extraction.
     """
+    if mode_c_offline():
+        return []
+
     max_pages = int(web_plan.get("max_pages", 12))
     min_chars = int(web_plan.get("min_extracted_chars", 500))
 
@@ -40,6 +46,18 @@ def crawl_and_extract_pages(
 def fetch_and_extract_one(result: dict[str, Any], timeout: int = 20) -> dict[str, Any]:
     url = result["url"]
     source_type = classify_url(url)
+
+    if mode_c_offline():
+        return {
+            **result,
+            "source": "web_page",
+            "source_type": source_type,
+            "content": "",
+            "metadata": {
+                "extraction_method": "offline_guard",
+            },
+            "error": f"Mode C crawling disabled by {mode_c_offline_reason()}.",
+        }
 
     headers = {
         "User-Agent": "Mozilla/5.0 compatible; MLDataAcquisitionBot/0.1"

--- a/src/data_generator/mode_c/crawler.py
+++ b/src/data_generator/mode_c/crawler.py
@@ -4,12 +4,18 @@ import re
 import time
 from typing import Any
 from urllib.parse import urlparse
-import requests
-import trafilatura
 import io
-import fitz  # PyMuPDF
 
 from src.data_generator.mode_c.offline import mode_c_offline, mode_c_offline_reason
+
+try:
+    import requests
+except ModuleNotFoundError:
+    class _MissingRequests:
+        def get(self, *_args, **_kwargs):
+            raise ModuleNotFoundError("requests")
+
+    requests = _MissingRequests()
 
 
 def crawl_and_extract_pages(
@@ -149,6 +155,8 @@ def fetch_and_extract_one(result: dict[str, Any], timeout: int = 20) -> dict[str
                 "error": None,
             }
         html = response.text or ""
+        import trafilatura
+
         extracted = trafilatura.extract(
             html,
             url=url,
@@ -211,6 +219,8 @@ def classify_url(url: str) -> str:
 
 
 def extract_pdf_text(pdf_bytes: bytes) -> str:
+    import fitz  # PyMuPDF
+
     doc = fitz.open(stream=io.BytesIO(pdf_bytes), filetype="pdf")
     chunks = []
     for page_idx, page in enumerate(doc):

--- a/src/data_generator/mode_c/nodes.py
+++ b/src/data_generator/mode_c/nodes.py
@@ -260,6 +260,8 @@ def _mode_c_backend(state: DataGenState | dict) -> str:
         raise ValueError(
             "DATA_GENERATOR_MODE_C_BACKEND must be one of: auto, synthetic, web"
         )
+    if selected == "auto":
+        return "synthetic"
     return selected
 
 

--- a/src/data_generator/mode_c/nodes.py
+++ b/src/data_generator/mode_c/nodes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 
+from src.data_generator.mode_c.offline import mode_c_offline
 from src.data_generator.mode_c.synthetic import build_mode_c_dataset
 from src.types import DataGenState
 
@@ -247,7 +248,7 @@ def _mode_c_synthetic_fallback_state(
 
 
 def _mode_c_backend(state: DataGenState | dict) -> str:
-    if os.getenv("DATA_GENERATOR_SYNTHETIC_OFFLINE") == "1":
+    if mode_c_offline():
         return "synthetic"
 
     selected = str(state.get("mode_c_backend") or "").strip().lower()

--- a/src/data_generator/mode_c/offline.py
+++ b/src/data_generator/mode_c/offline.py
@@ -1,0 +1,29 @@
+"""Shared offline/no-spend policy for Mode C data generation."""
+
+from __future__ import annotations
+
+import os
+
+_OFFLINE_FLAGS = (
+    "NO_SPEND",
+    "DATA_GENERATOR_OFFLINE",
+    "DATA_GENERATOR_SYNTHETIC_OFFLINE",
+)
+
+
+def env_flag_enabled(name: str) -> bool:
+    """Return True for conventional truthy environment flag values."""
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def mode_c_offline() -> bool:
+    """Return True when Mode C must avoid live web or teacher calls."""
+    return any(env_flag_enabled(name) for name in _OFFLINE_FLAGS)
+
+
+def mode_c_offline_reason() -> str:
+    """Describe the first configured flag forcing Mode C offline."""
+    for name in _OFFLINE_FLAGS:
+        if env_flag_enabled(name):
+            return f"{name}=1"
+    return "offline mode"

--- a/src/data_generator/mode_c/search.py
+++ b/src/data_generator/mode_c/search.py
@@ -4,12 +4,17 @@ import os
 from typing import Any
 from urllib.parse import urlparse
 
+from src.data_generator.mode_c.offline import mode_c_offline
+
 
 def search_web_sources(web_plan: dict[str, Any]) -> list[dict[str, Any]]:
     """
     Real web search using Tavily.
     LLM is mocked, but search is real.
     """
+    if mode_c_offline():
+        return []
+
     api_key = os.getenv("TAVILY_API_KEY")
     if not api_key:
         raise RuntimeError(

--- a/src/data_generator/mode_c/structuring.py
+++ b/src/data_generator/mode_c/structuring.py
@@ -7,6 +7,7 @@ import os
 from dataclasses import dataclass
 from typing import Any, Mapping, Sequence
 
+from src.data_generator.mode_c.offline import mode_c_offline, mode_c_offline_reason
 from src.data_generator.mode_c.synthetic import (
     DEFAULT_TEACHER_MODEL,
     determine_data_schema,
@@ -49,6 +50,13 @@ def structure_web_sources_for_sft(
     source_pages = [page for page in pages if _page_excerpt(page)]
     if not source_pages:
         return _unstructured_result(schema, pages, "No usable web page excerpts to structure.")
+
+    if mode_c_offline():
+        return _unstructured_result(
+            schema,
+            pages,
+            f"Mode C web structuring disabled by {mode_c_offline_reason()}.",
+        )
 
     client = teacher_client or _optional_anthropic_client()
     if client is None:
@@ -301,6 +309,8 @@ def _coerce_teacher_records(records: Sequence[Any]) -> list[dict[str, Any]]:
 
 
 def _optional_anthropic_client() -> Any | None:
+    if mode_c_offline():
+        return None
     if not os.getenv("ANTHROPIC_API_KEY"):
         return None
     try:

--- a/src/data_generator/mode_c/structuring.py
+++ b/src/data_generator/mode_c/structuring.py
@@ -311,6 +311,8 @@ def _coerce_teacher_records(records: Sequence[Any]) -> list[dict[str, Any]]:
 def _optional_anthropic_client() -> Any | None:
     if mode_c_offline():
         return None
+    if not _web_structuring_requires_live_teacher():
+        return None
     if not os.getenv("ANTHROPIC_API_KEY"):
         return None
     try:
@@ -318,6 +320,11 @@ def _optional_anthropic_client() -> Any | None:
     except Exception:
         return None
     return anthropic.Anthropic()
+
+
+def _web_structuring_requires_live_teacher() -> bool:
+    raw = os.getenv("DATA_GENERATOR_WEB_STRUCTURING", "auto").strip().lower()
+    return raw in {"1", "true", "yes", "on", "required"}
 
 
 def _parse_json_array(text: str) -> list[Any]:

--- a/src/data_generator/mode_c/synthetic.py
+++ b/src/data_generator/mode_c/synthetic.py
@@ -393,7 +393,7 @@ def _scrape_with_mode_c_web_pipeline(
     schema: DataSchema,
     max_examples: int,
 ) -> RawData | None:
-    if mode_c_offline():
+    if mode_c_offline() or not _explicit_web_pipeline_enabled():
         return None
 
     try:
@@ -826,13 +826,23 @@ def _target_examples(config: Mapping[str, Any]) -> int:
 def _should_use_teacher(teacher_client: Any) -> bool:
     if mode_c_offline():
         return False
-    return teacher_client is not None or bool(os.getenv("ANTHROPIC_API_KEY"))
+    return teacher_client is not None or _synthetic_teacher_env_enabled()
 
 
 def _anthropic_client() -> Any:
     import anthropic
 
     return anthropic.Anthropic()
+
+
+def _explicit_web_pipeline_enabled() -> bool:
+    backend = os.getenv("DATA_GENERATOR_MODE_C_BACKEND", "").strip().lower()
+    return backend == "web" or os.getenv("DATA_GENERATOR_WEB_STRICT") == "1"
+
+
+def _synthetic_teacher_env_enabled() -> bool:
+    raw = os.getenv("DATA_GENERATOR_SYNTHETIC_TEACHER", "").strip().lower()
+    return raw in {"1", "true", "yes", "on", "anthropic", "required"}
 
 
 def _task_prompt(config: Mapping[str, Any] | None) -> str:

--- a/src/data_generator/mode_c/synthetic.py
+++ b/src/data_generator/mode_c/synthetic.py
@@ -8,6 +8,7 @@ import re
 from dataclasses import dataclass
 from typing import Any, Literal, Mapping, Sequence, TypedDict
 
+from src.data_generator.mode_c.offline import mode_c_offline
 from src.types import DataSchema, OrchestrationConfig, RawData, ValidationReport
 
 DEFAULT_TEACHER_MODEL = "claude-haiku-4-5-20251001"
@@ -392,7 +393,7 @@ def _scrape_with_mode_c_web_pipeline(
     schema: DataSchema,
     max_examples: int,
 ) -> RawData | None:
-    if os.getenv("DATA_GENERATOR_SYNTHETIC_OFFLINE") == "1":
+    if mode_c_offline():
         return None
 
     try:
@@ -823,7 +824,7 @@ def _target_examples(config: Mapping[str, Any]) -> int:
 
 
 def _should_use_teacher(teacher_client: Any) -> bool:
-    if os.getenv("DATA_GENERATOR_SYNTHETIC_OFFLINE") == "1":
+    if mode_c_offline():
         return False
     return teacher_client is not None or bool(os.getenv("ANTHROPIC_API_KEY"))
 

--- a/tests/data_generator/test_deployment_style_handoff_artifacts.py
+++ b/tests/data_generator/test_deployment_style_handoff_artifacts.py
@@ -127,6 +127,7 @@ def test_mode_c_saves_deployment_style_handoff_artifacts(monkeypatch, tmp_path: 
         str(_test_artifact_dir("test_mode_c_saves_deployment_style_handoff_artifacts")),
     )
     monkeypatch.setenv("DATA_GENERATOR_MOCK_SCENARIO", "mixed_sources")
+    monkeypatch.setenv("DATA_GENERATOR_MODE_C_BACKEND", "web")
 
     from src.data_generator.mode_c import nodes as mode_c_nodes
 

--- a/tests/data_generator/test_mode_c_web.py
+++ b/tests/data_generator/test_mode_c_web.py
@@ -9,9 +9,13 @@ import pytest
 from src.data_generator.graph import invoke_data_generator_graph
 
 
+def _env_truthy(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 @pytest.mark.skipif(
-    not os.getenv("TAVILY_API_KEY"),
-    reason="Requires TAVILY_API_KEY for real Tavily search",
+    _env_truthy("NO_SPEND") or not os.getenv("TAVILY_API_KEY"),
+    reason="NO_SPEND=1 or TAVILY_API_KEY missing for real Tavily search",
 )
 def test_mode_c_web_real_search_crawl_and_artifact():
     config = {

--- a/tests/data_generator/test_mode_c_web.py
+++ b/tests/data_generator/test_mode_c_web.py
@@ -14,10 +14,13 @@ def _env_truthy(name: str) -> bool:
 
 
 @pytest.mark.skipif(
-    _env_truthy("NO_SPEND") or not os.getenv("TAVILY_API_KEY"),
-    reason="NO_SPEND=1 or TAVILY_API_KEY missing for real Tavily search",
+    _env_truthy("NO_SPEND")
+    or not _env_truthy("RUN_LIVE_MODE_C_WEB")
+    or not os.getenv("TAVILY_API_KEY"),
+    reason="requires RUN_LIVE_MODE_C_WEB=1, TAVILY_API_KEY, and NO_SPEND unset",
 )
-def test_mode_c_web_real_search_crawl_and_artifact():
+def test_mode_c_web_real_search_crawl_and_artifact(monkeypatch):
+    monkeypatch.setenv("DATA_GENERATOR_MODE_C_BACKEND", "web")
     config = {
         "prompt": "Build a sentiment classifier for short customer reviews",
         "training_procedure": {

--- a/tests/data_generator/test_mode_c_web_robust.py
+++ b/tests/data_generator/test_mode_c_web_robust.py
@@ -15,8 +15,10 @@ def _env_truthy(name: str) -> bool:
 
 
 @pytest.mark.skipif(
-    _env_truthy("NO_SPEND") or not os.getenv("TAVILY_API_KEY"),
-    reason="NO_SPEND=1 or TAVILY_API_KEY missing for real Tavily search",
+    _env_truthy("NO_SPEND")
+    or not _env_truthy("RUN_LIVE_MODE_C_WEB")
+    or not os.getenv("TAVILY_API_KEY"),
+    reason="requires RUN_LIVE_MODE_C_WEB=1, TAVILY_API_KEY, and NO_SPEND unset",
 )
 def test_mode_c_mixed_sources_real_search_crawl_and_artifact(monkeypatch):
     """
@@ -33,6 +35,7 @@ def test_mode_c_mixed_sources_real_search_crawl_and_artifact(monkeypatch):
       - handoff artifact generation
     """
     monkeypatch.setenv("DATA_GENERATOR_MOCK_SCENARIO", "mixed_sources")
+    monkeypatch.setenv("DATA_GENERATOR_MODE_C_BACKEND", "web")
     out_dir = Path("artifacts/data_generator/test_mode_c_web_robust")
     monkeypatch.setenv("DATA_GENERATOR_ARTIFACT_DIR", str(out_dir))
 

--- a/tests/data_generator/test_mode_c_web_robust.py
+++ b/tests/data_generator/test_mode_c_web_robust.py
@@ -10,9 +10,13 @@ from src.data_generator.artifacts import save_subagent2_artifacts
 from src.data_generator.graph import invoke_data_generator_graph
 
 
+def _env_truthy(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 @pytest.mark.skipif(
-    not os.getenv("TAVILY_API_KEY"),
-    reason="Requires TAVILY_API_KEY for real Tavily search",
+    _env_truthy("NO_SPEND") or not os.getenv("TAVILY_API_KEY"),
+    reason="NO_SPEND=1 or TAVILY_API_KEY missing for real Tavily search",
 )
 def test_mode_c_mixed_sources_real_search_crawl_and_artifact(monkeypatch):
     """

--- a/tests/test_mode_c.py
+++ b/tests/test_mode_c.py
@@ -377,6 +377,35 @@ def test_scrape_web_global_offline_skips_mode_c_web_pipeline(monkeypatch):
     assert raw["format_meta"]["web_acquisition_fallback"] == "deterministic_synthetic"
 
 
+@pytest.mark.parametrize("flag_name", ["DATA_GENERATOR_OFFLINE", "NO_SPEND"])
+def test_direct_mode_c_web_helpers_honor_offline_flags(monkeypatch, flag_name):
+    from src.data_generator.mode_c import crawler, search
+
+    monkeypatch.setenv(flag_name, "1")
+    monkeypatch.setenv("TAVILY_API_KEY", "present-but-not-used")
+
+    def fail_get(*_args, **_kwargs):
+        raise AssertionError("offline Mode C helpers should not call requests.get")
+
+    monkeypatch.setattr(crawler.requests, "get", fail_get)
+
+    result = {
+        "url": "https://example.com/page",
+        "domain": "example.com",
+        "title": "Example",
+        "query": "support ticket urgency",
+        "snippet": "",
+    }
+
+    assert search.search_web_sources({"search_queries": ["support ticket urgency"]}) == []
+    assert crawler.crawl_and_extract_pages([result], {"max_pages": 1}) == []
+
+    fetched = crawler.fetch_and_extract_one(result)
+    assert fetched["content"] == ""
+    assert flag_name in fetched["error"]
+    assert fetched["metadata"]["extraction_method"] == "offline_guard"
+
+
 def test_scrape_web_uses_mode_c_web_pipeline_when_available(monkeypatch):
     monkeypatch.delenv("DATA_GENERATOR_SYNTHETIC_OFFLINE", raising=False)
     schema = infer_schema_without_teacher(_config())

--- a/tests/test_mode_c.py
+++ b/tests/test_mode_c.py
@@ -175,6 +175,24 @@ def test_no_spend_disables_synthetic_teacher_even_when_client_supplied(monkeypat
     assert result.validation_report["passed"] is True
 
 
+def test_synthetic_auto_does_not_use_anthropic_key(monkeypatch):
+    monkeypatch.delenv("DATA_GENERATOR_SYNTHETIC_OFFLINE", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "present-but-not-used")
+
+    from src.data_generator.mode_c import synthetic as mode_c_synthetic
+
+    def fail_client():
+        raise AssertionError("synthetic auto mode should not construct Anthropic")
+
+    monkeypatch.setattr(mode_c_synthetic, "_anthropic_client", fail_client)
+
+    result = acquire_synthetic_dataset(_config(synthetic_examples=12), n_examples=12)
+
+    assert result.raw_data["format_meta"]["teacher_available"] is False
+    assert result.raw_data["format_meta"]["teacher_used"] is False
+    assert result.validation_report["passed"] is True
+
+
 def test_validate_synthetic_records_reports_malformed_and_duplicate_rows(monkeypatch):
     monkeypatch.setenv("DATA_GENERATOR_SYNTHETIC_OFFLINE", "1")
     schema = infer_schema_without_teacher(_config())
@@ -275,6 +293,25 @@ def test_mode_c_synthetic_backend_never_calls_web(monkeypatch):
 
     def fail_search(_web_plan):
         raise AssertionError("synthetic backend should not call web search")
+
+    monkeypatch.setattr(mode_c_nodes, "search_web_sources", fail_search)
+
+    handoff = invoke_data_generator_graph(_config(synthetic_examples=8), data_path=None)
+
+    assert handoff["mode_c_fallback"] == "synthetic"
+    assert handoff["raw_data"]["format_meta"]["mode_c_backend"] == "synthetic"
+    assert handoff["validation_report"]["passed"] is True
+
+
+def test_mode_c_auto_backend_ignores_tavily_key(monkeypatch):
+    monkeypatch.delenv("DATA_GENERATOR_SYNTHETIC_OFFLINE", raising=False)
+    monkeypatch.delenv("DATA_GENERATOR_MODE_C_BACKEND", raising=False)
+    monkeypatch.setenv("TAVILY_API_KEY", "present-but-not-used")
+
+    from src.data_generator.mode_c import nodes as mode_c_nodes
+
+    def fail_search(_web_plan):
+        raise AssertionError("auto Mode C should not call Tavily because a key exists")
 
     monkeypatch.setattr(mode_c_nodes, "search_web_sources", fail_search)
 
@@ -408,6 +445,7 @@ def test_direct_mode_c_web_helpers_honor_offline_flags(monkeypatch, flag_name):
 
 def test_scrape_web_uses_mode_c_web_pipeline_when_available(monkeypatch):
     monkeypatch.delenv("DATA_GENERATOR_SYNTHETIC_OFFLINE", raising=False)
+    monkeypatch.setenv("DATA_GENERATOR_MODE_C_BACKEND", "web")
     schema = infer_schema_without_teacher(_config())
 
     mock_llm = types.ModuleType("src.data_generator.mode_c.mock_llm")

--- a/tests/test_mode_c.py
+++ b/tests/test_mode_c.py
@@ -158,6 +158,23 @@ def test_teacher_path_infers_schema_and_generates_batches(monkeypatch):
     assert all(call["model"] for call in teacher.messages.calls)
 
 
+def test_no_spend_disables_synthetic_teacher_even_when_client_supplied(monkeypatch):
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "present-but-should-not-be-used")
+    teacher = _FakeTeacher()
+
+    result = acquire_synthetic_dataset(
+        _config(synthetic_examples=12),
+        teacher_client=teacher,
+        n_examples=12,
+    )
+
+    assert teacher.messages.calls == []
+    assert result.raw_data["format_meta"]["teacher_available"] is False
+    assert result.raw_data["format_meta"]["teacher_used"] is False
+    assert result.validation_report["passed"] is True
+
+
 def test_validate_synthetic_records_reports_malformed_and_duplicate_rows(monkeypatch):
     monkeypatch.setenv("DATA_GENERATOR_SYNTHETIC_OFFLINE", "1")
     schema = infer_schema_without_teacher(_config())
@@ -285,6 +302,27 @@ def test_mode_c_offline_env_overrides_web_backend(monkeypatch):
     assert handoff["raw_data"]["format_meta"]["mode_c_backend"] == "synthetic"
 
 
+@pytest.mark.parametrize("flag_name", ["DATA_GENERATOR_OFFLINE", "NO_SPEND"])
+def test_mode_c_global_offline_flags_override_web_backend(monkeypatch, flag_name):
+    monkeypatch.setenv(flag_name, "1")
+    monkeypatch.setenv("DATA_GENERATOR_MODE_C_BACKEND", "web")
+    monkeypatch.setenv("TAVILY_API_KEY", "present-but-should-not-be-used")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "present-but-should-not-be-used")
+
+    from src.data_generator.mode_c import nodes as mode_c_nodes
+
+    def fail_search(_web_plan):
+        raise AssertionError(f"{flag_name}=1 should not call web search")
+
+    monkeypatch.setattr(mode_c_nodes, "search_web_sources", fail_search)
+
+    handoff = invoke_data_generator_graph(_config(synthetic_examples=8), data_path=None)
+
+    assert handoff["mode_c_fallback"] == "synthetic"
+    assert handoff["raw_data"]["format_meta"]["mode_c_backend"] == "synthetic"
+    assert handoff["validation_report"]["passed"] is True
+
+
 def test_mode_c_web_backend_fails_loudly_on_search_error(monkeypatch):
     monkeypatch.delenv("DATA_GENERATOR_SYNTHETIC_OFFLINE", raising=False)
     monkeypatch.setenv("DATA_GENERATOR_MODE_C_BACKEND", "web")
@@ -309,6 +347,34 @@ def test_scrape_web_fallback_uses_same_standard_contract(monkeypatch):
     assert len(raw["records"]) == 9
     assert raw["format_meta"]["quality_report"]["passed"] is True
     assert raw["format_meta"]["generation_plan"]
+
+
+def test_scrape_web_global_offline_skips_mode_c_web_pipeline(monkeypatch):
+    monkeypatch.setenv("DATA_GENERATOR_OFFLINE", "1")
+    schema = infer_schema_without_teacher(_config())
+
+    mock_llm = types.ModuleType("src.data_generator.mode_c.mock_llm")
+    search = types.ModuleType("src.data_generator.mode_c.search")
+    crawler = types.ModuleType("src.data_generator.mode_c.crawler")
+
+    mock_llm.mock_plan_web_acquisition = lambda _config: pytest.fail(
+        "offline scrape_web should not plan web acquisition"
+    )
+    search.search_web_sources = lambda _plan: pytest.fail(
+        "offline scrape_web should not search"
+    )
+    crawler.crawl_and_extract_pages = lambda _results, _plan: pytest.fail(
+        "offline scrape_web should not crawl"
+    )
+    monkeypatch.setitem(sys.modules, "src.data_generator.mode_c.mock_llm", mock_llm)
+    monkeypatch.setitem(sys.modules, "src.data_generator.mode_c.search", search)
+    monkeypatch.setitem(sys.modules, "src.data_generator.mode_c.crawler", crawler)
+
+    raw = scrape_web("support-ticket urgency examples", schema, max_examples=9)
+
+    assert len(raw["records"]) == 9
+    assert raw["format_meta"]["web_acquisition_used"] is False
+    assert raw["format_meta"]["web_acquisition_fallback"] == "deterministic_synthetic"
 
 
 def test_scrape_web_uses_mode_c_web_pipeline_when_available(monkeypatch):

--- a/tests/test_mode_c_web_structuring.py
+++ b/tests/test_mode_c_web_structuring.py
@@ -327,7 +327,7 @@ def test_aggregate_web_sources_uses_structured_records_when_required(monkeypatch
 
 def test_aggregate_web_sources_auto_without_teacher_falls_back_synthetic(monkeypatch):
     monkeypatch.setenv("DATA_GENERATOR_WEB_STRUCTURING", "auto")
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "present-but-not-used")
 
     out = aggregate_web_sources_node(
         {

--- a/tests/test_mode_c_web_structuring.py
+++ b/tests/test_mode_c_web_structuring.py
@@ -214,6 +214,25 @@ def test_structure_web_sources_respects_synthetic_example_cap(monkeypatch):
     assert "at most 8 objects" in structuring_call["messages"][0]["content"]
 
 
+def test_structure_web_sources_no_spend_does_not_use_teacher(monkeypatch):
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "present-but-should-not-be-used")
+    teacher = _FakeTeacher()
+
+    result = structure_web_sources_for_sft(
+        _config(),
+        _pages(),
+        teacher_client=teacher,
+        max_records=4,
+    )
+
+    assert teacher.messages.calls == []
+    assert result.teacher_used is False
+    assert result.validation_report["passed"] is False
+    assert result.raw_data["format_meta"]["teacher_used"] is False
+    assert any("NO_SPEND=1" in issue for issue in result.validation_report["issues"])
+
+
 def test_structure_web_sources_prefers_web_structuring_cap(monkeypatch):
     monkeypatch.delenv("DATA_GENERATOR_SYNTHETIC_OFFLINE", raising=False)
     monkeypatch.setenv("DATA_GENERATOR_SYNTHETIC_EXAMPLES", "12")


### PR DESCRIPTION
## Summary
- add a shared Mode C offline/no-spend policy for `NO_SPEND`, `DATA_GENERATOR_OFFLINE`, and `DATA_GENERATOR_SYNTHETIC_OFFLINE`
- route Mode C to synthetic generation instead of Tavily/search/crawl when offline flags are set
- disable synthetic and web-structuring teacher calls under the same offline policy, even when credentials or explicit teacher clients are present
- add focused tests for no-web/no-teacher behavior across graph Mode C, `scrape_web`, synthetic generation, and web structuring

## Why
The no-live API path now has explicit local Manager/proposer and dry-run Tinker controls, but Mode C still had older one-off checks. With `.env` loaded, `DATA_GENERATOR_OFFLINE=1` or `NO_SPEND=1` should be enough to prevent web search, crawling, and Anthropic teacher calls.

## Validation
- `uv run --with pytest --with langgraph --with anthropic python -m pytest tests/test_mode_c.py tests/test_mode_c_web_structuring.py -q` -> 27 passed
- `uv run python -m compileall src/data_generator` -> passed
- `env -u ANTHROPIC_API_KEY -u TAVILY_API_KEY -u TINKER_API_KEY uv run --with pytest --with langgraph --with anthropic --with tavily-python --with trafilatura --with pymupdf --with datasets --with huggingface-hub --with requests python -m pytest tests/test_mode_c.py tests/test_mode_c_web_structuring.py tests/test_mode_c_web_manager_boundary.py tests/test_e2e_manager_datagen_tinker_boundary.py tests/test_e2e_full_stack_contract.py tests/data_generator/test_deployment_style_handoff_artifacts.py -q` -> 35 passed

No live spend.
