### PR TITLE
[codex] make frontend result actions honest

### DIFF
--- a/ml-agent-frontend/src/components/Dashboard.tsx
+++ b/ml-agent-frontend/src/components/Dashboard.tsx
@@ -79,7 +79,7 @@ function CancelledArtifacts({ state, onReset }: Props) {
   const results = [
     { label: 'Checkpoint F1', value: bestIter ? bestIter.f1.toFixed(3) : '—' },
     { label: 'Val Accuracy', value: lastMetric ? `${(lastMetric.accuracy * 100).toFixed(1)}%` : '—' },
-    { label: 'Cost Spent', value: `$${state.costSpent.toFixed(2)}` },
+    { label: 'Budget Used', value: `$${state.costSpent.toFixed(2)}` },
   ];
 
   return (

--- a/ml-agent-frontend/src/components/FinalResults.tsx
+++ b/ml-agent-frontend/src/components/FinalResults.tsx
@@ -16,9 +16,9 @@ const RESULT_TOOLTIPS: Record<string, { label: string; body: string }> = {
     label: 'Validation Accuracy',
     body: 'The model\'s correct-prediction rate on held-out data it has never seen. This is the more honest measure of real-world performance.',
   },
-  'Total Cost': {
-    label: 'Total Compute Cost',
-    body: 'The full cost of this training run across all pipeline stages, billed against your original budget cap.',
+  'Budget Used': {
+    label: 'Budget Accounted',
+    body: 'The amount counted against this run\'s budget cap. Dry-run and no-spend runs use reserved or estimated budget, not provider-billed spend.',
   },
 };
 
@@ -53,7 +53,7 @@ export default function FinalResults({ state, onReset }: Props) {
   const results = [
     { label: 'Final F1', value: bestIter ? bestIter.f1.toFixed(3) : '—' },
     { label: 'Val Accuracy', value: lastMetric ? `${(lastMetric.accuracy * 100).toFixed(1)}%` : '—' },
-    { label: 'Total Cost', value: `$${state.costSpent.toFixed(2)}` },
+    { label: 'Budget Used', value: `$${state.costSpent.toFixed(2)}` },
   ];
   const compactPath = (value?: string | null) => {
     if (!value) return '—';
@@ -199,22 +199,6 @@ export default function FinalResults({ state, onReset }: Props) {
             placement="top"
           />
         </span>
-        <button
-          onClick={() => alert('Deploy endpoint: configure in production')}
-          style={{
-            padding: '0.5rem 1rem',
-            background: 'var(--success-dim)',
-            border: '0.5px solid var(--success)',
-            borderRadius: '6px',
-            color: 'var(--success)',
-            fontSize: '13px',
-            cursor: 'pointer',
-            fontFamily: 'inherit',
-          }}
-          aria-label="Deploy model"
-        >
-          Deploy Model
-        </button>
         <button
           onClick={onReset}
           style={{

--- a/ml-agent-frontend/src/components/MetricsGrid.tsx
+++ b/ml-agent-frontend/src/components/MetricsGrid.tsx
@@ -17,8 +17,8 @@ const TOOLTIPS: Record<string, { label: string; body: string }> = {
     body: 'The model\'s correct-prediction rate on held-out data it has never seen. This is the more honest measure of real-world performance.',
   },
   cost: {
-    label: 'Accumulated Cost',
-    body: 'Total compute spend so far across all pipeline stages. Updates in real time so you can monitor burn against your budget.',
+    label: 'Budget Accounted',
+    body: 'Amount counted against the run budget so far. Dry-run and no-spend runs use reserved or estimated budget, not provider-billed spend.',
   },
   iter: {
     label: 'Experiment Iterations',
@@ -75,7 +75,7 @@ export default function MetricsGrid({ metrics, costSpent }: Props) {
     >
       <MetricCard label="Training Loss" value={loss} tooltipKey="loss" />
       <MetricCard label="Val Accuracy" value={accuracy} tooltipKey="accuracy" />
-      <MetricCard label="Cost Spent" value={cost} tooltipKey="cost" />
+      <MetricCard label="Budget Used" value={cost} tooltipKey="cost" />
       <MetricCard label="Iterations" value={iter} tooltipKey="iter" />
     </div>
   );

--- a/ml-agent-frontend/src/components/PipelineProgress.tsx
+++ b/ml-agent-frontend/src/components/PipelineProgress.tsx
@@ -109,8 +109,8 @@ export default function PipelineProgress({ stages, costSpent, budget }: Props) {
           <div style={{ display: 'flex', alignItems: 'center' }}>
             <span style={{ fontSize: '12px', color: 'var(--text-muted)' }}>Budget</span>
             <Tooltip
-              label="Live Budget Usage"
-              body="Tracks how much of your cost cap has been spent so far. Turns amber at 50% and red at 70% as a warning before the limit is hit."
+              label="Budget Usage"
+              body="Tracks budget-accounted usage against the run cap. Dry-run and no-spend runs use reserved or estimated budget, not provider-billed spend."
               placement="bottom"
             />
           </div>


### PR DESCRIPTION
## Summary
- remove the completed-run `Deploy Model` button because it only opened a placeholder alert
- rename frontend cost cards from `Cost Spent` / `Total Cost` to `Budget Used`
- update budget tooltips to clarify that dry-run/no-spend runs show budget-accounted or reserved estimates, not provider-billed spend

## Validation
- `npm ci`
- `npm run lint`
- `npm run build`
- Browser smoke in explicit simulation mode: completed a run, verified final UI shows `Budget Used`, verified `Deploy Model`, `Cost Spent`, and `Total Cost` are absent from the rendered complete state

No live backend credentials or paid services were used.
