### PR TITLE
Label training primary scores honestly

### DIFF
--- a/ml-agent-frontend/src/components/Dashboard.tsx
+++ b/ml-agent-frontend/src/components/Dashboard.tsx
@@ -6,6 +6,13 @@ import MetricsChart from './MetricsChart';
 import IterationsList from './IterationsList';
 import ActivityLog from './ActivityLog';
 import FinalResults from './FinalResults';
+import {
+  formatPrimaryMetric,
+  iterationMetricValue,
+  metricPointValue,
+  primaryMetricLabel,
+  shortMetricLabel,
+} from '../utils/metricDisplay';
 
 interface Props {
   state: TrainingState;
@@ -71,14 +78,22 @@ function CancelledArtifacts({ state, onReset }: Props) {
   const bestIter = state.iterations.find(i => i.status === 'KEPT') ?? state.iterations[0];
   const artifactFiles = state.artifacts?.files.filter(file => file.exists) ?? [];
   const checkpointEntries = Object.entries(state.artifacts?.checkpoints ?? {}).filter(([, value]) => value);
+  const bestLabel = primaryMetricLabel(bestIter?.primaryMetricLabel ?? lastMetric?.primaryMetricLabel);
+  const latestLabel = primaryMetricLabel(lastMetric?.primaryMetricLabel ?? bestLabel);
   const compactPath = (value?: string | null) => {
     if (!value) return '—';
     if (value.length <= 72) return value;
     return `…${value.slice(-69)}`;
   };
   const results = [
-    { label: 'Checkpoint F1', value: bestIter ? bestIter.f1.toFixed(3) : '—' },
-    { label: 'Val Accuracy', value: lastMetric ? `${(lastMetric.accuracy * 100).toFixed(1)}%` : '—' },
+    {
+      label: `Checkpoint ${shortMetricLabel(bestLabel)}`,
+      value: formatPrimaryMetric(iterationMetricValue(bestIter), bestLabel),
+    },
+    {
+      label: latestLabel,
+      value: formatPrimaryMetric(metricPointValue(lastMetric), latestLabel),
+    },
     { label: 'Budget Used', value: `$${state.costSpent.toFixed(2)}` },
   ];
 

--- a/ml-agent-frontend/src/components/FinalResults.tsx
+++ b/ml-agent-frontend/src/components/FinalResults.tsx
@@ -1,5 +1,12 @@
 import { resolveApiHref } from '../api/runs';
 import type { TrainingState } from '../types';
+import {
+  formatPrimaryMetric,
+  iterationMetricValue,
+  metricPointValue,
+  primaryMetricLabel,
+  shortMetricLabel,
+} from '../utils/metricDisplay';
 import Tooltip from './Tooltip';
 
 interface Props {
@@ -8,25 +15,25 @@ interface Props {
 }
 
 const RESULT_TOOLTIPS: Record<string, { label: string; body: string }> = {
-  'Final F1': {
-    label: 'Final F1 Score',
-    body: 'Balances precision and recall into one number. Ranges from 0 to 1 — higher is better, especially useful when classes are imbalanced.',
-  },
-  'Val Accuracy': {
-    label: 'Validation Accuracy',
-    body: 'The model\'s correct-prediction rate on held-out data it has never seen. This is the more honest measure of real-world performance.',
+  score: {
+    label: 'Primary Metric',
+    body: 'The higher-is-better score returned by the evaluation step. Tinker SFT runs report the normalized primary score derived from validation loss.',
   },
   'Budget Used': {
     label: 'Budget Accounted',
     body: 'The amount counted against this run\'s budget cap. Dry-run and no-spend runs use reserved or estimated budget, not provider-billed spend.',
   },
 };
+type ResultTooltipKey = keyof typeof RESULT_TOOLTIPS;
 
 export default function FinalResults({ state, onReset }: Props) {
   const lastMetric = state.metrics[state.metrics.length - 1];
   const bestIter = state.iterations.find(i => i.status === 'KEPT') ?? state.iterations[0];
   const artifactFiles = state.artifacts?.files.filter(file => file.exists) ?? [];
   const checkpointEntries = Object.entries(state.artifacts?.checkpoints ?? {}).filter(([, value]) => value);
+  const bestLabel = primaryMetricLabel(bestIter?.primaryMetricLabel ?? lastMetric?.primaryMetricLabel);
+  const finalScoreLabel = `Final ${shortMetricLabel(bestLabel)}`;
+  const latestLabel = primaryMetricLabel(lastMetric?.primaryMetricLabel ?? bestLabel);
 
   const handleExportDiary = () => {
     const diary = {
@@ -50,10 +57,18 @@ export default function FinalResults({ state, onReset }: Props) {
     URL.revokeObjectURL(url);
   };
 
-  const results = [
-    { label: 'Final F1', value: bestIter ? bestIter.f1.toFixed(3) : '—' },
-    { label: 'Val Accuracy', value: lastMetric ? `${(lastMetric.accuracy * 100).toFixed(1)}%` : '—' },
-    { label: 'Budget Used', value: `$${state.costSpent.toFixed(2)}` },
+  const results: Array<{ label: string; value: string; tooltipKey: ResultTooltipKey }> = [
+    {
+      label: finalScoreLabel,
+      value: formatPrimaryMetric(iterationMetricValue(bestIter), bestLabel),
+      tooltipKey: 'score',
+    },
+    {
+      label: latestLabel,
+      value: formatPrimaryMetric(metricPointValue(lastMetric), latestLabel),
+      tooltipKey: 'score',
+    },
+    { label: 'Budget Used', value: `$${state.costSpent.toFixed(2)}`, tooltipKey: 'Budget Used' },
   ];
   const compactPath = (value?: string | null) => {
     if (!value) return '—';
@@ -101,8 +116,8 @@ export default function FinalResults({ state, onReset }: Props) {
         gap: '12px',
         marginBottom: '1.5rem',
       }}>
-        {results.map(({ label, value }) => {
-          const tip = RESULT_TOOLTIPS[label];
+        {results.map(({ label, value, tooltipKey }) => {
+          const tip = RESULT_TOOLTIPS[tooltipKey];
           return (
             <div key={label} style={{
               background: 'var(--bg-elevated)',

--- a/ml-agent-frontend/src/components/IterationsList.tsx
+++ b/ml-agent-frontend/src/components/IterationsList.tsx
@@ -1,4 +1,5 @@
 import type { Iteration } from '../types';
+import { formatPrimaryMetric, iterationMetricValue, shortMetricLabel } from '../utils/metricDisplay';
 import Tooltip from './Tooltip';
 
 interface Props {
@@ -102,7 +103,7 @@ export default function IterationsList({ iterations }: Props) {
                   L {iter.loss.toFixed(3)}
                 </span>
                 <span style={{ fontSize: '11px', color: 'var(--text-muted)', flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
-                  F1 {iter.f1.toFixed(3)}
+                  {shortMetricLabel(iter.primaryMetricLabel)} {formatPrimaryMetric(iterationMetricValue(iter), iter.primaryMetricLabel)}
                 </span>
                 <StatusBadge status={iter.status} />
               </div>

--- a/ml-agent-frontend/src/components/MetricsChart.tsx
+++ b/ml-agent-frontend/src/components/MetricsChart.tsx
@@ -9,6 +9,7 @@ import {
   Legend,
 } from 'recharts';
 import type { MetricPoint } from '../types';
+import { formatPrimaryMetric, metricPointValue, primaryMetricLabel } from '../utils/metricDisplay';
 import TooltipInfo from './Tooltip';
 
 interface Props {
@@ -24,10 +25,11 @@ const tooltipStyle: React.CSSProperties = {
 };
 
 export default function MetricsChart({ metrics }: Props) {
+  const latestLabel = primaryMetricLabel(metrics[metrics.length - 1]?.primaryMetricLabel);
   const data = metrics.map(m => ({
     iter: m.iteration,
     loss: m.loss,
-    accuracy: +(m.accuracy * 100).toFixed(2),
+    primaryScore: metricPointValue(m) ?? 0,
   }));
 
   return (
@@ -45,7 +47,7 @@ export default function MetricsChart({ metrics }: Props) {
         <p style={{ fontSize: '12px', color: 'var(--text-muted)' }}>Training Curves</p>
         <TooltipInfo
           label="Training Curves"
-          body="Plots loss and accuracy together over time. Diverging curves (loss up, accuracy down) signal overfitting; converging curves signal healthy learning."
+          body="Plots loss and the primary evaluation score together over time. Tinker SFT score is normalized from validation loss, so higher is better."
         />
       </div>
       {data.length === 0 ? (
@@ -73,23 +75,25 @@ export default function MetricsChart({ metrics }: Props) {
             <YAxis
               yAxisId="acc"
               orientation="right"
-              domain={[70, 100]}
+              domain={[0, 1]}
               tick={{ fill: 'var(--text-muted)', fontSize: 10 }}
               tickLine={false}
               axisLine={{ stroke: 'var(--border)' }}
-              tickFormatter={v => `${v}%`}
+              tickFormatter={v => formatPrimaryMetric(Number(v), latestLabel)}
             />
             <Tooltip
               contentStyle={tooltipStyle}
               labelFormatter={v => `Iteration ${v}`}
               formatter={(value, name) => {
                 const v = Number(value);
-                return name === 'loss' ? [v.toFixed(4), 'Loss'] : [`${v.toFixed(1)}%`, 'Accuracy'];
+                return name === 'loss'
+                  ? [v.toFixed(4), 'Loss']
+                  : [formatPrimaryMetric(v, latestLabel), latestLabel];
               }}
             />
             <Legend
               wrapperStyle={{ fontSize: '11px', color: 'var(--text-muted)' }}
-              formatter={(value) => value === 'loss' ? 'Training Loss' : 'Val Accuracy'}
+              formatter={(value) => value === 'loss' ? 'Training Loss' : latestLabel}
             />
             <Line
               yAxisId="loss"
@@ -103,7 +107,7 @@ export default function MetricsChart({ metrics }: Props) {
             <Line
               yAxisId="acc"
               type="monotone"
-              dataKey="accuracy"
+              dataKey="primaryScore"
               stroke="var(--success)"
               strokeWidth={1.5}
               dot={false}

--- a/ml-agent-frontend/src/components/MetricsGrid.tsx
+++ b/ml-agent-frontend/src/components/MetricsGrid.tsx
@@ -1,4 +1,5 @@
 import type { MetricPoint } from '../types';
+import { formatPrimaryMetric, metricPointValue, primaryMetricLabel } from '../utils/metricDisplay';
 import Tooltip from './Tooltip';
 
 interface Props {
@@ -12,9 +13,9 @@ const TOOLTIPS: Record<string, { label: string; body: string }> = {
     label: 'Training Loss',
     body: 'Measures how wrong the model\'s predictions are on training data. Lower is better — a steadily decreasing value means the model is learning.',
   },
-  accuracy: {
-    label: 'Validation Accuracy',
-    body: 'The model\'s correct-prediction rate on held-out data it has never seen. This is the more honest measure of real-world performance.',
+  primary: {
+    label: 'Primary Metric',
+    body: 'The higher-is-better score returned by the evaluation step. Tinker SFT runs report the normalized primary score derived from validation loss.',
   },
   cost: {
     label: 'Budget Accounted',
@@ -59,7 +60,8 @@ function MetricCard({ label, value, tooltipKey }: CardProps) {
 export default function MetricsGrid({ metrics, costSpent }: Props) {
   const last = metrics[metrics.length - 1];
   const loss = last ? last.loss.toFixed(4) : '—';
-  const accuracy = last ? `${(last.accuracy * 100).toFixed(1)}%` : '—';
+  const scoreLabel = primaryMetricLabel(last?.primaryMetricLabel);
+  const score = formatPrimaryMetric(metricPointValue(last), scoreLabel);
   const cost = `$${costSpent.toFixed(2)}`;
   const iter = `${metrics.length}/${Math.max(metrics.length, 12)}`;
 
@@ -74,7 +76,7 @@ export default function MetricsGrid({ metrics, costSpent }: Props) {
       aria-label="Training metrics"
     >
       <MetricCard label="Training Loss" value={loss} tooltipKey="loss" />
-      <MetricCard label="Val Accuracy" value={accuracy} tooltipKey="accuracy" />
+      <MetricCard label={scoreLabel} value={score} tooltipKey="primary" />
       <MetricCard label="Budget Used" value={cost} tooltipKey="cost" />
       <MetricCard label="Iterations" value={iter} tooltipKey="iter" />
     </div>

--- a/ml-agent-frontend/src/hooks/useTrainingSimulation.ts
+++ b/ml-agent-frontend/src/hooks/useTrainingSimulation.ts
@@ -64,37 +64,37 @@ const ITERATIONS: Array<Omit<Iteration, 'id'>> = [
   {
     experiment: 'Decrease learning_rate 3e-4→1.5e-4 to reduce loss spikes.',
     diff: '- learning_rate: 0.0003\n+ learning_rate: 0.00015',
-    loss: 0.289, f1: 0.871, status: 'KEPT',
+    loss: 0.289, f1: 0.871, primaryMetric: 0.871, primaryMetricLabel: 'F1', status: 'KEPT',
   },
   {
     experiment: 'Increase lora_rank 16→32 to expand model capacity for task.',
     diff: '- lora_rank: 16\n+ lora_rank: 32',
-    loss: 0.271, f1: 0.901, status: 'KEPT',
+    loss: 0.271, f1: 0.901, primaryMetric: 0.901, primaryMetricLabel: 'F1', status: 'KEPT',
   },
   {
     experiment: 'Increase learning_rate 1.5e-4→6.1e-4 (local ±20% perturbation).',
     diff: '- learning_rate: 0.00015\n+ learning_rate: 0.00061',
-    loss: 0.334, f1: 0.862, status: 'REVERTED',
+    loss: 0.334, f1: 0.862, primaryMetric: 0.862, primaryMetricLabel: 'F1', status: 'REVERTED',
   },
   {
     experiment: 'Increase warmup_steps 100→500 to stabilize early training.',
     diff: '- warmup_steps: 100\n+ warmup_steps: 500',
-    loss: 0.248, f1: 0.914, status: 'KEPT',
+    loss: 0.248, f1: 0.914, primaryMetric: 0.914, primaryMetricLabel: 'F1', status: 'KEPT',
   },
   {
     experiment: 'Decrease dropout 0.1→0.06 (local ±20% perturbation).',
     diff: '- dropout: 0.1\n+ dropout: 0.06',
-    loss: 0.243, f1: 0.917, status: 'KEPT',
+    loss: 0.243, f1: 0.917, primaryMetric: 0.917, primaryMetricLabel: 'F1', status: 'KEPT',
   },
   {
     experiment: 'Increase num_epochs 3→4 to allow longer convergence.',
     diff: '- num_epochs: 3\n+ num_epochs: 4',
-    loss: 0.261, f1: 0.908, status: 'REVERTED',
+    loss: 0.261, f1: 0.908, primaryMetric: 0.908, primaryMetricLabel: 'F1', status: 'REVERTED',
   },
   {
     experiment: 'Decrease learning_rate 1.5e-4→1.2e-4 (local ±20% perturbation).',
     diff: '- learning_rate: 0.00015\n+ learning_rate: 0.00012',
-    loss: 0.231, f1: 0.923, status: 'KEPT',
+    loss: 0.231, f1: 0.923, primaryMetric: 0.923, primaryMetricLabel: 'F1', status: 'KEPT',
   },
 ];
 
@@ -184,7 +184,16 @@ export function useTrainingSimulation() {
           schedule(() => {
             setState(prev => ({
               ...prev,
-              metrics: [...prev.metrics, { loss, accuracy, iteration: prev.metrics.length + 1 }],
+              metrics: [
+                ...prev.metrics,
+                {
+                  loss,
+                  accuracy,
+                  primaryMetric: accuracy,
+                  primaryMetricLabel: 'Accuracy',
+                  iteration: prev.metrics.length + 1,
+                },
+              ],
             }));
           }, stageStart + t * 500 + 200);
         }

--- a/ml-agent-frontend/src/types.ts
+++ b/ml-agent-frontend/src/types.ts
@@ -20,6 +20,8 @@ export interface PipelineStage {
 export interface MetricPoint {
   loss: number;
   accuracy: number;
+  primaryMetric?: number | null;
+  primaryMetricLabel?: string | null;
   iteration: number;
 }
 
@@ -29,6 +31,8 @@ export interface Iteration {
   diff?: string;
   loss: number;
   f1: number;
+  primaryMetric?: number | null;
+  primaryMetricLabel?: string | null;
   status: IterationStatus;
 }
 

--- a/ml-agent-frontend/src/utils/metricDisplay.ts
+++ b/ml-agent-frontend/src/utils/metricDisplay.ts
@@ -1,0 +1,34 @@
+import type { Iteration, MetricPoint } from '../types';
+
+const DEFAULT_PRIMARY_LABEL = 'Primary Score';
+
+export function primaryMetricLabel(label?: string | null): string {
+  return label?.trim() || DEFAULT_PRIMARY_LABEL;
+}
+
+export function metricPointValue(metric?: MetricPoint | null): number | null {
+  if (!metric) return null;
+  return metric.primaryMetric ?? metric.accuracy ?? null;
+}
+
+export function iterationMetricValue(iteration?: Iteration | null): number | null {
+  if (!iteration) return null;
+  return iteration.primaryMetric ?? iteration.f1 ?? null;
+}
+
+export function shortMetricLabel(label?: string | null): string {
+  const normalized = primaryMetricLabel(label);
+  if (normalized.toLowerCase().includes('primary')) return 'Score';
+  if (normalized.toLowerCase().includes('accuracy')) return 'Accuracy';
+  return normalized;
+}
+
+export function formatPrimaryMetric(value: number | null | undefined, label?: string | null): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return '—';
+  const normalized = primaryMetricLabel(label).toLowerCase();
+  if (normalized.includes('accuracy')) {
+    return `${(value * 100).toFixed(1)}%`;
+  }
+  return value.toFixed(3);
+}
+

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -198,18 +198,54 @@ def _fail_current_stage(record: _RunRecord, message: str) -> None:
     _append_log(record, "Manager", message, "error")
 
 
+def _primary_metric_value_and_label(
+    metrics: dict[str, Any],
+    *,
+    scalar: Any = None,
+) -> tuple[float, str]:
+    for key, label in (
+        ("accuracy", "Accuracy"),
+        ("f1", "F1"),
+        ("primary_metric", "Primary Score"),
+    ):
+        value = metrics.get(key)
+        if value is None:
+            continue
+        try:
+            score = float(value)
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(score):
+            return score, label
+
+    try:
+        score = float(scalar)
+    except (TypeError, ValueError):
+        return 0.0, "Primary Score"
+    return (score, "Primary Score") if math.isfinite(score) else (0.0, "Primary Score")
+
+
 def _metric_from_result(result: dict[str, Any]) -> MetricPoint | None:
     score = result.get("metrics") or {}
     metrics = score.get("metrics") or {}
-    scalar = float(score.get("scalar") or metrics.get("primary_metric") or 0.0)
+    primary_metric, primary_metric_label = _primary_metric_value_and_label(
+        metrics,
+        scalar=score.get("scalar"),
+    )
 
     loss = metrics.get("val_loss")
     if loss is None:
         loss = metrics.get("train_loss")
     if loss is None:
-        loss = max(0.0, 1.0 - scalar)
+        loss = max(0.0, 1.0 - primary_metric)
 
-    return MetricPoint(loss=float(loss), accuracy=scalar, iteration=1)
+    return MetricPoint(
+        loss=float(loss),
+        accuracy=primary_metric,
+        primaryMetric=primary_metric,
+        primaryMetricLabel=primary_metric_label,
+        iteration=1,
+    )
 
 
 def _iterations_from_diary(path: str | None) -> list[IterationView]:
@@ -234,6 +270,7 @@ def _iterations_from_diary(path: str | None) -> list[IterationView]:
         decision = row.get("decision") or "PENDING"
         if decision not in {"KEPT", "REVERTED", "PENDING"}:
             decision = "PENDING"
+        primary_metric, primary_metric_label = _primary_metric_value_and_label(metrics)
 
         iterations.append(
             IterationView(
@@ -241,7 +278,9 @@ def _iterations_from_diary(path: str | None) -> list[IterationView]:
                 experiment=str(row.get("hypothesis") or "AutoResearch iteration"),
                 diff=row.get("patch"),
                 loss=float(metrics.get("val_loss") or metrics.get("train_loss") or 0.0),
-                f1=float(metrics.get("primary_metric") or 0.0),
+                f1=primary_metric,
+                primaryMetric=primary_metric,
+                primaryMetricLabel=primary_metric_label,
                 status=decision,
             )
         )
@@ -345,15 +384,20 @@ def _latest_artifact_experiment_dir(record: _RunRecord) -> Path | None:
 
 def _metric_point(row: dict[str, Any], iteration: int) -> MetricPoint | None:
     loss = row.get("val_loss", row.get("train_loss"))
-    score = row.get("primary_metric")
+    primary_metric, primary_metric_label = _primary_metric_value_and_label(row)
     try:
         loss_value = float(loss)
-        score_value = float(score or 0.0)
     except (TypeError, ValueError):
         return None
     if not math.isfinite(loss_value):
         return None
-    return MetricPoint(loss=loss_value, accuracy=score_value, iteration=iteration)
+    return MetricPoint(
+        loss=loss_value,
+        accuracy=primary_metric,
+        primaryMetric=primary_metric,
+        primaryMetricLabel=primary_metric_label,
+        iteration=iteration,
+    )
 
 
 def _metrics_from_experiments(record: _RunRecord) -> list[MetricPoint]:

--- a/src/server/schemas.py
+++ b/src/server/schemas.py
@@ -28,6 +28,8 @@ class PipelineStage(BaseModel):
 class MetricPoint(BaseModel):
     loss: float
     accuracy: float
+    primaryMetric: float | None = None
+    primaryMetricLabel: str = "Primary Score"
     iteration: int
 
 
@@ -37,6 +39,8 @@ class IterationView(BaseModel):
     diff: str | None = None
     loss: float
     f1: float
+    primaryMetric: float | None = None
+    primaryMetricLabel: str = "Primary Score"
     status: Literal["KEPT", "REVERTED", "PENDING"]
 
 

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -197,7 +197,11 @@ def test_create_run_completes_with_manager_result(tmp_path, monkeypatch):
     assert state["dataPath"] is None
     assert state["metrics"][0]["loss"] == 0.29
     assert state["metrics"][0]["accuracy"] == 0.775
+    assert state["metrics"][0]["primaryMetric"] == 0.775
+    assert state["metrics"][0]["primaryMetricLabel"] == "Primary Score"
     assert state["iterations"][0]["status"] == "KEPT"
+    assert state["iterations"][0]["primaryMetric"] == 0.775
+    assert state["iterations"][0]["primaryMetricLabel"] == "Primary Score"
     assert state["result"]["weights_path"] == "outputs/experiments/run/model"
 
 


### PR DESCRIPTION
## Summary
- Adds explicit primaryMetric/primaryMetricLabel fields to server run metrics and AutoResearch iteration rows while preserving accuracy/f1 compatibility fields.
- Updates the frontend metric cards, chart, final results, cancelled artifacts, and simulation data to render the metric label supplied by the API instead of hardcoded Val Accuracy / Final F1 labels.
- Keeps real Accuracy/F1 labels when those are the actual simulated metrics, and uses Primary Score for Tinker SFT proxy scores derived from validation loss.

## Validation
- python3 -m compileall src/server/app.py src/server/schemas.py tests/test_server_api.py
- env -u ANTHROPIC_API_KEY -u TINKER_API_KEY -u TAVILY_API_KEY UV_NO_NETWORK=1 uv run --with pytest --with fastapi --with httpx --with anthropic --with langgraph python -m pytest tests/test_server_api.py -q
- npm run lint
- npm run build
- Browser smoke on http://127.0.0.1:5182/ with VITE_USE_SIMULATION=1: completed a simulated run; confirmed old hardcoded Val Accuracy string is absent and dynamic Accuracy/F1 labels render for the simulation path.

Stacked on #108.