### PR TITLE
[codex] default frontend to Manager API

### DIFF
--- a/ml-agent-frontend/README.md
+++ b/ml-agent-frontend/README.md
@@ -10,14 +10,24 @@ npm run dev        # http://localhost:5173
 npm run build      # production build → dist/
 ```
 
-By default the UI runs in local simulation mode. To use the real Manager API:
+By default the UI calls the real Manager API at `/api`; Vite proxies that path
+to the local backend during development:
 
 ```bash
 cd ..
 uvicorn src.server.app:app --reload --port 8000
 
 cd ml-agent-frontend
-VITE_API_BASE_URL=/api npm run dev
+npm run dev
+```
+
+To point at a different backend, set `VITE_API_BASE_URL` to the API prefix, for
+example `VITE_API_BASE_URL=http://localhost:8000/api npm run dev`.
+
+For static UI demos without a backend, opt into the local simulation:
+
+```bash
+VITE_USE_SIMULATION=1 npm run dev
 ```
 
 ## Deploy (Vercel)

--- a/ml-agent-frontend/README.md
+++ b/ml-agent-frontend/README.md
@@ -28,6 +28,20 @@ For static UI demos without a backend, opt into the local simulation:
 
 ```bash
 VITE_USE_SIMULATION=1 npm run dev
+npm run build:simulation
+npm run preview:simulation
+```
+
+`VITE_*` values are baked into the built bundle. Static previews and Vercel
+deployments without a Manager API should use `npm run build:simulation`; otherwise
+the app will correctly try to call `/api` and report that the backend is missing.
+
+For a deployed frontend backed by a remote Manager API, build with the API prefix
+and allow that frontend origin on the backend:
+
+```bash
+VITE_API_BASE_URL=https://manager.example.com/api npm run build
+MANAGER_API_CORS_ORIGINS=https://frontend-preview.example.com uvicorn src.server.app:app
 ```
 
 ## Deploy (Vercel)
@@ -37,5 +51,8 @@ vercel --prod
 # Build command: npm run build
 # Output directory: dist
 ```
+
+For demo-only Vercel previews that do not have a Manager API attached, use
+`npm run build:simulation` as the build command.
 
 Bundle: ~168 KB gzipped.

--- a/ml-agent-frontend/package.json
+++ b/ml-agent-frontend/package.json
@@ -6,8 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "build:simulation": "VITE_USE_SIMULATION=1 tsc -b && VITE_USE_SIMULATION=1 vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "preview:simulation": "npm run build:simulation && vite preview"
   },
   "dependencies": {
     "react": "^19.2.5",

--- a/ml-agent-frontend/src/api/runs.ts
+++ b/ml-agent-frontend/src/api/runs.ts
@@ -18,14 +18,24 @@ interface CreateRunRequest {
   data_path?: string | null;
 }
 
+function envFlagEnabled(value: string | undefined): boolean {
+  return ['1', 'true', 'yes', 'on'].includes(value?.trim().toLowerCase() ?? '');
+}
+
+export function isSimulationModeConfigured(): boolean {
+  return envFlagEnabled(import.meta.env.VITE_USE_SIMULATION);
+}
+
 export function getApiBaseUrl(): string | null {
+  if (isSimulationModeConfigured()) return null;
+
   const value = import.meta.env.VITE_API_BASE_URL?.trim();
-  if (!value) return null;
-  return value.replace(/\/$/, '');
+  const configured = value || '/api';
+  return configured.replace(/\/$/, '');
 }
 
 export function isBackendApiConfigured(): boolean {
-  return getApiBaseUrl() !== null;
+  return !isSimulationModeConfigured();
 }
 
 export function resolveApiHrefFromBase(


### PR DESCRIPTION
## Summary
- Default the frontend API base to /api so the UI uses the real Manager API path without requiring VITE_API_BASE_URL.
- Keep the existing simulation controller available behind explicit VITE_USE_SIMULATION=1 for static demos.
- Update the frontend README with backend, alternate API, and simulation startup commands.

## Validation
- npm run lint
- npm run build
- VITE_USE_SIMULATION=1 npm run build
- VITE_API_BASE_URL=http://localhost:8000/api npm run build

No live spend.