### PR TITLE
[codex] harden API no-spend dry-run fences

### DIFF
--- a/src/tinker_api/sft_runner.py
+++ b/src/tinker_api/sft_runner.py
@@ -3,9 +3,9 @@ SDK-native Tinker supervised fine-tuning runner.
 
 This module is intentionally lazy about importing ``tinker`` and
 ``tinker_cookbook`` so the regular unit suite can run without live SDK
-dependencies installed. Set ``TINKER_BACKEND=dry_run`` to exercise the same
-chat/SFT JSONL artifact contract without importing or constructing live Tinker
-SDK clients.
+dependencies installed. Set ``TINKER_BACKEND=dry_run`` or ``NO_SPEND=1`` to
+exercise the same chat/SFT JSONL artifact contract without importing or
+constructing live Tinker SDK clients.
 """
 
 from __future__ import annotations
@@ -34,6 +34,7 @@ DEFAULT_TINKER_MODEL = "Qwen/Qwen3.5-9B"
 DEFAULT_LIVE_SMOKE_STEPS = 5
 TINKER_BACKEND_ENV = "TINKER_BACKEND"
 TINKER_DRY_RUN_BACKEND = "dry_run"
+NO_SPEND_ENV = "NO_SPEND"
 QWEN35_9B_RENDERER = "qwen3_5_disable_thinking"
 SUPPORTED_TINKER_TUNABLES: frozenset[str] = frozenset(
     {"learning_rate", "batch_size", "max_seq_length", "lora_rank", "num_epochs"}
@@ -64,9 +65,9 @@ def run_tinker_sft_experiment(
 
     ``dataset`` may be a repo ``DatasetResult``, a JSONL path, or an in-memory
     sequence of JSON-like records. Metrics and manifest artifacts are written
-    under ``output_dir/run_id``. Set ``TINKER_BACKEND=dry_run`` to write the
-    same artifact contract with deterministic synthetic metrics and no live
-    Tinker client construction.
+    under ``output_dir/run_id``. Set ``TINKER_BACKEND=dry_run`` or
+    ``NO_SPEND=1`` to write the same artifact contract with deterministic
+    synthetic metrics and no live Tinker client construction.
     """
     cfg = _coerce_training_config(config)
     run_name = run_id or f"tinker-sft-{int(time.time())}-{uuid4().hex[:8]}"
@@ -443,8 +444,14 @@ def _load_tinker_deps() -> tuple[Any, Any, Any, Any, Any, Any]:
 
 
 def _use_dry_run_backend() -> bool:
+    if _env_flag_enabled(NO_SPEND_ENV):
+        return True
     backend = os.getenv(TINKER_BACKEND_ENV, "").strip().lower().replace("-", "_")
     return backend == TINKER_DRY_RUN_BACKEND
