### PR TITLE
[codex] expose DataGen provenance artifacts

### DIFF
--- a/src/data_generator/artifacts.py
+++ b/src/data_generator/artifacts.py
@@ -81,13 +81,14 @@ def build_subagent2_handoff_payload(handoff: dict[str, Any]) -> dict[str, Any]:
 
 
 def _resolve_output_dir(handoff: dict[str, Any]) -> Path:
+    root = get_output_root()
+    if root is not None:
+        # API/background runs must keep evidence under the run root for safe downloads.
+        return root / "data_generator" / "artifacts"
+
     configured = os.getenv("DATA_GENERATOR_ARTIFACT_DIR", "").strip()
     if configured:
         return Path(configured)
-
-    root = get_output_root()
-    if root is not None:
-        return root / "data_generator" / "artifacts"
 
     root = Path("artifacts") / "data_generator"
     run_stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -60,6 +60,38 @@ ARTIFACT_DEFINITIONS = {
     "sample": ("Sample", "sample.json", "application/json"),
     "diary": ("Research Diary", None, "application/x-ndjson"),
 }
+DATA_GENERATOR_ARTIFACT_DEFINITIONS = {
+    "data_manifest": (
+        "Data Manifest",
+        "manifest",
+        "artifact_manifest.json",
+        "application/json",
+    ),
+    "data_handoff": (
+        "Data Handoff",
+        "handoff_payload",
+        "raw_handoff_data.json",
+        "application/json",
+    ),
+    "data_curation_report": (
+        "Data Curation Report",
+        "curation_human_readable",
+        "human_readable.md",
+        "text/markdown",
+    ),
+    "data_debug_context": (
+        "Data Debug Context",
+        "debug_context",
+        "debug_context.json",
+        "application/json",
+    ),
+    "data_source_report": (
+        "Data Source Report",
+        "source_human_readable",
+        "source_human_readable.md",
+        "text/markdown",
+    ),
+}
 
 
 app = FastAPI(title="Nemoral ML Agent API")
@@ -525,6 +557,79 @@ def _is_run_artifact_path(record: _RunRecord, path: Path | None) -> bool:
     return True
 
 
