### PR TITLE
[codex] harden Tinker cancellation finalization

### DIFF
--- a/src/tinker_api/sft_runner.py
+++ b/src/tinker_api/sft_runner.py
@@ -123,9 +123,7 @@ def run_tinker_sft_experiment(
 
         with active_tinker_job(run_name):
             for step in range(target_steps):
-                if cancellation_requested():
-                    cancel_job(run_name)
-                if is_cancelled(run_name):
+                if _sync_cancellation(run_name):
                     status = "CANCELLED"
                     break
 
@@ -172,31 +170,54 @@ def run_tinker_sft_experiment(
                 if nonfinite_loss:
                     break
 
-        checkpoints, sampling_client = _save_final_artifacts(training_client, run_name)
-        sample_payload = _sample_once(
-            sampling_client=sampling_client,
-            renderer=renderer,
-            tinker_types=tinker_types,
-            conversations=conversations,
-        )
-        _write_json(run_dir / "sample.json", sample_payload)
+            if _sync_cancellation(run_name):
+                status = "CANCELLED"
 
-        val_loss = _evaluate_holdout_loss(
-            training_client=training_client,
-            conversations=splits.val,
-            renderer=renderer,
-            supervised_data=supervised_data,
-            cfg=cfg,
-            train_on_what=train_on_what,
-        )
-        test_loss = _evaluate_holdout_loss(
-            training_client=training_client,
-            conversations=splits.test,
-            renderer=renderer,
-            supervised_data=supervised_data,
-            cfg=cfg,
-            train_on_what=train_on_what,
-        )
+            if status == "CANCELLED":
+                checkpoints = _cancelled_checkpoints()
+                sample_payload = _cancelled_sample(conversations)
+                val_loss = None
+                test_loss = None
+            else:
+                checkpoints, sampling_client = _save_final_artifacts(training_client, run_name)
+                if _sync_cancellation(run_name):
+                    status = "CANCELLED"
+                    sample_payload = _cancelled_sample(conversations)
+                    val_loss = None
+                    test_loss = None
+                else:
+                    sample_payload = _sample_once(
+                        sampling_client=sampling_client,
+                        renderer=renderer,
+                        tinker_types=tinker_types,
+                        conversations=conversations,
+                    )
+                    if _sync_cancellation(run_name):
+                        status = "CANCELLED"
+                        val_loss = None
+                        test_loss = None
+                    else:
+                        val_loss = _evaluate_holdout_loss(
+                            training_client=training_client,
+                            conversations=splits.val,
+                            renderer=renderer,
+                            supervised_data=supervised_data,
+                            cfg=cfg,
+                            train_on_what=train_on_what,
+                        )
+                        if _sync_cancellation(run_name):
+                            status = "CANCELLED"
+                            test_loss = None
+                        else:
+                            test_loss = _evaluate_holdout_loss(
+                                training_client=training_client,
+                                conversations=splits.test,
+                                renderer=renderer,
+                                supervised_data=supervised_data,
+                                cfg=cfg,
+                                train_on_what=train_on_what,
+                            )
+        _write_json(run_dir / "sample.json", sample_payload)
         final_metrics = _final_metrics(
             metrics_history,
             status,
@@ -461,6 +482,29 @@ def _load_tinker_deps() -> tuple[Any, Any, Any, Any, Any, Any]:
     return tinker, tinker_types, model_info, renderers, supervised_data, tokenizer_utils
 
 
+def _sync_cancellation(run_name: str) -> bool:
+    if cancellation_requested():
+        cancel_job(run_name)
+    return is_cancelled(run_name)
+
+
+def _cancelled_checkpoints() -> dict[str, str]:
+    return {"skipped": "cancelled"}
+
+
+def _cancelled_sample(conversations: list[list[dict[str, str]]]) -> dict[str, Any]:
+    prompt_messages = [message for message in conversations[0] if message["role"] != "assistant"]
+    if not prompt_messages:
+        prompt_messages = [{"role": "user", "content": conversations[0][0]["content"]}]
+    return {
+        "prompt": prompt_messages,
+        "text": "",
+        "tokens": [],
+        "status": "CANCELLED",
+        "backend": "cancelled",
+    }
+
+
 def _use_dry_run_backend() -> bool:
     if _env_flag_enabled(NO_SPEND_ENV):
         return True
@@ -498,68 +542,72 @@ def _run_dry_run_sft_experiment(
         max_steps=max_steps,
     )
 
-    for step in range(target_steps):
-        if is_cancelled(run_name):
+    with active_tinker_job(run_name):
+        for step in range(target_steps):
+            if _sync_cancellation(run_name):
+                status = "CANCELLED"
+                break
+
+            batch_conversations = _conversation_batch(
+                training_conversations,
+                cfg.batch_size,
+                step,
+            )
+            tokens = sum(_dry_run_token_count(conversation) for conversation in batch_conversations)
+            record_tokens(run_name, tokens)
+            loss = _dry_run_batch_loss(batch_conversations, step)
+            step_metrics = {
+                "step": step + 1,
+                "train_loss": loss,
+                "val_loss": loss,
+                "test_loss": loss,
+                "primary_metric": _score_from_loss(loss),
+                "tokens": tokens,
+            }
+            metrics_history.append(step_metrics)
+            with open(metrics_path, "a") as fh:
+                fh.write(json.dumps(step_metrics, allow_nan=False) + "\n")
+
+        if _sync_cancellation(run_name):
             status = "CANCELLED"
-            break
 
-        batch_conversations = _conversation_batch(
-            training_conversations,
-            cfg.batch_size,
-            step,
+        val_loss = _dry_run_holdout_loss(splits.val)
+        test_loss = _dry_run_holdout_loss(splits.test)
+        final_metrics = _final_metrics(
+            metrics_history,
+            status,
+            val_loss=val_loss,
+            test_loss=test_loss,
         )
-        tokens = sum(_dry_run_token_count(conversation) for conversation in batch_conversations)
-        record_tokens(run_name, tokens)
-        loss = _dry_run_batch_loss(batch_conversations, step)
-        step_metrics = {
-            "step": step + 1,
-            "train_loss": loss,
-            "val_loss": loss,
-            "test_loss": loss,
-            "primary_metric": _score_from_loss(loss),
-            "tokens": tokens,
+        checkpoints = {
+            "state_path": f"dry-run://state/{run_name}-final-state",
+            "sampler_path": f"dry-run://sampler/{run_name}-final-sampler",
         }
-        metrics_history.append(step_metrics)
-        with open(metrics_path, "a") as fh:
-            fh.write(json.dumps(step_metrics, allow_nan=False) + "\n")
-
-    val_loss = _dry_run_holdout_loss(splits.val)
-    test_loss = _dry_run_holdout_loss(splits.test)
-    final_metrics = _final_metrics(
-        metrics_history,
-        status,
-        val_loss=val_loss,
-        test_loss=test_loss,
-    )
-    checkpoints = {
-        "state_path": f"dry-run://state/{run_name}-final-state",
-        "sampler_path": f"dry-run://sampler/{run_name}-final-sampler",
-    }
-    manifest = {
-        "run_id": run_name,
-        "status": status,
-        "backend": TINKER_DRY_RUN_BACKEND,
-        "model_name": model_name,
-        "renderer_name": "dry_run_chat",
-        "train_on_what": "last_assistant_message",
-        "dataset_path": _dataset_path_for_manifest(dataset),
-        "training_examples": len(training_conversations),
-        "split_examples": {
-            "train": len(splits.train),
-            "val": len(splits.val),
-            "test": len(splits.test),
-        },
-        "heldout_eval": {
-            "val_loss": val_loss,
-            "test_loss": test_loss,
-        },
-        "max_steps": max_steps,
-        "completed_steps": len(metrics_history),
-        "checkpoints": checkpoints,
-    }
-    _write_json(run_dir / "sample.json", _dry_run_sample(conversations))
-    _write_json(run_dir / "manifest.json", manifest)
-    _write_json(run_dir / "metrics.json", final_metrics)
+        manifest = {
+            "run_id": run_name,
+            "status": status,
+            "backend": TINKER_DRY_RUN_BACKEND,
+            "model_name": model_name,
+            "renderer_name": "dry_run_chat",
+            "train_on_what": "last_assistant_message",
+            "dataset_path": _dataset_path_for_manifest(dataset),
+            "training_examples": len(training_conversations),
+            "split_examples": {
+                "train": len(splits.train),
+                "val": len(splits.val),
+                "test": len(splits.test),
+            },
+            "heldout_eval": {
+                "val_loss": val_loss,
+                "test_loss": test_loss,
+            },
+            "max_steps": max_steps,
+            "completed_steps": len(metrics_history),
+            "checkpoints": checkpoints,
+        }
+        _write_json(run_dir / "sample.json", _dry_run_sample(conversations))
+        _write_json(run_dir / "manifest.json", manifest)
+        _write_json(run_dir / "metrics.json", final_metrics)
 
     return {
         "job_id": run_name,

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -573,6 +573,73 @@ def test_cancel_running_run_stops_at_safe_boundary(tmp_path, monkeypatch):
     assert any("cancel" in item["message"].lower() for item in state["logs"])
 
 
+def test_cancel_no_spend_dry_run_tinker_run(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("TINKER_API_KEY", raising=False)
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+
+    from src.autoresearch.config import TrainingConfig
+    from src.tinker_api import sft_runner, tinker_api
+
+    started = threading.Event()
+    original_record_tokens = tinker_api.record_tokens
+
+    def slow_first_step(job_id: str, n_tokens: int) -> None:
+        if not started.is_set():
+            started.set()
+            time.sleep(0.2)
+        original_record_tokens(job_id, n_tokens)
+
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
+        root = get_output_root()
+        assert root is not None
+        return sft_runner.run_tinker_sft_experiment(
+            TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=1),
+            [{"input": "Question", "output": "Answer"}],
+            run_id="server-dry-run",
+            max_steps=250,
+            output_dir=str(root / "experiments"),
+        )
+
+    monkeypatch.setattr(sft_runner, "record_tokens", slow_first_step)
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+
+    client = TestClient(server_app.app)
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune a cancellable no-spend dry-run assistant",
+            "budget": 3,
+            "task_type": "fine-tuning",
+        },
+    )
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    assert started.wait(timeout=5)
+
+    cancel_response = client.post(f"/api/runs/{run_id}/cancel")
+    assert cancel_response.status_code == 200
+    assert cancel_response.json()["status"] in {"cancelling", "cancelled"}
+
+    state = _wait_for_status(client, run_id, "cancelled")
+    manifest_path = (
+        tmp_path
+        / "outputs"
+        / "api-runs"
+        / run_id
+        / "experiments"
+        / "server-dry-run"
+        / "manifest.json"
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert state["status"] == "cancelled"
+    assert manifest["status"] == "CANCELLED"
+    assert tinker_api.is_cancelled("server-dry-run")
+
+
 def test_cancel_missing_run_returns_404():
     client = TestClient(server_app.app)
     response = client.post("/api/runs/not-a-run/cancel")

--- a/tests/test_tinker_runner.py
+++ b/tests/test_tinker_runner.py
@@ -4,6 +4,7 @@ import importlib
 import json
 import math
 import sys
+import threading
 import types
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -345,6 +346,48 @@ def test_run_tinker_sft_experiment_dry_run_cancels_between_steps(
     assert len(rows) == 1
 
 
+def test_run_tinker_sft_experiment_dry_run_honors_runtime_cancellation(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("TINKER_BACKEND", "dry_run")
+    from src.runtime_context import cancellation_context
+    from src.tinker_api import sft_runner, tinker_api
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    cancel_event = threading.Event()
+    active_jobs: set[str] = set()
+    original_record_tokens = tinker_api.record_tokens
+
+    def request_cancel_after_first_step(job_id: str, n_tokens: int) -> None:
+        original_record_tokens(job_id, n_tokens)
+        assert job_id in active_jobs
+        cancel_event.set()
+
+    monkeypatch.setattr(sft_runner, "record_tokens", request_cancel_after_first_step)
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [{"input": "Question", "output": "Answer"}],
+    )
+
+    with cancellation_context(cancel_event, active_jobs):
+        result = run_tinker_sft_experiment(
+            TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=1),
+            str(data_path),
+            run_id="runtime-dry-cancel",
+            max_steps=3,
+            output_dir=str(tmp_path / "experiments"),
+        )
+
+    run_dir = tmp_path / "experiments" / "runtime-dry-cancel"
+    manifest = _assert_strict_json_file(run_dir / "manifest.json")
+
+    assert result["status"] == "CANCELLED"
+    assert manifest["completed_steps"] == 1
+    assert tinker_api.is_cancelled("runtime-dry-cancel")
+    assert active_jobs == set()
+
+
 def test_run_tinker_sft_experiment_writes_strict_json_for_nonfinite_training_loss(
     tmp_path,
     monkeypatch,
@@ -646,7 +689,7 @@ def test_extract_forward_loss_uses_weighted_logprobs():
 
 
 def test_run_tinker_sft_experiment_stops_on_cancel_and_writes_artifacts(tmp_path, monkeypatch):
-    _install_fake_tinker_stack(monkeypatch, losses=[0.5, 0.25, 0.1])
+    state = _install_fake_tinker_stack(monkeypatch, losses=[0.5, 0.25, 0.1])
     from src.tinker_api import tinker_api
     from src.tinker_api.sft_runner import run_tinker_sft_experiment
 
@@ -671,10 +714,17 @@ def test_run_tinker_sft_experiment_stops_on_cancel_and_writes_artifacts(tmp_path
     )
 
     run_dir = tmp_path / "experiments" / "cancel-run"
+    manifest = _assert_strict_json_file(run_dir / "manifest.json")
+    sample = _assert_strict_json_file(run_dir / "sample.json")
+
     assert result["status"] == "CANCELLED"
-    assert (run_dir / "manifest.json").exists()
-    assert (run_dir / "sample.json").exists()
+    assert manifest["checkpoints"] == {"skipped": "cancelled"}
+    assert sample["status"] == "CANCELLED"
     assert (run_dir / "metrics.jsonl").read_text().count("\n") == 1
+    assert state.training_client.save_state_calls == 0
+    assert state.training_client.save_weights_calls == 0
+    assert state.training_client.sample_calls == 0
+    assert state.training_client.forward_calls == 0
 
 
 def test_run_evals_scores_tinker_metrics(tmp_path):
@@ -1230,9 +1280,13 @@ class _FakeTrainingClient:
         self.forward_backward_calls = 0
         self.forward_calls = 0
         self.optim_step_calls = 0
+        self.save_state_calls = 0
+        self.save_weights_calls = 0
+        self.sample_calls = 0
         self.batches = []
         self.forward_batches = []
         self.sampling_client = _FakeSamplingClient()
+        self.sampling_client.training_client = self
 
     def forward_backward(self, batch, loss_fn):
         self.forward_backward_calls += 1
@@ -1255,9 +1309,11 @@ class _FakeTrainingClient:
         return _FakeFuture(types.SimpleNamespace(metrics={}))
 
     def save_state(self, name):
+        self.save_state_calls += 1
         return _FakeFuture(types.SimpleNamespace(path=f"tinker://state/{name}"))
 
     def save_weights_for_sampler(self, name):
+        self.save_weights_calls += 1
         return _FakeFuture(types.SimpleNamespace(path=f"tinker://sampler/{name}"))
 
     def save_weights_and_get_sampling_client(self, name=None):
@@ -1266,6 +1322,7 @@ class _FakeTrainingClient:
 
 class _FakeSamplingClient:
     def sample(self, prompt, num_samples, sampling_params):
+        self.training_client.sample_calls += 1
         sequence = types.SimpleNamespace(tokens=[10, 11, 12])
         return _FakeFuture(types.SimpleNamespace(sequences=[sequence]))
 


### PR DESCRIPTION
## Summary
- keep Tinker SFT runs registered with the runtime cancellation context through finalization
- stop cancelled live runs from making post-cancel checkpoint/sample/holdout eval SDK calls
- make dry-run/NO_SPEND Tinker runs cancellable through the same active-job registry as live runs
- add unit and FastAPI coverage for runtime cancellation and no-spend dry-run cancellation

## Validation
- `python3 -m compileall src/tinker_api/sft_runner.py tests/test_tinker_runner.py tests/test_server_api.py`
- `env -u ANTHROPIC_API_KEY -u TINKER_API_KEY -u TAVILY_API_KEY UV_NO_NETWORK=1 uv run --with pytest --with fastapi --with httpx --with anthropic python -m pytest tests/test_tinker_runner.py::test_run_tinker_sft_experiment_dry_run_honors_runtime_cancellation tests/test_tinker_runner.py::test_run_tinker_sft_experiment_stops_on_cancel_and_writes_artifacts tests/test_server_api.py::test_cancel_no_spend_dry_run_tinker_run -q`
- `env -u ANTHROPIC_API_KEY -u TINKER_API_KEY -u TAVILY_API_KEY UV_NO_NETWORK=1 uv run --with pytest --with anthropic python -m pytest tests/test_tinker_runner.py -q`
- `env -u ANTHROPIC_API_KEY -u TINKER_API_KEY -u TAVILY_API_KEY UV_NO_NETWORK=1 uv run --with pytest --with fastapi --with httpx --with anthropic --with langgraph python -m pytest tests/test_server_api.py -q`

No live credentials were set for these validations.