+
+
+def _env_flag_enabled(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _run_dry_run_sft_experiment(

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -699,7 +699,7 @@ def test_create_run_local_jsonl_reaches_tinker_dry_run_without_live_credentials(
     monkeypatch.setenv("MANAGER_REASONER", "local")
     monkeypatch.setenv("AUTORESEARCH_PROPOSER", "local")
     monkeypatch.setenv("AUTORESEARCH_EVAL_ADAPTATION", "off")
-    monkeypatch.setenv("TINKER_BACKEND", "dry_run")
+    monkeypatch.delenv("TINKER_BACKEND", raising=False)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("TINKER_API_KEY", raising=False)
 
@@ -756,7 +756,7 @@ def test_create_run_hf_data_path_reaches_tinker_dry_run_without_live_credentials
     monkeypatch.setenv("AUTORESEARCH_EVAL_ADAPTATION", "off")
     monkeypatch.setenv("DATA_GENERATOR_OFFLINE", "1")
     monkeypatch.setenv("DATA_GENERATOR_MAX_ROWS_PER_DATASET", "6")
-    monkeypatch.setenv("TINKER_BACKEND", "dry_run")
+    monkeypatch.delenv("TINKER_BACKEND", raising=False)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("TINKER_API_KEY", raising=False)
 
@@ -813,7 +813,7 @@ def test_create_run_without_data_path_reaches_mode_c_tinker_dry_run_without_live
     monkeypatch.setenv("DATA_GENERATOR_SYNTHETIC_OFFLINE", "1")
     monkeypatch.setenv("DATA_GENERATOR_MODE_C_BACKEND", "synthetic")
     monkeypatch.setenv("DATA_GENERATOR_MAX_ROWS_PER_DATASET", "6")
-    monkeypatch.setenv("TINKER_BACKEND", "dry_run")
+    monkeypatch.delenv("TINKER_BACKEND", raising=False)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("TINKER_API_KEY", raising=False)
     monkeypatch.delenv("TAVILY_API_KEY", raising=False)

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -137,6 +137,56 @@ def _fail_live_service(name: str):
     return _fail
 
 
+def _install_no_live_service_fences(monkeypatch):
+    monkeypatch.setattr("builtins.input", _fail_live_service("user input"))
+    monkeypatch.setattr("anthropic.Anthropic", _fail_live_service("Claude"))
+
+    try:
+        import requests
+
+        monkeypatch.setattr(requests, "get", _fail_live_service("requests.get"))
+    except Exception:
+        pass
+
+    from src.autoresearch import autoresearch as ar
+    from src.data_generator import mode_b
+    from src.data_generator.mode_c import nodes as mode_c_nodes
+    from src.data_generator.mode_c import synthetic as mode_c_synthetic
+    from src.tinker_api import sft_runner
+
+    monkeypatch.setattr(ar, "_MAX_ITERATIONS", 1)
+    monkeypatch.setattr(
+        mode_b,
+        "_fetch_with_hf_datasets",
+        _fail_live_service("Hugging Face dataset fetch"),
+    )
+    monkeypatch.setattr(
+        mode_c_nodes,
+        "search_web_sources",
+        _fail_live_service("Tavily web search"),
+    )
+    monkeypatch.setattr(
+        mode_c_nodes,
+        "crawl_and_extract_pages",
+        _fail_live_service("web crawl"),
+    )
+    monkeypatch.setattr(
+        mode_c_nodes,
+        "structure_web_sources_for_sft",
+        _fail_live_service("Mode C web teacher structuring"),
+    )
+    monkeypatch.setattr(
+        mode_c_synthetic,
+        "_anthropic_client",
+        _fail_live_service("Mode C synthetic teacher"),
+    )
+    monkeypatch.setattr(
+        sft_runner,
+        "_load_tinker_deps",
+        _fail_live_service("Tinker SDK"),
+    )
+
+
 def setup_function():
     server_app._reset_runs_for_tests()
 
@@ -653,18 +703,7 @@ def test_create_run_local_jsonl_reaches_tinker_dry_run_without_live_credentials(
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("TINKER_API_KEY", raising=False)
 
-    monkeypatch.setattr("builtins.input", _fail_live_service("user input"))
-    monkeypatch.setattr("anthropic.Anthropic", _fail_live_service("Claude"))
-
-    from src.autoresearch import autoresearch as ar
-    from src.tinker_api import sft_runner
-
-    monkeypatch.setattr(ar, "_MAX_ITERATIONS", 1)
-    monkeypatch.setattr(
-        sft_runner,
-        "_load_tinker_deps",
-        _fail_live_service("Tinker SDK"),
-    )
+    _install_no_live_service_fences(monkeypatch)
 
     client = TestClient(server_app.app)
     response = client.post(
@@ -721,18 +760,7 @@ def test_create_run_hf_data_path_reaches_tinker_dry_run_without_live_credentials
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("TINKER_API_KEY", raising=False)
 
-    monkeypatch.setattr("builtins.input", _fail_live_service("user input"))
-    monkeypatch.setattr("anthropic.Anthropic", _fail_live_service("Claude"))
-
-    from src.autoresearch import autoresearch as ar
-    from src.tinker_api import sft_runner
-
-    monkeypatch.setattr(ar, "_MAX_ITERATIONS", 1)
-    monkeypatch.setattr(
-        sft_runner,
-        "_load_tinker_deps",
-        _fail_live_service("Tinker SDK"),
-    )
+    _install_no_live_service_fences(monkeypatch)
 
     client = TestClient(server_app.app)
     response = client.post(
@@ -790,18 +818,7 @@ def test_create_run_without_data_path_reaches_mode_c_tinker_dry_run_without_live
     monkeypatch.delenv("TINKER_API_KEY", raising=False)
     monkeypatch.delenv("TAVILY_API_KEY", raising=False)
 
-    monkeypatch.setattr("builtins.input", _fail_live_service("user input"))
-    monkeypatch.setattr("anthropic.Anthropic", _fail_live_service("Claude"))
-
-    from src.autoresearch import autoresearch as ar
-    from src.tinker_api import sft_runner
-
-    monkeypatch.setattr(ar, "_MAX_ITERATIONS", 1)
-    monkeypatch.setattr(
-        sft_runner,
-        "_load_tinker_deps",
-        _fail_live_service("Tinker SDK"),
-    )
+    _install_no_live_service_fences(monkeypatch)
 
     client = TestClient(server_app.app)
     response = client.post(

--- a/tests/test_tinker_runner.py
+++ b/tests/test_tinker_runner.py
@@ -207,6 +207,48 @@ def test_run_tinker_sft_experiment_dry_run_uses_real_dataset_without_sdk(
     assert sample["backend"] == "dry_run"
 
 
+def test_run_tinker_sft_experiment_no_spend_uses_dry_run_without_sdk(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.delenv("TINKER_BACKEND", raising=False)
+    from src.tinker_api import sft_runner
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    class FailingServiceClient:
+        def create_lora_training_client(self, *args, **kwargs):
+            raise AssertionError("NO_SPEND should not construct live training clients")
+
+    monkeypatch.setattr(
+        sft_runner,
+        "_load_tinker_deps",
+        lambda: pytest.fail("NO_SPEND should not load Tinker SDK dependencies"),
+    )
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [{"input": "Question", "output": "Answer"}],
+    )
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=1),
+        str(data_path),
+        run_id="no-spend-dry-run",
+        max_steps=1,
+        output_dir=str(tmp_path / "experiments"),
+        service_client=FailingServiceClient(),
+    )
+
+    run_dir = tmp_path / "experiments" / "no-spend-dry-run"
+    manifest = _assert_strict_json_file(run_dir / "manifest.json")
+    sample = _assert_strict_json_file(run_dir / "sample.json")
+
+    assert result["status"] == "COMPLETED"
+    assert manifest["backend"] == "dry_run"
+    assert manifest["completed_steps"] == 1
+    assert sample["backend"] == "dry_run"
+
+
 def test_run_tinker_sft_experiment_dry_run_cancels_before_steps(
     tmp_path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- adds one shared test helper for the API dry-run smokes that fails if stdin, Claude, Hugging Face dataset fetches, web search/crawl, Mode C teacher structuring, synthetic teacher creation, `requests.get`, or live Tinker SDK loading are touched
- applies that fence to all three API entry-path smokes: local JSONL, `hf://...`, and no-data Mode C

## Why
The dry-run API smokes already completed without live credentials. This makes the contract sharper: the tests now fail at the underlying live/network seams if a future change accidentally routes around the explicit local/offline/dry-run modes.

## Validation
- `env -u ANTHROPIC_API_KEY -u TINKER_API_KEY -u TAVILY_API_KEY UV_NO_NETWORK=1 uv run --with-requirements requirements.txt pytest -q tests/test_server_api.py::test_create_run_local_jsonl_reaches_tinker_dry_run_without_live_credentials tests/test_server_api.py::test_create_run_hf_data_path_reaches_tinker_dry_run_without_live_credentials tests/test_server_api.py::test_create_run_without_data_path_reaches_mode_c_tinker_dry_run_without_live_credentials` -> 3 passed
- `env -u ANTHROPIC_API_KEY -u TINKER_API_KEY -u TAVILY_API_KEY UV_NO_NETWORK=1 uv run --with-requirements requirements.txt pytest -q tests/test_server_api.py tests/test_tinker_runner.py::test_run_tinker_sft_experiment_dry_run_uses_real_dataset_without_sdk` -> 21 passed
- `python3 -m compileall tests/test_server_api.py` -> passed
- `git diff --check` -> passed

No network and no live spend.
