### PR TITLE
[codex] surface run provenance in dashboard

### DIFF
--- a/ml-agent-frontend/src/components/Dashboard.tsx
+++ b/ml-agent-frontend/src/components/Dashboard.tsx
@@ -73,6 +73,82 @@ function StatusDot({ status }: { status: TrainingState['status'] }) {
   );
 }
 
+function titleCaseToken(value: string) {
+  return value
+    .replace(/[_-]+/g, ' ')
+    .replace(/\b\w/g, char => char.toUpperCase());
+}
+
+function spendModeLabel(value?: string | null) {
+  switch (value) {
+    case 'no_spend':
+      return 'NO_SPEND';
+    case 'dry_run':
+      return 'Dry-run';
+    case 'budget_skipped':
+      return 'Budget skipped';
+    case 'live':
+      return 'Live services';
+    case 'local':
+      return 'Local';
+    default:
+      return value ? titleCaseToken(value) : null;
+  }
+}
+
+function backendLabel(value?: string | null) {
+  const normalized = value?.replace('-', '_').toLowerCase();
+  if (normalized === 'dry_run') return 'Tinker dry-run';
+  if (normalized === 'tinker') return 'Live Tinker';
+  return value ? titleCaseToken(value) : null;
+}
+
+function ProvenanceBadges({ state }: { state: TrainingState }) {
+  const provenance = state.provenance;
+  if (!provenance) return null;
+
+  const badges = Array.from(new Set([
+    spendModeLabel(provenance.spendMode),
+    backendLabel(provenance.trainingBackend),
+    provenance.dataMode ? `Mode ${provenance.dataMode}` : null,
+    provenance.modeCFallback ? `${titleCaseToken(provenance.modeCFallback)} fallback` : null,
+    provenance.budgetPreflightSkipped ? 'Budget skipped' : null,
+    provenance.liveServices.length > 0 ? `Live: ${provenance.liveServices.join(', ')}` : null,
+  ].filter((label): label is string => Boolean(label))));
+
+  if (badges.length === 0) return null;
+
+  return (
+    <div
+      aria-label="Run provenance"
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '0.4rem',
+        marginTop: '-0.75rem',
+        marginBottom: '1.25rem',
+      }}
+    >
+      {badges.map(label => (
+        <span
+          key={label}
+          style={{
+            fontSize: '11px',
+            color: 'var(--text-secondary)',
+            background: 'var(--bg-elevated)',
+            border: '0.5px solid var(--border)',
+            borderRadius: '4px',
+            padding: '2px 8px',
+            lineHeight: 1.6,
+          }}
+        >
+          {label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
 function CancelledArtifacts({ state, onReset }: Props) {
   const lastMetric = state.metrics[state.metrics.length - 1];
   const bestIter = state.iterations.find(i => i.status === 'KEPT') ?? state.iterations[0];
@@ -333,6 +409,8 @@ export default function Dashboard({ state, onReset, onCancel }: Props) {
             {state.taskType}
           </span>
         </div>
+
+        <ProvenanceBadges state={state} />
 
         {/* Pipeline + budget */}
         <PipelineProgress stages={state.stages} costSpent={state.costSpent} budget={state.budget} />

--- a/ml-agent-frontend/src/components/Dashboard.tsx
+++ b/ml-agent-frontend/src/components/Dashboard.tsx
@@ -99,7 +99,7 @@ function spendModeLabel(value?: string | null) {
 function backendLabel(value?: string | null) {
   const normalized = value?.replace('-', '_').toLowerCase();
   if (normalized === 'dry_run') return 'Tinker dry-run';
-  if (normalized === 'tinker') return 'Live Tinker';
+  if (normalized === 'tinker' || normalized === 'tinker_sft') return 'Live Tinker';
   return value ? titleCaseToken(value) : null;
 }
 

--- a/ml-agent-frontend/src/hooks/useTrainingRun.ts
+++ b/ml-agent-frontend/src/hooks/useTrainingRun.ts
@@ -16,6 +16,7 @@ function makeInitialState(): TrainingState {
     logs: [],
     stages: [],
     artifacts: null,
+    provenance: null,
     result: null,
     error: null,
   };
@@ -47,6 +48,7 @@ function makeStartingState(
       { id: 5, label: 'Finalization', status: 'pending' },
     ],
     artifacts: null,
+    provenance: null,
     result: null,
     error: null,
   };
@@ -70,6 +72,7 @@ function stateFromBackend(next: BackendRunState): TrainingState {
     logs: next.logs,
     stages: next.stages,
     artifacts: next.artifacts ?? null,
+    provenance: next.provenance ?? null,
     result: next.result ?? null,
     error: next.error,
     runId: next.run_id,

--- a/ml-agent-frontend/src/hooks/useTrainingSimulation.ts
+++ b/ml-agent-frontend/src/hooks/useTrainingSimulation.ts
@@ -11,6 +11,16 @@ const STAGE_LABELS = [
 ];
 
 const STAGE_DURATIONS = [1200, 1800, 1500, 3000, 3000, 1200]; // ms
+const SIMULATION_PROVENANCE = {
+  spendMode: 'simulation',
+  trainingBackend: 'simulation',
+  dataMode: null,
+  modeCFallback: null,
+  budgetPreflightSkipped: false,
+  budgetSkipReason: null,
+  liveServices: [],
+  evidence: [],
+};
 
 function makeStages(): PipelineStage[] {
   return STAGE_LABELS.map((label, i) => ({ id: i, label, status: 'pending' as const }));
@@ -113,6 +123,7 @@ export function useTrainingSimulation() {
     stages: makeStages(),
     artifacts: null,
     result: null,
+    provenance: null,
   });
 
   const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
@@ -151,6 +162,7 @@ export function useTrainingSimulation() {
       stages: makeStages(),
       artifacts: null,
       result: null,
+      provenance: SIMULATION_PROVENANCE,
     });
 
     let cursor = 0; // ms elapsed
@@ -253,7 +265,7 @@ export function useTrainingSimulation() {
 
     // Mark complete
     schedule(() => {
-      setState(prev => ({ ...prev, status: 'complete', stage: 5 }));
+      setState(prev => ({ ...prev, status: 'complete', stage: 5, provenance: SIMULATION_PROVENANCE }));
     }, cursor + 100);
   }, [schedule, appendLog]);
 
@@ -273,6 +285,7 @@ export function useTrainingSimulation() {
       stages: makeStages(),
       artifacts: null,
       result: null,
+      provenance: null,
     });
   }, []);
 

--- a/ml-agent-frontend/src/types.ts
+++ b/ml-agent-frontend/src/types.ts
@@ -61,6 +61,17 @@ export interface RunArtifacts {
   files: ArtifactFile[];
 }
 
+export interface RunProvenance {
+  spendMode: string;
+  trainingBackend?: string | null;
+  dataMode?: string | null;
+  modeCFallback?: string | null;
+  budgetPreflightSkipped: boolean;
+  budgetSkipReason?: string | null;
+  liveServices: string[];
+  evidence: string[];
+}
+
 export interface TrainingState {
   status: RunStatus;
   stage: number;
@@ -74,6 +85,7 @@ export interface TrainingState {
   logs: LogEntry[];
   stages: PipelineStage[];
   artifacts?: RunArtifacts | null;
+  provenance?: RunProvenance | null;
   result?: Record<string, unknown> | null;
   error?: string | null;
   runId?: string;

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -36,6 +36,7 @@ from src.server.schemas import (
     MetricPoint,
     PipelineStage,
     RunArtifactsView,
+    RunProvenanceView,
     RunCreated,
     RunRequest,
     RunState,
@@ -471,6 +472,10 @@ def _read_json_if_exists(path: Path | None) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
+def _env_flag_enabled(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _resolve_reported_path(record: _RunRecord, value: Any) -> Path | None:
     if not isinstance(value, str) or not value.strip():
         return None
@@ -563,6 +568,125 @@ def _artifacts_from_result(record: _RunRecord, result: dict[str, Any]) -> RunArt
     )
 
 
+def _latest_tinker_manifest(record: _RunRecord) -> tuple[dict[str, Any] | None, Path | None]:
+    path = record.artifact_paths.get("manifest")
+    if path is None:
+        run_dir = _latest_artifact_experiment_dir(record) or _latest_experiment_dir(record)
+        path = run_dir / "manifest.json" if run_dir else None
+    return _read_json_if_exists(path), path
+
+
+def _latest_data_generator_debug(record: _RunRecord) -> tuple[dict[str, Any] | None, Path | None]:
+    latest = _read_json_if_exists(record.output_dir / "data_generator" / "latest_run.json")
+    if not latest:
+        return None, None
+
+    manifest_path = _resolve_reported_path(record, latest.get("manifest_path"))
+    manifest = _read_json_if_exists(manifest_path)
+    files = manifest.get("files", {}) if manifest else {}
+    debug_path = _resolve_reported_path(record, files.get("debug_context"))
+    return _read_json_if_exists(debug_path), debug_path
+
+
+def _training_backend_from_manifest(manifest: dict[str, Any] | None) -> str | None:
+    if not manifest:
+        return None
+    backend = manifest.get("backend") or manifest.get("training_backend")
+    if isinstance(backend, str) and backend.strip():
+        return backend.strip()
+
+    checkpoints = manifest.get("checkpoints")
+    if isinstance(checkpoints, dict):
+        values = [str(value) for value in checkpoints.values() if value]
+        if any(value.startswith("dry-run://") for value in values):
+            return "dry_run"
+        if any(value.startswith("tinker://") for value in values):
+            return "tinker"
+    return None
+
+
+def _data_format_meta(debug: dict[str, Any] | None) -> dict[str, Any]:
+    if not debug:
+        return {}
+    raw_data = debug.get("raw_data")
+    if not isinstance(raw_data, dict):
+        return {}
+    format_meta = raw_data.get("format_meta")
+    return format_meta if isinstance(format_meta, dict) else {}
+
+
+def _provenance_for_record(record: _RunRecord) -> RunProvenanceView:
+    manifest, manifest_path = _latest_tinker_manifest(record)
+    data_debug, data_debug_path = _latest_data_generator_debug(record)
+
+    training_backend = _training_backend_from_manifest(manifest)
+    data_mode = None
+    mode_c_fallback = None
+    if data_debug:
+        data_mode = data_debug.get("mode_used")
+        mode_c_fallback = data_debug.get("mode_c_fallback")
+        source_metadata = data_debug.get("source_metadata")
+        if mode_c_fallback is None and isinstance(source_metadata, dict):
+            mode_c_fallback = source_metadata.get("mode_c_fallback")
+
+    budget_preflight_skipped = bool(manifest and manifest.get("budget_preflight_skipped"))
+    cost = record.result.get("cost") if isinstance(record.result, dict) else None
+    manifest_cost = manifest.get("cost") if isinstance(manifest, dict) else None
+    budget_skip_reason = None
+    if isinstance(manifest_cost, dict):
+        budget_skip_reason = manifest_cost.get("termination_reason")
+    if not budget_skip_reason and isinstance(cost, dict):
+        budget_skip_reason = cost.get("termination_reason")
+    if budget_skip_reason != "budget_limit":
+        budget_skip_reason = None
+
+    no_spend = _env_flag_enabled("NO_SPEND")
+    backend_key = (training_backend or "").replace("-", "_").lower()
+    configured_backend = os.getenv("TINKER_BACKEND", "").strip().replace("-", "_").lower()
+
+    live_services: list[str] = []
+    if not no_spend and backend_key == "tinker":
+        live_services.append("Tinker")
+
+    format_meta = _data_format_meta(data_debug)
+    if not no_spend and format_meta.get("search_backend"):
+        live_services.append(str(format_meta["search_backend"]))
+    if not no_spend and format_meta.get("teacher_used"):
+        live_services.append("Teacher LLM")
+
+    evidence: list[str] = []
+    if _env_flag_enabled("NO_SPEND"):
+        evidence.append("env:NO_SPEND=1")
+    if configured_backend:
+        evidence.append(f"env:TINKER_BACKEND={configured_backend}")
+    if manifest_path and manifest_path.is_file():
+        evidence.append(str(manifest_path))
+    if data_debug_path and data_debug_path.is_file():
+        evidence.append(str(data_debug_path))
+
+    if no_spend:
+        spend_mode = "no_spend"
+    elif budget_preflight_skipped:
+        spend_mode = "budget_skipped"
+    elif backend_key == "dry_run" or configured_backend == "dry_run":
+        spend_mode = "dry_run"
+    elif live_services:
+        spend_mode = "live"
+    else:
+        spend_mode = "local"
+
+    return RunProvenanceView(
+        spendMode=spend_mode,
+        trainingBackend=training_backend,
+        dataMode=str(data_mode) if data_mode else None,
+        modeCFallback=str(mode_c_fallback) if mode_c_fallback else None,
+        budgetPreflightSkipped=budget_preflight_skipped,
+        budgetSkipReason=budget_skip_reason,
+        liveServices=list(dict.fromkeys(live_services)),
+        evidence=evidence,
+    )
+
+
 def _store_manager_result(record: _RunRecord, result: dict[str, Any]) -> None:
     record.result = result
     record.status = "complete"
@@ -629,6 +753,7 @@ def _to_state(record: _RunRecord) -> RunState:
         logs=record.logs,
         stages=record.stages,
         artifacts=record.artifacts,
+        provenance=_provenance_for_record(record),
         result=record.result,
         error=record.error,
     )

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -645,7 +645,7 @@ def _provenance_for_record(record: _RunRecord) -> RunProvenanceView:
     configured_backend = os.getenv("TINKER_BACKEND", "").strip().replace("-", "_").lower()
 
     live_services: list[str] = []
-    if not no_spend and backend_key == "tinker":
+    if not no_spend and backend_key in {"tinker", "tinker_sft"}:
         live_services.append("Tinker")
 
     format_meta = _data_format_meta(data_debug)

--- a/src/server/schemas.py
+++ b/src/server/schemas.py
@@ -69,6 +69,17 @@ class RunArtifactsView(BaseModel):
     files: list[ArtifactView] = Field(default_factory=list)
 
 
+class RunProvenanceView(BaseModel):
+    spendMode: str = "unknown"
+    trainingBackend: str | None = None
+    dataMode: str | None = None
+    modeCFallback: str | None = None
+    budgetPreflightSkipped: bool = False
+    budgetSkipReason: str | None = None
+    liveServices: list[str] = Field(default_factory=list)
+    evidence: list[str] = Field(default_factory=list)
+
+
 class RunState(BaseModel):
     run_id: str
     status: Literal["running", "cancelling", "cancelled", "complete", "failed"]
@@ -83,5 +94,6 @@ class RunState(BaseModel):
     logs: list[LogEntryView]
     stages: list[PipelineStage]
     artifacts: RunArtifactsView | None = None
+    provenance: RunProvenanceView = Field(default_factory=RunProvenanceView)
     result: dict[str, Any] | None = None
     error: str | None = None

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -25,21 +25,26 @@ def _write_tinker_artifacts(
     test_loss: float = 0.33,
     primary_metric: float = 0.775,
     sample_text: str = "sample completion",
+    backend: str | None = None,
+    budget_preflight_skipped: bool = False,
+    termination_reason: str | None = None,
 ) -> None:
     run_dir.mkdir(parents=True, exist_ok=True)
     checkpoints = {"state_path": state_path}
     if sampler_path:
         checkpoints["sampler_path"] = sampler_path
-    (run_dir / "manifest.json").write_text(
-        json.dumps(
-            {
-                "run_id": run_id,
-                "status": "COMPLETED",
-                "checkpoints": checkpoints,
-            }
-        ),
-        encoding="utf-8",
-    )
+    manifest = {
+        "run_id": run_id,
+        "status": "COMPLETED",
+        "checkpoints": checkpoints,
+    }
+    if backend:
+        manifest["backend"] = backend
+    if budget_preflight_skipped:
+        manifest["budget_preflight_skipped"] = True
+    if termination_reason:
+        manifest["cost"] = {"termination_reason": termination_reason}
+    (run_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
     (run_dir / "metrics.json").write_text(
         json.dumps(
             {
@@ -57,6 +62,50 @@ def _write_tinker_artifacts(
     )
     (run_dir / "sample.json").write_text(
         json.dumps({"text": sample_text}),
+        encoding="utf-8",
+    )
+
+
+def _write_data_generator_debug_artifacts(
+    root: Path,
+    *,
+    mode_used: str = "C",
+    mode_c_fallback: str | None = "synthetic",
+) -> None:
+    artifact_dir = root / "data_generator" / "artifacts"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    debug_path = artifact_dir / "debug_context.json"
+    manifest_path = artifact_dir / "artifact_manifest.json"
+    debug_path.write_text(
+        json.dumps(
+            {
+                "mode_used": mode_used,
+                "mode_c_fallback": mode_c_fallback,
+                "source_metadata": {
+                    "mode": mode_used,
+                    "mode_c_fallback": mode_c_fallback,
+                },
+                "raw_data": {
+                    "format_meta": {
+                        "mode_c_backend": "synthetic",
+                        "mode_c_fallback": mode_c_fallback,
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "mode_used": mode_used,
+                "files": {"debug_context": str(debug_path)},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (root / "data_generator" / "latest_run.json").write_text(
+        json.dumps({"mode_used": mode_used, "manifest_path": str(manifest_path)}),
         encoding="utf-8",
     )
 
@@ -234,6 +283,9 @@ def test_create_run_surfaces_artifacts_and_allowlisted_downloads(tmp_path, monke
     assert artifacts["checkpoints"]["state_path"] == "tinker://state/abc"
     assert artifacts["metrics"]["val_loss"] == 0.29
     assert artifacts["sample"]["text"] == "sample completion"
+    assert state["provenance"]["trainingBackend"] == "tinker"
+    assert state["provenance"]["spendMode"] == "live"
+    assert "Tinker" in state["provenance"]["liveServices"]
 
     files = {item["name"]: item for item in artifacts["files"]}
     assert files["manifest"]["exists"] is True
@@ -250,6 +302,54 @@ def test_create_run_surfaces_artifacts_and_allowlisted_downloads(tmp_path, monke
 
     missing_response = client.get(f"/api/runs/{run_id}/artifacts/not-real")
     assert missing_response.status_code == 404
+
+
+def test_run_state_surfaces_provenance_from_manifests(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def fake_invoke(prompt, budget, data_path=None):
+        root = get_output_root()
+        assert root is not None
+        run_dir = root / "experiments" / "dry-skip"
+        _write_tinker_artifacts(
+            run_dir,
+            run_id="dry-skip",
+            state_path="dry-run://state/abc",
+            backend="dry_run",
+            budget_preflight_skipped=True,
+            termination_reason="budget_limit",
+        )
+        _write_data_generator_debug_artifacts(root, mode_used="C", mode_c_fallback="synthetic")
+        result = _fake_model(root, total_cost=0.0)
+        result["weights_path"] = str(run_dir)
+        result["cost"]["termination_reason"] = "budget_limit"
+        return result
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune a dry-run support assistant",
+            "budget": 25,
+            "task_type": "fine-tuning",
+        },
+    )
+
+    assert response.status_code == 200
+    state = _wait_for_status(client, response.json()["run_id"], "complete")
+
+    provenance = state["provenance"]
+    assert provenance["spendMode"] == "budget_skipped"
+    assert provenance["trainingBackend"] == "dry_run"
+    assert provenance["dataMode"] == "C"
+    assert provenance["modeCFallback"] == "synthetic"
+    assert provenance["budgetPreflightSkipped"] is True
+    assert provenance["budgetSkipReason"] == "budget_limit"
+    assert provenance["liveServices"] == []
+    assert any(item.endswith("manifest.json") for item in provenance["evidence"])
+    assert any(item.endswith("debug_context.json") for item in provenance["evidence"])
 
 
 def test_running_run_refreshes_logs_iterations_metrics_and_artifacts(tmp_path, monkeypatch):

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -138,6 +138,7 @@ def _fake_model(tmp_path, *, total_cost=1.25, with_artifacts=False):
             run_id="tinker-run",
             state_path="tinker://state/abc",
             sampler_path="tinker://sampler/abc",
+            backend="tinker_sft",
         )
     return {
         "weights_path": weights_path,
@@ -283,7 +284,7 @@ def test_create_run_surfaces_artifacts_and_allowlisted_downloads(tmp_path, monke
     assert artifacts["checkpoints"]["state_path"] == "tinker://state/abc"
     assert artifacts["metrics"]["val_loss"] == 0.29
     assert artifacts["sample"]["text"] == "sample completion"
-    assert state["provenance"]["trainingBackend"] == "tinker"
+    assert state["provenance"]["trainingBackend"] == "tinker_sft"
     assert state["provenance"]["spendMode"] == "live"
     assert "Tinker" in state["provenance"]["liveServices"]
 


### PR DESCRIPTION
## Summary
- add typed API provenance for run spend mode, Tinker backend, DataGen mode/fallback, budget preflight skips, live-service evidence
- render compact provenance badges in the dashboard and keep simulation labeled honestly
- cover manifest/debug-derived provenance in server API tests

## Validation
- python3 -m compileall src/server/app.py src/server/schemas.py tests/test_server_api.py
- env -u ANTHROPIC_API_KEY -u TINKER_API_KEY -u TAVILY_API_KEY UV_NO_NETWORK=1 uv run --with pytest --with fastapi --with httpx --with anthropic --with langgraph python -m pytest tests/test_server_api.py -q
- npm run lint
- npm run build
- Browser smoke on VITE_USE_SIMULATION=1: run completes, provenance badge renders, no new console errors

## Stack
Stacked on #109 / codex/primary-score-ui so the dashboard labels primary scores and provenance together.