### PR TITLE
[codex] mark terminal pipeline stages

### DIFF
--- a/ml-agent-frontend/src/components/Dashboard.tsx
+++ b/ml-agent-frontend/src/components/Dashboard.tsx
@@ -149,7 +149,9 @@ function ProvenanceBadges({ state }: { state: TrainingState }) {
   );
 }
 
-function CancelledArtifacts({ state, onReset }: Props) {
+function TerminalArtifacts({ state, onReset }: Props) {
+  const isFailed = state.status === 'failed';
+  const tone = isFailed ? 'var(--danger)' : 'var(--warning)';
   const lastMetric = state.metrics[state.metrics.length - 1];
   const bestIter = state.iterations.find(i => i.status === 'KEPT') ?? state.iterations[0];
   const artifactFiles = state.artifacts?.files.filter(file => file.exists) ?? [];
@@ -177,12 +179,12 @@ function CancelledArtifacts({ state, onReset }: Props) {
     <section
       style={{
         background: 'var(--bg-surface)',
-        border: '0.5px solid var(--warning)',
+        border: `0.5px solid ${tone}`,
         borderRadius: 'var(--radius)',
         padding: '1.5rem',
         marginBottom: '1.5rem',
       }}
-      aria-label="Cancelled run artifacts"
+      aria-label={isFailed ? 'Failed run artifacts' : 'Cancelled run artifacts'}
     >
       <div style={{ marginBottom: '1.25rem', textAlign: 'center' }}>
         <span style={{
@@ -192,17 +194,19 @@ function CancelledArtifacts({ state, onReset }: Props) {
           fontSize: '11px',
           fontWeight: 600,
           letterSpacing: '0.1em',
-          color: 'var(--warning)',
+          color: tone,
           background: 'var(--bg-elevated)',
-          border: '0.5px solid var(--warning)',
+          border: `0.5px solid ${tone}`,
           borderRadius: '4px',
           padding: '3px 10px',
           marginBottom: '0.75rem',
         }}>
-          CANCELLED RUN ARTIFACTS
+          {isFailed ? 'FAILED RUN ARTIFACTS' : 'CANCELLED RUN ARTIFACTS'}
         </span>
         <p style={{ fontSize: '13px', color: 'var(--text-secondary)', marginTop: '0.25rem' }}>
-          This run was cancelled before completion. The latest checkpoint metrics and downloadable files are still available.
+          {isFailed
+            ? 'This run failed before completion. Any checkpoint metrics and downloadable files produced before failure are still available.'
+            : 'This run was cancelled before completion. The latest checkpoint metrics and downloadable files are still available.'}
         </p>
       </div>
 
@@ -303,6 +307,7 @@ function CancelledArtifacts({ state, onReset }: Props) {
 export default function Dashboard({ state, onReset, onCancel }: Props) {
   const canCancel = state.status === 'running' || state.status === 'cancelling';
   const hasCancelledArtifacts = state.status === 'cancelled' && Boolean(state.artifacts);
+  const hasTerminalArtifacts = (state.status === 'cancelled' || state.status === 'failed') && Boolean(state.artifacts);
 
   return (
     <div style={{ minHeight: '100vh' }}>
@@ -478,7 +483,7 @@ export default function Dashboard({ state, onReset, onCancel }: Props) {
         {state.status === 'complete' && (
           <FinalResults state={state} onReset={onReset} />
         )}
-        {hasCancelledArtifacts && <CancelledArtifacts state={state} onReset={onReset} onCancel={onCancel} />}
+        {hasTerminalArtifacts && <TerminalArtifacts state={state} onReset={onReset} onCancel={onCancel} />}
       </main>
     </div>
   );

--- a/ml-agent-frontend/src/components/PipelineProgress.tsx
+++ b/ml-agent-frontend/src/components/PipelineProgress.tsx
@@ -34,6 +34,20 @@ function StageIcon({ status }: { status: PipelineStage['status'] }) {
       </span>
     );
   }
+  if (status === 'failed') {
+    return (
+      <span style={{ ...base, background: 'rgba(239, 68, 68, 0.12)', color: 'var(--danger)', border: '0.5px solid var(--danger)' }}>
+        !
+      </span>
+    );
+  }
+  if (status === 'cancelled') {
+    return (
+      <span style={{ ...base, background: 'rgba(245, 158, 11, 0.12)', color: 'var(--warning)', border: '0.5px solid var(--warning)' }}>
+        x
+      </span>
+    );
+  }
   return (
     <span style={{ ...base, background: 'transparent', color: 'var(--text-muted)', border: '0.5px solid var(--border)' }}>
       ○
@@ -44,6 +58,13 @@ function StageIcon({ status }: { status: PipelineStage['status'] }) {
 export default function PipelineProgress({ stages, costSpent, budget }: Props) {
   const pct = budget > 0 ? Math.min((costSpent / budget) * 100, 100) : 0;
   const barColor = pct >= 70 ? 'var(--danger)' : pct >= 50 ? 'var(--warning)' : 'var(--accent)';
+  const stageColor = (status: PipelineStage['status']) => {
+    if (status === 'in-progress') return 'var(--accent)';
+    if (status === 'failed') return 'var(--danger)';
+    if (status === 'cancelled') return 'var(--warning)';
+    if (status === 'complete') return 'var(--text-secondary)';
+    return 'var(--text-muted)';
+  };
 
   return (
     <section style={{ marginBottom: '1.5rem' }}>
@@ -79,7 +100,7 @@ export default function PipelineProgress({ stages, costSpent, budget }: Props) {
               <span
                 style={{
                   fontSize: '11px',
-                  color: stage.status === 'in-progress' ? 'var(--accent)' : stage.status === 'complete' ? 'var(--text-secondary)' : 'var(--text-muted)',
+                  color: stageColor(stage.status),
                   textAlign: 'center',
                   whiteSpace: 'nowrap',
                   transition: 'color 0.3s',

--- a/ml-agent-frontend/src/hooks/useTrainingRun.ts
+++ b/ml-agent-frontend/src/hooks/useTrainingRun.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { cancelRun, createRun, getRun, type BackendRunState } from '../api/runs';
-import type { StartTraining, TaskType, TrainingState } from '../types';
+import type { PipelineStage, StartTraining, StageStatus, TaskType, TrainingState } from '../types';
 
 function makeInitialState(): TrainingState {
   return {
@@ -58,8 +58,47 @@ function isTerminalStatus(status: TrainingState['status']) {
   return status === 'complete' || status === 'failed' || status === 'cancelled';
 }
 
-function stateFromBackend(next: BackendRunState): TrainingState {
+function terminalStageStatus(status: TrainingState['status']): Extract<StageStatus, 'failed' | 'cancelled'> | null {
+  if (status === 'failed' || status === 'cancelled') return status;
+  return null;
+}
+
+function terminalStageIndex(stages: PipelineStage[], stage: number): number {
+  if (stages.length === 0) return -1;
+
+  const activeStage = stages.findIndex(item => item.status === 'in-progress');
+  if (activeStage >= 0) return activeStage;
+
+  return Math.max(0, Math.min(stage, stages.length - 1));
+}
+
+function markTerminalStage(
+  stages: PipelineStage[],
+  stage: number,
+  status: Extract<StageStatus, 'failed' | 'cancelled'>
+): PipelineStage[] {
+  const activeStage = terminalStageIndex(stages, stage);
+  if (activeStage < 0) return stages;
+
+  return stages.map((item, index) => {
+    if (index < activeStage) return { ...item, status: 'complete' };
+    if (index === activeStage) return { ...item, status };
+    return { ...item, status: 'pending' };
+  });
+}
+
+function withTerminalStages(state: TrainingState): TrainingState {
+  const status = terminalStageStatus(state.status);
+  if (!status) return state;
+
   return {
+    ...state,
+    stages: markTerminalStage(state.stages, state.stage, status),
+  };
+}
+
+function stateFromBackend(next: BackendRunState): TrainingState {
+  return withTerminalStages({
     status: next.status,
     stage: next.stage,
     prompt: next.prompt,
@@ -76,7 +115,7 @@ function stateFromBackend(next: BackendRunState): TrainingState {
     result: next.result ?? null,
     error: next.error,
     runId: next.run_id,
-  };
+  });
 }
 
 export function useTrainingRun() {
@@ -121,7 +160,7 @@ export function useTrainingRun() {
         void poll(created.run_id).catch((error: unknown) => {
           stopPolling();
           setState(prev => ({
-            ...prev,
+            ...withTerminalStages({ ...prev, status: 'failed' }),
             status: 'failed',
             error: error instanceof Error ? error.message : String(error),
           }));
@@ -129,7 +168,7 @@ export function useTrainingRun() {
       }, 2000);
     } catch (error) {
       setState(prev => ({
-        ...prev,
+        ...withTerminalStages({ ...prev, status: 'failed' }),
         status: 'failed',
         error: error instanceof Error ? error.message : String(error),
       }));
@@ -157,7 +196,7 @@ export function useTrainingRun() {
       }
     } catch (error) {
       setState(prev => ({
-        ...prev,
+        ...withTerminalStages({ ...prev, status: 'failed' }),
         status: 'failed',
         error: error instanceof Error ? error.message : String(error),
       }));

--- a/ml-agent-frontend/src/types.ts
+++ b/ml-agent-frontend/src/types.ts
@@ -1,4 +1,4 @@
-export type StageStatus = 'pending' | 'in-progress' | 'complete';
+export type StageStatus = 'pending' | 'in-progress' | 'complete' | 'failed' | 'cancelled';
 export type TaskType = 'classification' | 'regression' | 'fine-tuning';
 export type LogType = 'default' | 'success' | 'warning' | 'error';
 export type IterationStatus = 'KEPT' | 'REVERTED' | 'PENDING';

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -124,6 +124,7 @@ def _is_terminal(record: _RunRecord) -> bool:
 def _mark_cancelled(record: _RunRecord, message: str = "Run cancelled") -> None:
     record.status = "cancelled"
     record.error = None
+    _mark_current_stage_terminal(record, "cancelled")
     _append_log(record, "Manager", message, "warning")
 
 
@@ -193,9 +194,24 @@ def _complete_all_stages(record: _RunRecord) -> None:
     ]
 
 
+def _mark_current_stage_terminal(record: _RunRecord, status: str) -> None:
+    def stage_status(item: PipelineStage) -> str:
+        if item.id < record.stage:
+            return "complete"
+        if item.id == record.stage:
+            return status
+        return "pending"
+
+    record.stages = [
+        PipelineStage(id=item.id, label=item.label, status=stage_status(item))
+        for item in record.stages
+    ]
+
+
 def _fail_current_stage(record: _RunRecord, message: str) -> None:
     record.status = "failed"
     record.error = message
+    _mark_current_stage_terminal(record, "failed")
     _append_log(record, "Manager", message, "error")
 
 

--- a/src/server/schemas.py
+++ b/src/server/schemas.py
@@ -22,7 +22,7 @@ class RunCreated(BaseModel):
 class PipelineStage(BaseModel):
     id: int
     label: str
-    status: Literal["pending", "in-progress", "complete"]
+    status: Literal["pending", "in-progress", "complete", "failed", "cancelled"]
 
 
 class MetricPoint(BaseModel):

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -604,6 +604,7 @@ def test_cancel_running_run_stops_at_safe_boundary(tmp_path, monkeypatch):
     assert is_cancelled("server-active-job")
     state = _wait_for_status(client, run_id, "cancelled")
     assert state["status"] == "cancelled"
+    assert state["stages"][state["stage"]]["status"] == "cancelled"
     assert state["result"] is None
     assert any("cancel" in item["message"].lower() for item in state["logs"])
 
@@ -732,6 +733,7 @@ def test_create_run_surfaces_manager_failure(tmp_path, monkeypatch):
     assert response.status_code == 200
     state = _wait_for_status(client, response.json()["run_id"], "failed")
     assert "DataGen did not produce a trainable dataset" in state["error"]
+    assert state["stages"][state["stage"]]["status"] == "failed"
     assert state["logs"][0]["type"] == "error"
 
 


### PR DESCRIPTION
## Summary
- extend pipeline stage status values with `failed` and `cancelled`
- mark the active stage terminal when a run fails or is cancelled instead of leaving it in progress
- render failed/cancelled stage icons and colors in the dashboard

## Validation
- python3 -m compileall src/server/app.py src/server/schemas.py tests/test_server_api.py
- env -u ANTHROPIC_API_KEY -u TINKER_API_KEY -u TAVILY_API_KEY UV_NO_NETWORK=1 uv run --with pytest --with fastapi --with httpx --with anthropic --with langgraph python -m pytest tests/test_server_api.py -q
- npm ci
- npm run lint
- npm run build
- Browser smoke with VITE_USE_SIMULATION=1: pipeline renders and no new console errors appear

## Stack
Stacked on #110 / codex/frontend-run-provenance.