+def _is_run_artifact_dir(record: _RunRecord, path: Path | None) -> bool:
+    if path is None or not path.is_dir():
+        return False
+    try:
+        path.resolve().relative_to(record.output_dir.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def _path_is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve().relative_to(parent.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def _latest_data_generator_manifest(record: _RunRecord) -> tuple[dict[str, Any] | None, Path | None]:
+    latest = _read_json_if_exists(record.output_dir / "data_generator" / "latest_run.json")
+    if not latest:
+        return None, None
+
+    manifest_path = _resolve_reported_path(record, latest.get("manifest_path"))
+    if (
+        not _is_run_artifact_path(record, manifest_path)
+        or manifest_path is None
+        or manifest_path.name != "artifact_manifest.json"
+    ):
+        return None, None
+    return _read_json_if_exists(manifest_path), manifest_path
+
+
+def _data_generator_artifact_dir(
+    record: _RunRecord,
+    manifest: dict[str, Any],
+    manifest_path: Path,
+) -> Path | None:
+    artifact_dir = _resolve_reported_path(record, manifest.get("artifact_dir"))
+    if not _is_run_artifact_dir(record, artifact_dir):
+        artifact_dir = manifest_path.parent
+    return artifact_dir if _is_run_artifact_dir(record, artifact_dir) else None
+
+
+def _data_generator_artifact_paths(record: _RunRecord) -> dict[str, Path]:
+    manifest, manifest_path = _latest_data_generator_manifest(record)
+    if not manifest or manifest_path is None:
+        return {}
+
+    artifact_dir = _data_generator_artifact_dir(record, manifest, manifest_path)
+    if artifact_dir is None:
+        return {}
+
+    files = manifest.get("files")
+    files = files if isinstance(files, dict) else {}
+    paths: dict[str, Path] = {"data_manifest": manifest_path}
+
+    for name, (_, manifest_key, filename, _) in DATA_GENERATOR_ARTIFACT_DEFINITIONS.items():
+        if name == "data_manifest":
+            continue
+        reported = files.get(manifest_key)
+        path = _resolve_reported_path(record, reported) if reported else artifact_dir / filename
+        if (
+            _is_run_artifact_path(record, path)
+            and path is not None
+            and path.name == filename
+            and _path_is_within(path, artifact_dir)
+        ):
+            paths[name] = path
+
+    return paths
+
+
 def _artifacts_from_result(record: _RunRecord, result: dict[str, Any]) -> RunArtifactsView:
     model_path = _resolve_reported_path(record, result.get("weights_path"))
     diary_path = _resolve_reported_path(record, result.get("research_diary_path"))
@@ -552,6 +657,24 @@ def _artifacts_from_result(record: _RunRecord, result: dict[str, Any]) -> RunArt
             artifact_paths[name] = path
             artifact_content_types[name] = content_type
 
+    data_paths = _data_generator_artifact_paths(record)
+    if data_paths:
+        for name, (label, _, _, content_type) in DATA_GENERATOR_ARTIFACT_DEFINITIONS.items():
+            path = data_paths.get(name)
+            downloadable = _is_run_artifact_path(record, path)
+            view = _artifact_view(
+                run_id=record.run_id,
+                name=name,
+                label=label,
+                path=path,
+                content_type=content_type,
+                downloadable=downloadable,
+            )
+            files.append(view)
+            if downloadable and path is not None:
+                artifact_paths[name] = path
+                artifact_content_types[name] = content_type
+
     manifest = _read_json_if_exists(artifact_paths.get("manifest"))
     checkpoints = manifest.get("checkpoints", {}) if manifest else {}
     metrics = _read_json_if_exists(artifact_paths.get("metrics"))
@@ -577,14 +700,9 @@ def _latest_tinker_manifest(record: _RunRecord) -> tuple[dict[str, Any] | None, 
 
 
 def _latest_data_generator_debug(record: _RunRecord) -> tuple[dict[str, Any] | None, Path | None]:
-    latest = _read_json_if_exists(record.output_dir / "data_generator" / "latest_run.json")
-    if not latest:
+    debug_path = _data_generator_artifact_paths(record).get("data_debug_context")
+    if debug_path is None:
         return None, None
-
-    manifest_path = _resolve_reported_path(record, latest.get("manifest_path"))
-    manifest = _read_json_if_exists(manifest_path)
-    files = manifest.get("files", {}) if manifest else {}
-    debug_path = _resolve_reported_path(record, files.get("debug_context"))
     return _read_json_if_exists(debug_path), debug_path
 
 
@@ -813,7 +931,10 @@ def get_run_artifact(run_id: str, artifact_name: str) -> FileResponse:
         record = _RUNS.get(run_id)
         if record is None:
             raise HTTPException(status_code=404, detail="run not found")
-        if artifact_name not in ARTIFACT_DEFINITIONS:
+        if (
+            artifact_name not in ARTIFACT_DEFINITIONS
+            and artifact_name not in DATA_GENERATOR_ARTIFACT_DEFINITIONS
+        ):
             raise HTTPException(status_code=404, detail="artifact not found")
         _refresh_record_from_files(record)
         path = record.artifact_paths.get(artifact_name)

--- a/tests/data_generator/test_deployment_style_handoff_artifacts.py
+++ b/tests/data_generator/test_deployment_style_handoff_artifacts.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from src.data_generator.artifacts import save_subagent2_artifacts
 from src.data_generator.graph import invoke_data_generator_graph
+from src.runtime_context import output_root
 
 
 def _base_config() -> dict:
@@ -201,3 +202,26 @@ def test_default_artifact_saving_uses_unique_run_directories(monkeypatch, tmp_pa
     assert latest_pointer.exists()
     latest = json.loads(latest_pointer.read_text(encoding="utf-8"))
     assert latest["artifact_dir"] == str(second_dir)
+
+
+def test_run_scoped_output_root_overrides_global_artifact_dir(monkeypatch, tmp_path: Path):
+    external_dir = tmp_path / "external-data-generator-artifacts"
+    run_root = tmp_path / "api-run-root"
+    monkeypatch.setenv("DATA_GENERATOR_ARTIFACT_DIR", str(external_dir))
+
+    handoff = {
+        "target_subagent": "data_curation",
+        "action": "structure_data",
+        "mode_used": "C",
+        "curation_payload": {"record_count": 1},
+        "curation_human_readable": "Sub-Agent 2 Curation Input\nRecord count: 1",
+    }
+
+    with output_root(run_root):
+        saved = save_subagent2_artifacts(handoff)
+
+    manifest_path = Path(saved["manifest"])
+    assert manifest_path == run_root / "data_generator" / "artifacts" / "artifact_manifest.json"
+    assert manifest_path.exists()
+    assert (run_root / "data_generator" / "latest_run.json").exists()
+    assert not external_dir.exists()

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -76,6 +76,22 @@ def _write_data_generator_debug_artifacts(
     artifact_dir.mkdir(parents=True, exist_ok=True)
     debug_path = artifact_dir / "debug_context.json"
     manifest_path = artifact_dir / "artifact_manifest.json"
+    handoff_path = artifact_dir / "raw_handoff_data.json"
+    report_path = artifact_dir / "human_readable.md"
+    source_report_path = artifact_dir / "source_human_readable.md"
+    handoff_path.write_text(
+        json.dumps(
+            {
+                "target_subagent": "data_curation",
+                "action": "curate_dataset",
+                "mode_used": mode_used,
+                "curation_payload": {"record_count": 1},
+            }
+        ),
+        encoding="utf-8",
+    )
+    report_path.write_text("# Curation report\n\n1 trainable row.\n", encoding="utf-8")
+    source_report_path.write_text("# Source report\n\nSynthetic fallback.\n", encoding="utf-8")
     debug_path.write_text(
         json.dumps(
             {
@@ -99,7 +115,13 @@ def _write_data_generator_debug_artifacts(
         json.dumps(
             {
                 "mode_used": mode_used,
-                "files": {"debug_context": str(debug_path)},
+                "artifact_dir": str(artifact_dir),
+                "files": {
+                    "handoff_payload": str(handoff_path),
+                    "curation_human_readable": str(report_path),
+                    "debug_context": str(debug_path),
+                    "source_human_readable": str(source_report_path),
+                },
             }
         ),
         encoding="utf-8",
@@ -351,6 +373,147 @@ def test_run_state_surfaces_provenance_from_manifests(tmp_path, monkeypatch):
     assert provenance["liveServices"] == []
     assert any(item.endswith("manifest.json") for item in provenance["evidence"])
     assert any(item.endswith("debug_context.json") for item in provenance["evidence"])
+
+    files = {item["name"]: item for item in state["artifacts"]["files"]}
+    assert files["data_manifest"]["exists"] is True
+    assert files["data_handoff"]["exists"] is True
+    assert files["data_curation_report"]["exists"] is True
+    assert files["data_debug_context"]["downloadPath"] == (
+        f"/runs/{response.json()['run_id']}/artifacts/data_debug_context"
+    )
+    debug_response = client.get(
+        f"/api/runs/{response.json()['run_id']}/artifacts/data_debug_context"
+    )
+    assert debug_response.status_code == 200
+    assert debug_response.json()["mode_used"] == "C"
+    source_report_response = client.get(
+        f"/api/runs/{response.json()['run_id']}/artifacts/data_source_report"
+    )
+    assert source_report_response.status_code == 200
+    assert "Synthetic fallback" in source_report_response.text
+
+
+def test_data_generator_artifact_downloads_are_allowlisted(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def fake_invoke(prompt, budget, data_path=None):
+        root = get_output_root()
+        assert root is not None
+        run_dir = root / "experiments" / "dry-run"
+        _write_tinker_artifacts(
+            run_dir,
+            run_id="dry-run",
+            state_path="dry-run://state/abc",
+            backend="dry_run",
+        )
+
+        secret = tmp_path / "secret.json"
+        secret.write_text('{"secret": true}\n', encoding="utf-8")
+        artifact_dir = root / "data_generator" / "artifacts"
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        manifest_path = artifact_dir / "artifact_manifest.json"
+        safe_debug_path = artifact_dir / "debug_context.json"
+        safe_debug_path.write_text('{"mode_used": "C"}\n', encoding="utf-8")
+        hidden_path = artifact_dir / "hidden.json"
+        hidden_path.write_text('{"hidden": true}\n', encoding="utf-8")
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    "mode_used": "C",
+                    "artifact_dir": str(artifact_dir),
+                    "files": {
+                        "debug_context": str(secret),
+                        "handoff_payload": str(hidden_path),
+                        "secret": str(hidden_path),
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        (root / "data_generator" / "latest_run.json").write_text(
+            json.dumps({"mode_used": "C", "manifest_path": str(manifest_path)}),
+            encoding="utf-8",
+        )
+
+        result = _fake_model(root, total_cost=0.0)
+        result["weights_path"] = str(run_dir)
+        return result
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune with guarded DataGen artifact downloads",
+            "budget": 25,
+            "task_type": "fine-tuning",
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    state = _wait_for_status(client, run_id, "complete")
+    files = {item["name"]: item for item in state["artifacts"]["files"]}
+
+    assert files["data_manifest"]["downloadPath"] == f"/runs/{run_id}/artifacts/data_manifest"
+    assert files["data_debug_context"]["exists"] is False
+    assert files["data_debug_context"]["downloadPath"] is None
+    assert files["data_handoff"]["exists"] is False
+    assert files["data_handoff"]["downloadPath"] is None
+    assert "secret" not in files
+    assert client.get(f"/api/runs/{run_id}/artifacts/data_manifest").status_code == 200
+    assert client.get(f"/api/runs/{run_id}/artifacts/data_debug_context").status_code == 404
+    assert client.get(f"/api/runs/{run_id}/artifacts/secret").status_code == 404
+
+
+def test_data_generator_manifest_path_must_stay_inside_run(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def fake_invoke(prompt, budget, data_path=None):
+        root = get_output_root()
+        assert root is not None
+        run_dir = root / "experiments" / "dry-run"
+        _write_tinker_artifacts(
+            run_dir,
+            run_id="dry-run",
+            state_path="dry-run://state/abc",
+            backend="dry_run",
+        )
+
+        external_manifest = tmp_path / "external_manifest.json"
+        external_manifest.write_text(
+            json.dumps({"files": {"debug_context": str(tmp_path / "secret.json")}}),
+            encoding="utf-8",
+        )
+        (root / "data_generator").mkdir(parents=True, exist_ok=True)
+        (root / "data_generator" / "latest_run.json").write_text(
+            json.dumps({"mode_used": "C", "manifest_path": str(external_manifest)}),
+            encoding="utf-8",
+        )
+
+        result = _fake_model(root, total_cost=0.0)
+        result["weights_path"] = str(run_dir)
+        return result
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune with an escaped DataGen manifest",
+            "budget": 25,
+            "task_type": "fine-tuning",
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    state = _wait_for_status(client, run_id, "complete")
+    files = {item["name"]: item for item in state["artifacts"]["files"]}
+    assert "data_manifest" not in files
+    assert client.get(f"/api/runs/{run_id}/artifacts/data_manifest").status_code == 404
 
 
 def test_running_run_refreshes_logs_iterations_metrics_and_artifacts(tmp_path, monkeypatch):

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -516,6 +516,72 @@ def test_data_generator_manifest_path_must_stay_inside_run(tmp_path, monkeypatch
     assert client.get(f"/api/runs/{run_id}/artifacts/data_manifest").status_code == 404
 
 
+def test_api_run_routes_data_generator_artifacts_under_run_root(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    external_dir = tmp_path / "external-data-generator-artifacts"
+    monkeypatch.setenv("DATA_GENERATOR_ARTIFACT_DIR", str(external_dir))
+
+    def fake_invoke(prompt, budget, data_path=None):
+        root = get_output_root()
+        assert root is not None
+        run_dir = root / "experiments" / "dry-run"
+        _write_tinker_artifacts(
+            run_dir,
+            run_id="dry-run",
+            state_path="dry-run://state/abc",
+            backend="dry_run",
+        )
+
+        from src.data_generator.artifacts import save_subagent2_artifacts
+
+        save_subagent2_artifacts(
+            {
+                "target_subagent": "data_curation",
+                "action": "structure_data",
+                "mode_used": "C",
+                "curation_payload": {
+                    "schema_version": "data_curation_input.v1",
+                    "record_count": 1,
+                    "records": [{"messages": [{"role": "user", "content": "Hi"}]}],
+                },
+                "curation_human_readable": "Sub-Agent 2 Curation Input\nRecord count: 1",
+                "human_readable": "Mode C source report",
+            }
+        )
+
+        result = _fake_model(root, total_cost=0.0)
+        result["weights_path"] = str(run_dir)
+        return result
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune while preserving DataGen evidence under run root",
+            "budget": 25,
+            "task_type": "fine-tuning",
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    state = _wait_for_status(client, run_id, "complete")
+    files = {item["name"]: item for item in state["artifacts"]["files"]}
+
+    assert not external_dir.exists()
+    assert files["data_manifest"]["exists"] is True
+    assert files["data_manifest"]["path"].endswith(
+        f"outputs/api-runs/{run_id}/data_generator/artifacts/artifact_manifest.json"
+    )
+    assert files["data_debug_context"]["downloadPath"] == (
+        f"/runs/{run_id}/artifacts/data_debug_context"
+    )
+    assert client.get(f"/api/runs/{run_id}/artifacts/data_manifest").status_code == 200
+    assert client.get(f"/api/runs/{run_id}/artifacts/data_debug_context").status_code == 200
+
+
 def test_running_run_refreshes_logs_iterations_metrics_and_artifacts(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     ready = threading.Event()


### PR DESCRIPTION
## Summary
- add a fixed DataGen artifact allowlist to API run artifacts
- expose DataGen manifest, raw handoff, curation report, debug context, and optional source report downloads when present
- validate manifest paths and individual file paths stay inside the run output and DataGen artifact directory before serving

## Validation
- python3 -m compileall src/server/app.py tests/test_server_api.py
- env -u ANTHROPIC_API_KEY -u TINKER_API_KEY -u TAVILY_API_KEY UV_NO_NETWORK=1 uv run --with pytest --with fastapi --with httpx --with anthropic --with langgraph python -m pytest tests/test_server_api.py -q

## Stack
Stacked on #110 / codex/frontend-run-provenance so the new provenance badges have downloadable DataGen evidence behind them.