### PR TITLE
[codex] skip live tests in no-spend mode

### DIFF
--- a/src/data_generator/mode_b.py
+++ b/src/data_generator/mode_b.py
@@ -65,10 +65,10 @@ def fetch_hf_datasets(candidates: list[HFCandidate]) -> RawData:
     Acquisition step for Mode B:
     fetch explicit HF datasets and return combined raw records.
 
-    Set DATA_GENERATOR_OFFLINE=1 for deterministic local test runs.
+    Set DATA_GENERATOR_OFFLINE=1 or NO_SPEND=1 for deterministic local test runs.
     """
     records: list[dict] = []
-    offline = os.getenv("DATA_GENERATOR_OFFLINE", "").strip().lower() in {"1", "true", "yes"}
+    offline = _env_flag_enabled("DATA_GENERATOR_OFFLINE") or _env_flag_enabled("NO_SPEND")
     max_rows_per_dataset = _read_int_env("DATA_GENERATOR_MAX_ROWS_PER_DATASET", 80)
     max_total_records = _read_int_env("DATA_GENERATOR_MAX_TOTAL_RECORDS", 5000)
 
@@ -122,6 +122,10 @@ def fetch_hf_datasets(candidates: list[HFCandidate]) -> RawData:
 def _split_tokens(value: str) -> list[str]:
     parts = re.split(r"[\n,; ]+", value)
     return [p.strip() for p in parts if p.strip()]
+
+
+def _env_flag_enabled(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _coerce_source_tokens(value: object) -> list[str]:

--- a/tests/data_generator/test_mode_b_hf_retrieval.py
+++ b/tests/data_generator/test_mode_b_hf_retrieval.py
@@ -13,6 +13,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from src.data_generator.graph import invoke_data_generator_graph
+from src.data_generator import mode_b
 
 EXAMPLE_REPORT_PATH = (
     REPO_ROOT
@@ -56,6 +57,27 @@ LIVE_HF_DATASET_SEEDS = [
 
 def _env_truthy(name: str) -> bool:
     return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def test_fetch_hf_datasets_no_spend_forces_offline(monkeypatch):
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.delenv("DATA_GENERATOR_OFFLINE", raising=False)
+
+    def fail_fetch(*_args, **_kwargs):
+        raise AssertionError("NO_SPEND=1 should not call live Hugging Face loaders")
+
+    monkeypatch.setattr(mode_b, "_fetch_with_hf_datasets", fail_fetch)
+
+    raw = mode_b.fetch_hf_datasets(
+        mode_b.build_explicit_hf_candidates(["SetFit/sst2"], "text-classification")
+    )
+
+    assert raw["records"] == [
+        {
+            "source": "SetFit/sst2",
+            "content": "offline_placeholder: acquired metadata for SetFit/sst2",
+        }
+    ]
 
 
 def _extract_hf_dataset_ids_from_report(report: dict) -> list[str]:

--- a/tests/data_generator/test_mode_b_hf_retrieval.py
+++ b/tests/data_generator/test_mode_b_hf_retrieval.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
@@ -49,6 +52,10 @@ LIVE_HF_DATASET_SEEDS = [
     "SetFit/sst2",
     "bitext/Bitext-customer-support-llm-chatbot-training-dataset",
 ]
+
+
+def _env_truthy(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _extract_hf_dataset_ids_from_report(report: dict) -> list[str]:
@@ -410,6 +417,9 @@ def _write_subagent2_artifacts(handoff: dict) -> None:
 
 
 def test_hf_retreival(monkeypatch, tmp_path: Path) -> None:
+    if _env_truthy("NO_SPEND"):
+        pytest.skip("NO_SPEND=1 disables live Hugging Face retrieval")
+
     assert EXAMPLE_REPORT_PATH.exists(), f"Missing example report: {EXAMPLE_REPORT_PATH}"
 
     report = json.loads(EXAMPLE_REPORT_PATH.read_text(encoding="utf-8"))

--- a/tests/test_e2e_propose.py
+++ b/tests/test_e2e_propose.py
@@ -47,9 +47,13 @@ from src.autoresearch.proposer import (
 
 # ─── Markers ─────────────────────────────────────────────────────────────────
 
+def _env_truthy(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 integration = pytest.mark.skipif(
-    not os.getenv("ANTHROPIC_API_KEY"),
-    reason="ANTHROPIC_API_KEY not set — skipping live API test",
+    _env_truthy("NO_SPEND") or not os.getenv("ANTHROPIC_API_KEY"),
+    reason="NO_SPEND=1 or ANTHROPIC_API_KEY not set — skipping live API test",
 )
 
 


### PR DESCRIPTION
## Summary
- make the live Claude proposal integration marker skip when `NO_SPEND=1`
- make the live Hugging Face retrieval test skip before it clears offline settings when `NO_SPEND=1`

## Why
The overnight workflow often loads real credentials from `.env`, then relies on `NO_SPEND=1` for dry/no-live validation. Live tests should treat that flag as a hard stop even when API keys are present.

## Validation
- `python3 -m compileall tests/test_e2e_propose.py tests/data_generator/test_mode_b_hf_retrieval.py`
- `env NO_SPEND=1 ANTHROPIC_API_KEY=present UV_NO_NETWORK=1 uv run --with pytest --with anthropic python -m pytest tests/test_e2e_propose.py -q` -> 23 passed, 3 skipped
- `env NO_SPEND=1 UV_NO_NETWORK=1 uv run --with pytest python -m pytest tests/data_generator/test_mode_b_hf_retrieval.py::test_hf_retreival -q` -> 1 skipped
