### PR TITLE
[codex] Guard Tinker API no-spend calls

### DIFF
--- a/src/tinker_api/tinker_api.py
+++ b/src/tinker_api/tinker_api.py
@@ -192,6 +192,7 @@ def run_training_loop(
     Saves a final checkpoint when done or cancelled.
     Returns ``{"steps": int, "tokens": int, "cancelled": bool}``.
     """
+    _require_live_tinker_allowed("run_training_loop")
     steps = 0
     total_tokens = 0
     cancelled = False

--- a/src/tinker_api/tinker_api.py
+++ b/src/tinker_api/tinker_api.py
@@ -14,17 +14,13 @@ Reference: https://docs.tinkerlabs.ai/sdk
 
 from __future__ import annotations
 
+import importlib
 import os
 from typing import Any
 
-try:
-    import tinker                        # pip install tinker
-    from tinker import types as tinker_types
-    _TINKER_AVAILABLE = True
-except ImportError:                      # graceful degradation in test / CI envs
-    tinker = None          # type: ignore[assignment]
-    tinker_types = None    # type: ignore[assignment]
-    _TINKER_AVAILABLE = False
+tinker: Any | None = None
+tinker_types: Any | None = None
+_TINKER_AVAILABLE: bool | None = None
 
 # ── Pricing constant ───────────────────────────────────────────────────────────
 _COST_PER_MILLION_TOKENS: float = 0.40   # USD
@@ -48,11 +44,26 @@ class TinkerAPIError(Exception):
 
 
 def _require_tinker() -> None:
-    if not _TINKER_AVAILABLE:
+    global tinker, tinker_types, _TINKER_AVAILABLE
+    if _TINKER_AVAILABLE is True:
+        return
+    if _TINKER_AVAILABLE is False:
         raise TinkerAPIError(
             "tinker package not installed — run: pip install tinker",
             status_code=0,
         )
+    try:
+        tinker = importlib.import_module("tinker")
+        tinker_types = importlib.import_module("tinker.types")
+        _TINKER_AVAILABLE = True
+    except ImportError as exc:           # graceful degradation in test / CI envs
+        tinker = None
+        tinker_types = None
+        _TINKER_AVAILABLE = False
+        raise TinkerAPIError(
+            "tinker package not installed — run: pip install tinker",
+            status_code=0,
+        ) from exc
 
 
 def _env_flag_enabled(name: str) -> bool:

--- a/src/tinker_api/tinker_api.py
+++ b/src/tinker_api/tinker_api.py
@@ -14,6 +14,7 @@ Reference: https://docs.tinkerlabs.ai/sdk
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 try:
@@ -54,6 +55,23 @@ def _require_tinker() -> None:
         )
 
 
+def _live_tinker_block_reason() -> str | None:
+    if os.getenv("NO_SPEND", "").strip() == "1":
+        return "NO_SPEND=1"
+    if os.getenv("TINKER_BACKEND", "").strip().lower() == "dry_run":
+        return "TINKER_BACKEND=dry_run"
+    return None
+
+
+def _require_live_tinker_allowed(operation: str) -> None:
+    reason = _live_tinker_block_reason()
+    if reason:
+        raise TinkerAPIError(
+            f"{operation} is blocked because live Tinker API calls are disabled by {reason}",
+            status_code=0,
+        )
+
+
 # ── Client creation ────────────────────────────────────────────────────────────
 
 def create_service_client() -> Any:
@@ -61,6 +79,7 @@ def create_service_client() -> Any:
 
     Reads TINKER_API_KEY from the environment automatically.
     """
+    _require_live_tinker_allowed("create_service_client")
     _require_tinker()
     try:
         return tinker.ServiceClient()
@@ -77,6 +96,7 @@ def create_lora_training_client(
 
     Returns a client with forward_backward / optim_step / save_weights methods.
     """
+    _require_live_tinker_allowed("create_lora_training_client")
     _require_tinker()
     try:
         return service_client.create_lora_training_client(
@@ -91,6 +111,7 @@ def create_lora_training_client(
 
 def get_tokenizer(training_client: Any) -> Any:
     """Returns the tokeniser for the training client's base model."""
+    _require_live_tinker_allowed("get_tokenizer")
     return training_client.get_tokenizer()
 
 
@@ -105,6 +126,7 @@ def make_datum(
     input  = input_tokens[:-1]
     target = input_tokens[1:]
     """
+    _require_live_tinker_allowed("make_datum")
     _require_tinker()
     if target_tokens is None:
         target_tokens = input_tokens[1:]
@@ -130,6 +152,7 @@ def run_training_step(
     Optionally records token usage to the ledger under *job_id*.
     Returns ``{"tokens_processed": int, "loss": float | None}``.
     """
+    _require_live_tinker_allowed("run_training_step")
     _require_tinker()
     try:
         fwdbwd_result = training_client.forward_backward(
@@ -193,6 +216,7 @@ def run_training_loop(
 
 def save_checkpoint(training_client: Any, name: str) -> Any:
     """Saves weights and returns a SamplingClient for inference against this checkpoint."""
+    _require_live_tinker_allowed("save_checkpoint")
     _require_tinker()
     try:
         return training_client.save_weights_and_get_sampling_client(name=name)
@@ -202,6 +226,7 @@ def save_checkpoint(training_client: Any, name: str) -> Any:
 
 def save_weights(training_client: Any, name: str) -> None:
     """Saves weights without returning a sampling client (fire-and-forget)."""
+    _require_live_tinker_allowed("save_weights")
     _require_tinker()
     try:
         training_client.save_weights_for_sampler(name=name)
@@ -220,6 +245,7 @@ def sample(
 
     Returns a list of token-id lists (one per sample).
     """
+    _require_live_tinker_allowed("sample")
     _require_tinker()
     try:
         model_input = tinker_types.ModelInput.from_ints(prompt_tokens)

--- a/src/tinker_api/tinker_api.py
+++ b/src/tinker_api/tinker_api.py
@@ -55,8 +55,12 @@ def _require_tinker() -> None:
         )
 
 
+def _env_flag_enabled(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _live_tinker_block_reason() -> str | None:
-    if os.getenv("NO_SPEND", "").strip() == "1":
+    if _env_flag_enabled("NO_SPEND"):
         return "NO_SPEND=1"
     if os.getenv("TINKER_BACKEND", "").strip().lower() == "dry_run":
         return "TINKER_BACKEND=dry_run"

--- a/src/tinker_api/tinker_api.py
+++ b/src/tinker_api/tinker_api.py
@@ -73,7 +73,7 @@ def _env_flag_enabled(name: str) -> bool:
 def _live_tinker_block_reason() -> str | None:
     if _env_flag_enabled("NO_SPEND"):
         return "NO_SPEND=1"
-    if os.getenv("TINKER_BACKEND", "").strip().lower() == "dry_run":
+    if os.getenv("TINKER_BACKEND", "").strip().lower().replace("-", "_") == "dry_run":
         return "TINKER_BACKEND=dry_run"
     return None
 

--- a/tests/test_tinker_api.py
+++ b/tests/test_tinker_api.py
@@ -368,6 +368,18 @@ def test_no_spend_guards_block_sdk_helpers_before_construction_or_use(
     assert "blocked-job" not in api._token_ledger
 
     _assert_live_tinker_call_blocked(
+        api,
+        lambda: api.run_training_loop(
+            training_client, [batch], learning_rate=1e-4, job_id="blocked-loop"
+        ),
+        reason,
+    )
+    training_client.forward_backward.assert_not_called()
+    training_client.optim_step.assert_not_called()
+    training_client.save_weights_for_sampler.assert_not_called()
+    assert "blocked-loop" not in api._token_ledger
+
+    _assert_live_tinker_call_blocked(
         api, lambda: api.save_checkpoint(training_client, name="ckpt"), reason
     )
     training_client.save_weights_and_get_sampling_client.assert_not_called()

--- a/tests/test_tinker_api.py
+++ b/tests/test_tinker_api.py
@@ -4,6 +4,7 @@ All tests mock the `tinker` package so the suite runs without the SDK
 installed (CI / dev environments).
 """
 
+import builtins
 import sys
 import types as builtin_types
 from unittest.mock import MagicMock, patch
@@ -418,6 +419,28 @@ def test_no_spend_guards_allow_ledger_and_cancel_helpers(
 
     api.cancel_job("guarded-job")
     assert api.is_cancelled("guarded-job")
+
+
+def test_no_spend_guard_does_not_import_tinker_sdk(monkeypatch):
+    _remove_tinker_mock()
+    sys.modules.pop("src.tinker_api.tinker_api", None)
+    monkeypatch.setenv("NO_SPEND", "1")
+
+    real_import = builtins.__import__
+
+    def fail_tinker_import(name, *args, **kwargs):
+        if name == "tinker" or name.startswith("tinker."):
+            raise AssertionError("no-spend guard should not import tinker")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fail_tinker_import)
+
+    import importlib
+
+    api = importlib.import_module("src.tinker_api.tinker_api")
+    assert api._TINKER_AVAILABLE is None
+    _assert_live_tinker_call_blocked(api, api.create_service_client, "NO_SPEND=1")
+    assert api._TINKER_AVAILABLE is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tinker_api.py
+++ b/tests/test_tinker_api.py
@@ -12,6 +12,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+_MISSING = object()
+
+
 # ---------------------------------------------------------------------------
 # Helpers — build a minimal fake tinker package
 # ---------------------------------------------------------------------------
@@ -53,16 +56,40 @@ def fresh_tinker_state(monkeypatch):
     monkeypatch.delenv("NO_SPEND", raising=False)
     monkeypatch.delenv("TINKER_BACKEND", raising=False)
 
+    parent_package = sys.modules.get("src.tinker_api")
+    previous_package_attr = (
+        getattr(parent_package, "tinker_api", _MISSING)
+        if parent_package is not None
+        else _MISSING
+    )
+    previous_modules = {
+        name: sys.modules.get(name, _MISSING)
+        for name in ("tinker", "tinker.types", "src.tinker_api.tinker_api")
+    }
+
     tinker_mod, types_mod = _make_tinker_mock()
     _install_tinker_mock(tinker_mod, types_mod)
 
     # Force re-import so the module picks up the mocked tinker
     sys.modules.pop("src.tinker_api.tinker_api", None)
+    if parent_package is not None and hasattr(parent_package, "tinker_api"):
+        delattr(parent_package, "tinker_api")
 
     yield tinker_mod, types_mod
 
     _remove_tinker_mock()
     sys.modules.pop("src.tinker_api.tinker_api", None)
+    for name, module in previous_modules.items():
+        if module is _MISSING:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = module
+    if parent_package is not None:
+        if previous_package_attr is _MISSING:
+            if hasattr(parent_package, "tinker_api"):
+                delattr(parent_package, "tinker_api")
+        else:
+            setattr(parent_package, "tinker_api", previous_package_attr)
 
 
 def _api():

--- a/tests/test_tinker_api.py
+++ b/tests/test_tinker_api.py
@@ -350,6 +350,7 @@ def _assert_live_tinker_call_blocked(api, call, reason):
         ("NO_SPEND", "true", "NO_SPEND=1"),
         ("NO_SPEND", "on", "NO_SPEND=1"),
         ("TINKER_BACKEND", "dry_run", "TINKER_BACKEND=dry_run"),
+        ("TINKER_BACKEND", "dry-run", "TINKER_BACKEND=dry_run"),
     ],
 )
 def test_no_spend_guards_block_sdk_helpers_before_construction_or_use(
@@ -432,6 +433,7 @@ def test_no_spend_guards_block_sdk_helpers_before_construction_or_use(
         ("NO_SPEND", "1"),
         ("NO_SPEND", "true"),
         ("TINKER_BACKEND", "dry_run"),
+        ("TINKER_BACKEND", "dry-run"),
     ],
 )
 def test_no_spend_guards_allow_ledger_and_cancel_helpers(

--- a/tests/test_tinker_api.py
+++ b/tests/test_tinker_api.py
@@ -319,6 +319,8 @@ def _assert_live_tinker_call_blocked(api, call, reason):
     ("env_name", "env_value", "reason"),
     [
         ("NO_SPEND", "1", "NO_SPEND=1"),
+        ("NO_SPEND", "true", "NO_SPEND=1"),
+        ("NO_SPEND", "on", "NO_SPEND=1"),
         ("TINKER_BACKEND", "dry_run", "TINKER_BACKEND=dry_run"),
     ],
 )
@@ -388,6 +390,7 @@ def test_no_spend_guards_block_sdk_helpers_before_construction_or_use(
     ("env_name", "env_value"),
     [
         ("NO_SPEND", "1"),
+        ("NO_SPEND", "true"),
         ("TINKER_BACKEND", "dry_run"),
     ],
 )

--- a/tests/test_tinker_api.py
+++ b/tests/test_tinker_api.py
@@ -47,8 +47,11 @@ def _remove_tinker_mock():
 # ---------------------------------------------------------------------------
 
 @pytest.fixture(autouse=True)
-def fresh_tinker_state():
+def fresh_tinker_state(monkeypatch):
     """Each test gets a clean tinker mock and a fresh import of the wrapper module."""
+    monkeypatch.delenv("NO_SPEND", raising=False)
+    monkeypatch.delenv("TINKER_BACKEND", raising=False)
+
     tinker_mod, types_mod = _make_tinker_mock()
     _install_tinker_mock(tinker_mod, types_mod)
 
@@ -298,6 +301,108 @@ def test_save_weights_calls_save_for_sampler(fresh_tinker_state):
     tc = MagicMock()
     api.save_weights(tc, name="v1")
     tc.save_weights_for_sampler.assert_called_once_with(name="v1")
+
+
+# ---------------------------------------------------------------------------
+# NO_SPEND / dry-run guards
+# ---------------------------------------------------------------------------
+
+def _assert_live_tinker_call_blocked(api, call, reason):
+    with pytest.raises(api.TinkerAPIError) as excinfo:
+        call()
+    message = str(excinfo.value)
+    assert "live Tinker API calls are disabled" in message
+    assert reason in message
+
+
+@pytest.mark.parametrize(
+    ("env_name", "env_value", "reason"),
+    [
+        ("NO_SPEND", "1", "NO_SPEND=1"),
+        ("TINKER_BACKEND", "dry_run", "TINKER_BACKEND=dry_run"),
+    ],
+)
+def test_no_spend_guards_block_sdk_helpers_before_construction_or_use(
+    fresh_tinker_state, monkeypatch, env_name, env_value, reason
+):
+    tinker_mod, types_mod = fresh_tinker_state
+    api = _api()
+    monkeypatch.setenv(env_name, env_value)
+
+    _assert_live_tinker_call_blocked(api, api.create_service_client, reason)
+    tinker_mod.ServiceClient.assert_not_called()
+
+    service_client = MagicMock()
+    _assert_live_tinker_call_blocked(
+        api,
+        lambda: api.create_lora_training_client(
+            service_client, base_model="meta-llama/Llama-3.2-1B", rank=16
+        ),
+        reason,
+    )
+    service_client.create_lora_training_client.assert_not_called()
+
+    training_client = _make_training_client(types_mod)
+    _assert_live_tinker_call_blocked(
+        api, lambda: api.get_tokenizer(training_client), reason
+    )
+    training_client.get_tokenizer.assert_not_called()
+
+    _assert_live_tinker_call_blocked(api, lambda: api.make_datum([1, 2, 3]), reason)
+    types_mod.ModelInput.from_ints.assert_not_called()
+    types_mod.Datum.assert_not_called()
+
+    batch = _make_batch(types_mod, n_batches=1, tokens_each=3)
+    _assert_live_tinker_call_blocked(
+        api,
+        lambda: api.run_training_step(
+            training_client, batch, learning_rate=1e-4, job_id="blocked-job"
+        ),
+        reason,
+    )
+    training_client.forward_backward.assert_not_called()
+    training_client.optim_step.assert_not_called()
+    types_mod.AdamParams.assert_not_called()
+    assert "blocked-job" not in api._token_ledger
+
+    _assert_live_tinker_call_blocked(
+        api, lambda: api.save_checkpoint(training_client, name="ckpt"), reason
+    )
+    training_client.save_weights_and_get_sampling_client.assert_not_called()
+
+    _assert_live_tinker_call_blocked(
+        api, lambda: api.save_weights(training_client, name="weights"), reason
+    )
+    training_client.save_weights_for_sampler.assert_not_called()
+
+    sampling_client = MagicMock()
+    _assert_live_tinker_call_blocked(
+        api, lambda: api.sample(sampling_client, prompt_tokens=[1, 2, 3]), reason
+    )
+    sampling_client.sample.assert_not_called()
+    types_mod.ModelInput.from_ints.assert_not_called()
+    types_mod.SamplingParams.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("env_name", "env_value"),
+    [
+        ("NO_SPEND", "1"),
+        ("TINKER_BACKEND", "dry_run"),
+    ],
+)
+def test_no_spend_guards_allow_ledger_and_cancel_helpers(
+    fresh_tinker_state, monkeypatch, env_name, env_value
+):
+    api = _api()
+    monkeypatch.setenv(env_name, env_value)
+
+    api.record_tokens("guarded-job", 250_000)
+    api.record_tokens("guarded-job", 250_000)
+    assert api.get_cumulative_spend("guarded-job") == pytest.approx(0.20)
+
+    api.cancel_job("guarded-job")
+    assert api.is_cancelled("guarded-job")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add a runtime guard for low-level Tinker API helpers when `NO_SPEND=1` or `TINKER_BACKEND=dry_run`.
- Block client construction and SDK/client operations before fake or live clients are constructed or used.
- Keep token ledger and cancellation helpers usable under the same guards.

## Validation
- `uvx pytest tests/test_tinker_api.py` - 23 passed
- `python3 -m compileall src/tinker_api/tinker_api.py tests/test_tinker_api.py`
- `git diff --check`