### PR TITLE
[codex] consolidated Tinker SFT core

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,7 @@ transformers>=4.40.0
 peft>=0.10.0
 torch>=2.2.0
 pytest>=8.0.0
+
+# Tinker SDK path
+tinker
+tinker-cookbook

--- a/src/runtime_context.py
+++ b/src/runtime_context.py
@@ -1,0 +1,86 @@
+"""Run-scoped runtime context for mutable output paths."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from pathlib import Path
+from threading import Event
+from typing import MutableSet
+
+_OUTPUT_ROOT: ContextVar[Path | None] = ContextVar("output_root", default=None)
+_CANCEL_EVENT: ContextVar[Event | None] = ContextVar("cancel_event", default=None)
+_ACTIVE_TINKER_JOBS: ContextVar[MutableSet[str] | None] = ContextVar(
+    "active_tinker_jobs",
+    default=None,
+)
+
+
+class RunCancelled(RuntimeError):
+    """Raised when a run has been cancelled by its caller."""
+
+
+def get_output_root() -> Path | None:
+    """Return the current run-scoped output root, if one is active."""
+    return _OUTPUT_ROOT.get()
+
+
+def cancellation_requested() -> bool:
+    """Return True when the active run has been asked to stop."""
+    event = _CANCEL_EVENT.get()
+    return bool(event and event.is_set())
+
+
+def raise_if_cancelled() -> None:
+    """Abort cooperatively when the active run has been cancelled."""
+    if cancellation_requested():
+        raise RunCancelled("Run cancelled by user")
+
+
+def resolve_output_path(default: str | Path, *run_parts: str) -> Path:
+    """Resolve a path under the active run root, otherwise return ``default``."""
+    root = get_output_root()
+    if root is None:
+        return Path(default)
+    return root.joinpath(*run_parts)
+
+
+@contextmanager
+def output_root(path: str | Path) -> Iterator[Path]:
+    """Temporarily route mutable outputs under ``path`` for this context."""
+    root = Path(path)
+    root.mkdir(parents=True, exist_ok=True)
+    token = _OUTPUT_ROOT.set(root)
+    try:
+        yield root
+    finally:
+        _OUTPUT_ROOT.reset(token)
+
+
+@contextmanager
+def cancellation_context(
+    cancel_event: Event | None,
+    active_tinker_jobs: MutableSet[str] | None = None,
+) -> Iterator[None]:
+    """Make a cancellation signal and active Tinker registry visible in this context."""
+    event_token = _CANCEL_EVENT.set(cancel_event)
+    jobs_token = _ACTIVE_TINKER_JOBS.set(active_tinker_jobs)
+    try:
+        yield
+    finally:
+        _ACTIVE_TINKER_JOBS.reset(jobs_token)
+        _CANCEL_EVENT.reset(event_token)
+
+
+@contextmanager
+def active_tinker_job(job_id: str) -> Iterator[None]:
+    """Register a Tinker job while it is running so callers can cancel it."""
+    jobs = _ACTIVE_TINKER_JOBS.get()
+    if jobs is not None:
+        jobs.add(job_id)
+    try:
+        yield
+    finally:
+        if jobs is not None:
+            jobs.discard(job_id)

--- a/src/tinker_api/__init__.py
+++ b/src/tinker_api/__init__.py
@@ -14,6 +14,15 @@ from .tinker_api import (
     cancel_job,
     is_cancelled,
 )
+from .sft_runner import (
+    DEFAULT_LIVE_SMOKE_STEPS,
+    DEFAULT_TINKER_MODEL,
+    SUPPORTED_TINKER_TUNABLES,
+    load_conversations,
+    record_to_conversation,
+    resolve_renderer_name,
+    run_tinker_sft_experiment,
+)
 
 __all__ = [
     "TinkerAPIError",
@@ -30,4 +39,11 @@ __all__ = [
     "get_cumulative_spend",
     "cancel_job",
     "is_cancelled",
+    "DEFAULT_LIVE_SMOKE_STEPS",
+    "DEFAULT_TINKER_MODEL",
+    "SUPPORTED_TINKER_TUNABLES",
+    "load_conversations",
+    "record_to_conversation",
+    "resolve_renderer_name",
+    "run_tinker_sft_experiment",
 ]

--- a/src/tinker_api/sft_runner.py
+++ b/src/tinker_api/sft_runner.py
@@ -1,0 +1,1029 @@
+"""
+SDK-native Tinker supervised fine-tuning runner.
+
+This module is intentionally lazy about importing ``tinker`` and
+``tinker_cookbook`` so the regular unit suite can run without live SDK
+dependencies installed. Set ``TINKER_BACKEND=dry_run`` or ``NO_SPEND=1`` to
+exercise the same chat/SFT JSONL artifact contract without importing or
+constructing live Tinker SDK clients.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Mapping, Sequence
+from uuid import uuid4
+
+from src.tinker_api.tinker_api import (
+    TinkerAPIError,
+    cancel_job,
+    get_cumulative_spend,
+    is_cancelled,
+    record_tokens,
+)
+from src.runtime_context import active_tinker_job, cancellation_requested
+from src.types import DatasetResult, ExperimentResult, TrainingMetrics
+
+if TYPE_CHECKING:
+    from src.autoresearch.config import TrainingConfig
+
+DEFAULT_TINKER_MODEL = "Qwen/Qwen3.5-9B"
+DEFAULT_LIVE_SMOKE_STEPS = 5
+TINKER_BACKEND_ENV = "TINKER_BACKEND"
+TINKER_DRY_RUN_BACKEND = "dry_run"
+NO_SPEND_ENV = "NO_SPEND"
+QWEN35_9B_RENDERER = "qwen3_5_disable_thinking"
+SUPPORTED_TINKER_TUNABLES: frozenset[str] = frozenset(
+    {"learning_rate", "batch_size", "max_seq_length", "lora_rank", "num_epochs"}
+)
+
+_INPUT_KEYS = ("input", "prompt", "question", "content")
+_TARGET_KEYS = ("output", "answer", "label", "target")
+_NONFINITE_LOSS_SENTINEL = 1_000_000_000.0
+
+
+@dataclass(frozen=True)
+class _ConversationSplits:
+    train: list[list[dict[str, str]]]
+    val: list[list[dict[str, str]]]
+    test: list[list[dict[str, str]]]
+
+
+def run_tinker_sft_experiment(
+    config: TrainingConfig | Mapping[str, Any],
+    dataset: DatasetResult | str | os.PathLike[str] | Sequence[Mapping[str, Any]],
+    *,
+    run_id: str | None = None,
+    max_steps: int | None = None,
+    output_dir: str = "outputs/experiments",
+    service_client: Any = None,
+) -> ExperimentResult:
+    """Run a short chat/SFT LoRA experiment through the Tinker SDK.
+
+    ``dataset`` may be a repo ``DatasetResult``, a JSONL path, or an in-memory
+    sequence of JSON-like records. Metrics and manifest artifacts are written
+    under ``output_dir/run_id``. Set ``TINKER_BACKEND=dry_run`` or
+    ``NO_SPEND=1`` to write the same artifact contract with deterministic
+    synthetic metrics and no live Tinker client construction.
+    """
+    cfg = _coerce_training_config(config)
+    run_name = run_id or f"tinker-sft-{int(time.time())}-{uuid4().hex[:8]}"
+    run_dir = Path(output_dir) / run_name
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    conversations = load_conversations(dataset)
+    if not conversations:
+        raise ValueError("No valid chat/SFT examples found for Tinker training.")
+
+    if _use_dry_run_backend():
+        return _run_dry_run_sft_experiment(
+            cfg=cfg,
+            dataset=dataset,
+            conversations=conversations,
+            run_name=run_name,
+            run_dir=run_dir,
+            max_steps=max_steps,
+        )
+
+    try:
+        tinker, tinker_types, model_info, renderers, supervised_data, tokenizer_utils = (
+            _load_tinker_deps()
+        )
+        model_name = cfg.model_name or DEFAULT_TINKER_MODEL
+        renderer_name = resolve_renderer_name(model_name, model_info)
+        tokenizer = tokenizer_utils.get_tokenizer(model_name)
+        renderer = renderers.get_renderer(renderer_name, tokenizer)
+        splits = _split_conversations(dataset, conversations)
+        training_conversations = _expand_assistant_training_targets(splits.train)
+        if not training_conversations:
+            raise ValueError("No assistant targets found after a user message.")
+
+        svc = service_client if service_client is not None else tinker.ServiceClient()
+        training_client = svc.create_lora_training_client(
+            base_model=model_name,
+            rank=int(cfg.lora_rank or 32),
+        )
+
+        train_on_what = renderers.TrainOnWhat.LAST_ASSISTANT_MESSAGE
+        target_steps = _resolve_target_steps(
+            num_examples=len(training_conversations),
+            batch_size=cfg.batch_size,
+            num_epochs=cfg.num_epochs,
+            max_steps=max_steps,
+        )
+        metrics_history: list[dict[str, Any]] = []
+        metrics_path = run_dir / "metrics.jsonl"
+        metrics_path.touch()
+        status = "COMPLETED"
+
+        with active_tinker_job(run_name):
+            for step in range(target_steps):
+                if _sync_cancellation(run_name):
+                    status = "CANCELLED"
+                    break
+
+                batch_conversations = _conversation_batch(
+                    training_conversations,
+                    cfg.batch_size,
+                    step,
+                )
+                batch = [
+                    supervised_data.conversation_to_datum(
+                        conversation,
+                        renderer,
+                        cfg.max_seq_length,
+                        train_on_what,
+                    )
+                    for conversation in batch_conversations
+                ]
+
+                adam_params = tinker_types.AdamParams(learning_rate=cfg.learning_rate)
+                fwd_future = training_client.forward_backward(batch, loss_fn="cross_entropy")
+                optim_future = training_client.optim_step(adam_params)
+                fwd_result = _future_result(fwd_future)
+                optim_result = _future_result(optim_future)
+
+                tokens = sum(_datum_token_count(datum) for datum in batch)
+                record_tokens(run_name, tokens)
+                raw_loss = _extract_loss(fwd_result, optim_result)
+                loss, nonfinite_loss = _loss_for_artifact(raw_loss)
+                step_metrics = {
+                    "step": step + 1,
+                    "train_loss": loss,
+                    "val_loss": loss,
+                    "test_loss": loss,
+                    "primary_metric": 0.0 if nonfinite_loss else _score_from_loss(loss),
+                    "tokens": tokens,
+                }
+                if nonfinite_loss:
+                    step_metrics["nonfinite_loss"] = True
+                    step_metrics["raw_loss"] = str(raw_loss)
+                    status = "FAILED"
+                metrics_history.append(step_metrics)
+                with open(metrics_path, "a") as fh:
+                    fh.write(json.dumps(step_metrics, allow_nan=False) + "\n")
+                if nonfinite_loss:
+                    break
+
+            if _sync_cancellation(run_name):
+                status = "CANCELLED"
+
+            if status == "CANCELLED":
+                checkpoints = _cancelled_checkpoints()
+                sample_payload = _cancelled_sample(conversations)
+                val_loss = None
+                test_loss = None
+            else:
+                checkpoints, sampling_client = _save_final_artifacts(training_client, run_name)
+                if _sync_cancellation(run_name):
+                    status = "CANCELLED"
+                    sample_payload = _cancelled_sample(conversations)
+                    val_loss = None
+                    test_loss = None
+                else:
+                    sample_payload = _sample_once(
+                        sampling_client=sampling_client,
+                        renderer=renderer,
+                        tinker_types=tinker_types,
+                        conversations=conversations,
+                    )
+                    if _sync_cancellation(run_name):
+                        status = "CANCELLED"
+                        val_loss = None
+                        test_loss = None
+                    else:
+                        val_loss = _evaluate_holdout_loss(
+                            training_client=training_client,
+                            conversations=splits.val,
+                            renderer=renderer,
+                            supervised_data=supervised_data,
+                            cfg=cfg,
+                            train_on_what=train_on_what,
+                        )
+                        if _sync_cancellation(run_name):
+                            status = "CANCELLED"
+                            test_loss = None
+                        else:
+                            test_loss = _evaluate_holdout_loss(
+                                training_client=training_client,
+                                conversations=splits.test,
+                                renderer=renderer,
+                                supervised_data=supervised_data,
+                                cfg=cfg,
+                                train_on_what=train_on_what,
+                            )
+        _write_json(run_dir / "sample.json", sample_payload)
+        final_metrics = _final_metrics(
+            metrics_history,
+            status,
+            val_loss=val_loss,
+            test_loss=test_loss,
+        )
+        manifest = {
+            "run_id": run_name,
+            "status": status,
+            "backend": "tinker_sft",
+            "model_name": model_name,
+            "renderer_name": renderer_name,
+            "train_on_what": str(train_on_what),
+            "dataset_path": _dataset_path_for_manifest(dataset),
+            "training_examples": len(training_conversations),
+            "split_examples": {
+                "train": len(splits.train),
+                "val": len(splits.val),
+                "test": len(splits.test),
+            },
+            "heldout_eval": {
+                "val_loss": val_loss,
+                "test_loss": test_loss,
+            },
+            "max_steps": max_steps,
+            "completed_steps": len(metrics_history),
+            "checkpoints": checkpoints,
+        }
+        _write_json(run_dir / "manifest.json", manifest)
+        _write_json(run_dir / "metrics.json", final_metrics)
+
+        return {
+            "job_id": run_name,
+            "status": status,
+            "metrics": final_metrics,
+            "model_path": str(run_dir),
+            "cost_usd": get_cumulative_spend(run_name),
+            "logs_path": str(metrics_path),
+        }
+    except Exception as exc:
+        if isinstance(exc, (TinkerAPIError, ValueError)):
+            raise
+        raise TinkerAPIError(str(exc)) from exc
+
+
+def load_conversations(
+    dataset: DatasetResult | str | os.PathLike[str] | Sequence[Mapping[str, Any]],
+) -> list[list[dict[str, str]]]:
+    """Load and normalize chat/SFT examples into message conversations."""
+    records = _load_records(dataset)
+    conversations: list[list[dict[str, str]]] = []
+    errors: list[str] = []
+    for index, record in enumerate(records):
+        try:
+            conversations.append(record_to_conversation(record))
+        except ValueError as exc:
+            errors.append(f"row {index}: {exc}")
+
+    if records and not conversations:
+        preview = "; ".join(errors[:3])
+        raise ValueError(f"No valid chat/SFT examples found. {preview}")
+    return conversations
+
+
+def record_to_conversation(record: Mapping[str, Any]) -> list[dict[str, str]]:
+    """Convert one JSON-like record into a user/assistant conversation."""
+    messages = record.get("messages")
+    if messages is not None:
+        if not isinstance(messages, list):
+            raise ValueError("messages must be a list")
+        normalized = [_normalize_message(message) for message in messages]
+        if not any(message["role"] == "user" for message in normalized):
+            raise ValueError("messages must contain at least one user message")
+        if not any(message["role"] == "assistant" for message in normalized):
+            raise ValueError("messages must contain at least one assistant message")
+        if not _has_assistant_target_after_user(normalized):
+            raise ValueError("messages must contain an assistant message after a user message")
+        return normalized
+
+    user_text = _first_text(record, _INPUT_KEYS)
+    assistant_text = _first_text(record, _TARGET_KEYS)
+    if not user_text:
+        raise ValueError(f"missing input field; expected one of {_INPUT_KEYS}")
+    if not assistant_text:
+        raise ValueError(f"missing target field; expected one of {_TARGET_KEYS}")
+    return [
+        {"role": "user", "content": user_text},
+        {"role": "assistant", "content": assistant_text},
+    ]
+
+
+def _expand_assistant_training_targets(
+    conversations: Sequence[Sequence[dict[str, str]]],
+) -> list[list[dict[str, str]]]:
+    """Split multi-assistant chats into one target per assistant response.
+
+    Cookbook renderers warn against ``ALL_ASSISTANT_MESSAGES`` for renderers
+    without the extension property. Training one prefix ending in the target
+    assistant message preserves all assistant targets while using the safer
+    ``LAST_ASSISTANT_MESSAGE`` mode.
+    """
+    targets: list[list[dict[str, str]]] = []
+    for conversation in conversations:
+        prefix: list[dict[str, str]] = []
+        seen_user = False
+        for message in conversation:
+            copied = {"role": message["role"], "content": message["content"]}
+            prefix.append(copied)
+            if copied["role"] == "user":
+                seen_user = True
+            if copied["role"] == "assistant" and seen_user:
+                targets.append(list(prefix))
+    return targets
+
+
+def _split_conversations(
+    dataset: DatasetResult | str | os.PathLike[str] | Sequence[Mapping[str, Any]],
+    conversations: list[list[dict[str, str]]],
+) -> _ConversationSplits:
+    if not conversations:
+        return _ConversationSplits(train=[], val=[], test=[])
+
+    if not isinstance(dataset, Mapping):
+        return _ConversationSplits(train=conversations, val=[], test=[])
+
+    dataset_meta = dataset.get("dataset")
+    if not isinstance(dataset_meta, Mapping):
+        return _ConversationSplits(train=conversations, val=[], test=[])
+
+    train_size = max(0, int(dataset_meta.get("train_size") or 0))
+    val_size = max(0, int(dataset_meta.get("val_size") or 0))
+    test_size = max(0, int(dataset_meta.get("test_size") or 0))
+    if train_size <= 0:
+        return _ConversationSplits(train=conversations, val=[], test=[])
+
+    train_end = min(train_size, len(conversations))
+    val_end = min(train_end + val_size, len(conversations))
+    test_end = min(val_end + test_size, len(conversations))
+    train = conversations[:train_end]
+    val = conversations[train_end:val_end]
+    test = conversations[val_end:test_end]
+    if not train:
+        train = conversations
+    return _ConversationSplits(train=train, val=val, test=test)
+
+
+def _has_assistant_target_after_user(messages: Sequence[Mapping[str, str]]) -> bool:
+    seen_user = False
+    for message in messages:
+        role = message["role"]
+        if role == "user":
+            seen_user = True
+        elif role == "assistant" and seen_user:
+            return True
+    return False
+
+
+def resolve_renderer_name(model_name: str, model_info_module: Any | None = None) -> str:
+    """Resolve cookbook renderer name, with an explicit Qwen3.5-9B fallback."""
+    if model_info_module is None:
+        _tinker, _types, model_info_module, _renderers, _supervised, _tokenizers = (
+            _load_tinker_deps()
+        )
+    try:
+        return model_info_module.get_recommended_renderer_name(model_name)
+    except Exception:
+        if model_name == DEFAULT_TINKER_MODEL:
+            return QWEN35_9B_RENDERER
+        raise
+
+
+def _coerce_training_config(config: TrainingConfig | Mapping[str, Any]) -> TrainingConfig:
+    from src.autoresearch.config import TrainingConfig
+
+    if isinstance(config, TrainingConfig):
+        data = config.to_dict()
+    else:
+        data = dict(config)
+
+    if not data.get("model_name"):
+        data["model_name"] = DEFAULT_TINKER_MODEL
+    if "max_seq_len" in data and "max_seq_length" not in data:
+        data["max_seq_length"] = data["max_seq_len"]
+    if "epochs" in data and "num_epochs" not in data:
+        data["num_epochs"] = data["epochs"]
+    return TrainingConfig.from_dict(data)
+
+
+def _load_records(
+    dataset: DatasetResult | str | os.PathLike[str] | Sequence[Mapping[str, Any]],
+) -> list[Mapping[str, Any]]:
+    if isinstance(dataset, (str, os.PathLike)):
+        return _read_jsonl_records(_resolve_jsonl_path(Path(dataset)))
+    if isinstance(dataset, Mapping):
+        dataset_meta = dataset.get("dataset")
+        if isinstance(dataset_meta, Mapping) and dataset_meta.get("path"):
+            return _read_jsonl_records(_resolve_jsonl_path(Path(str(dataset_meta["path"]))))
+        if dataset.get("path"):
+            return _read_jsonl_records(_resolve_jsonl_path(Path(str(dataset["path"]))))
+    return [record for record in dataset if isinstance(record, Mapping)]  # type: ignore[arg-type]
+
+
+def _resolve_jsonl_path(path: Path) -> Path:
+    if path.is_file():
+        return path
+    if path.is_dir():
+        for name in ("train.jsonl", "train_data.jsonl", "data.jsonl"):
+            candidate = path / name
+            if candidate.exists():
+                return candidate
+    raise ValueError(f"Could not find JSONL dataset at {path}")
+
+
+def _read_jsonl_records(path: Path) -> list[Mapping[str, Any]]:
+    records: list[Mapping[str, Any]] = []
+    with open(path) as fh:
+        for lineno, line in enumerate(fh, 1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                parsed = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}:{lineno}: invalid JSONL row") from exc
+            if not isinstance(parsed, Mapping):
+                raise ValueError(f"{path}:{lineno}: JSONL row must be an object")
+            records.append(parsed)
+    return records
+
+
+def _normalize_message(message: Any) -> dict[str, str]:
+    if not isinstance(message, Mapping):
+        raise ValueError("message entries must be objects")
+    role = str(message.get("role", "")).strip()
+    content = message.get("content")
+    if role not in {"system", "user", "assistant"}:
+        raise ValueError(f"unsupported message role {role!r}")
+    if content is None or str(content).strip() == "":
+        raise ValueError("message content cannot be empty")
+    return {"role": role, "content": str(content)}
+
+
+def _first_text(record: Mapping[str, Any], keys: Sequence[str]) -> str:
+    for key in keys:
+        value = record.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return ""
+
+
+def _load_tinker_deps() -> tuple[Any, Any, Any, Any, Any, Any]:
+    try:
+        import tinker
+        from tinker import types as tinker_types
+        from tinker_cookbook import model_info, renderers
+        from tinker_cookbook.supervised import data as supervised_data
+        from tinker_cookbook import tokenizer_utils
+    except ImportError as exc:
+        raise TinkerAPIError(
+            "tinker and tinker-cookbook are required for live Tinker SFT runs"
+        ) from exc
+    return tinker, tinker_types, model_info, renderers, supervised_data, tokenizer_utils
+
+
+def _sync_cancellation(run_name: str) -> bool:
+    if cancellation_requested():
+        cancel_job(run_name)
+    return is_cancelled(run_name)
+
+
+def _cancelled_checkpoints() -> dict[str, str]:
+    return {"skipped": "cancelled"}
+
+
+def _cancelled_sample(conversations: list[list[dict[str, str]]]) -> dict[str, Any]:
+    prompt_messages = [message for message in conversations[0] if message["role"] != "assistant"]
+    if not prompt_messages:
+        prompt_messages = [{"role": "user", "content": conversations[0][0]["content"]}]
+    return {
+        "prompt": prompt_messages,
+        "text": "",
+        "tokens": [],
+        "status": "CANCELLED",
+        "backend": "cancelled",
+    }
+
+
+def _use_dry_run_backend() -> bool:
+    if _env_flag_enabled(NO_SPEND_ENV):
+        return True
+    backend = os.getenv(TINKER_BACKEND_ENV, "").strip().lower().replace("-", "_")
+    return backend == TINKER_DRY_RUN_BACKEND
+
+
+def _env_flag_enabled(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _run_dry_run_sft_experiment(
+    *,
+    cfg: TrainingConfig,
+    dataset: DatasetResult | str | os.PathLike[str] | Sequence[Mapping[str, Any]],
+    conversations: list[list[dict[str, str]]],
+    run_name: str,
+    run_dir: Path,
+    max_steps: int | None,
+) -> ExperimentResult:
+    model_name = cfg.model_name or DEFAULT_TINKER_MODEL
+    splits = _split_conversations(dataset, conversations)
+    training_conversations = _expand_assistant_training_targets(splits.train)
+    if not training_conversations:
+        raise ValueError("No assistant targets found after a user message.")
+
+    metrics_history: list[dict[str, Any]] = []
+    metrics_path = run_dir / "metrics.jsonl"
+    metrics_path.touch()
+    status = "COMPLETED"
+    target_steps = _resolve_target_steps(
+        num_examples=len(training_conversations),
+        batch_size=cfg.batch_size,
+        num_epochs=cfg.num_epochs,
+        max_steps=max_steps,
+    )
+
+    with active_tinker_job(run_name):
+        for step in range(target_steps):
+            if _sync_cancellation(run_name):
+                status = "CANCELLED"
+                break
+
+            batch_conversations = _conversation_batch(
+                training_conversations,
+                cfg.batch_size,
+                step,
+            )
+            tokens = sum(_dry_run_token_count(conversation) for conversation in batch_conversations)
+            record_tokens(run_name, tokens)
+            loss = _dry_run_batch_loss(batch_conversations, step)
+            step_metrics = {
+                "step": step + 1,
+                "train_loss": loss,
+                "val_loss": loss,
+                "test_loss": loss,
+                "primary_metric": _score_from_loss(loss),
+                "tokens": tokens,
+            }
+            metrics_history.append(step_metrics)
+            with open(metrics_path, "a") as fh:
+                fh.write(json.dumps(step_metrics, allow_nan=False) + "\n")
+
+        if _sync_cancellation(run_name):
+            status = "CANCELLED"
+
+        val_loss = _dry_run_holdout_loss(splits.val)
+        test_loss = _dry_run_holdout_loss(splits.test)
+        final_metrics = _final_metrics(
+            metrics_history,
+            status,
+            val_loss=val_loss,
+            test_loss=test_loss,
+        )
+        checkpoints = {
+            "state_path": f"dry-run://state/{run_name}-final-state",
+            "sampler_path": f"dry-run://sampler/{run_name}-final-sampler",
+        }
+        manifest = {
+            "run_id": run_name,
+            "status": status,
+            "backend": TINKER_DRY_RUN_BACKEND,
+            "model_name": model_name,
+            "renderer_name": "dry_run_chat",
+            "train_on_what": "last_assistant_message",
+            "dataset_path": _dataset_path_for_manifest(dataset),
+            "training_examples": len(training_conversations),
+            "split_examples": {
+                "train": len(splits.train),
+                "val": len(splits.val),
+                "test": len(splits.test),
+            },
+            "heldout_eval": {
+                "val_loss": val_loss,
+                "test_loss": test_loss,
+            },
+            "max_steps": max_steps,
+            "completed_steps": len(metrics_history),
+            "checkpoints": checkpoints,
+        }
+        _write_json(run_dir / "sample.json", _dry_run_sample(conversations))
+        _write_json(run_dir / "manifest.json", manifest)
+        _write_json(run_dir / "metrics.json", final_metrics)
+
+    return {
+        "job_id": run_name,
+        "status": status,
+        "metrics": final_metrics,
+        "model_path": str(run_dir),
+        "cost_usd": get_cumulative_spend(run_name),
+        "logs_path": str(metrics_path),
+    }
+
+
+def _dry_run_batch_loss(
+    conversations: Sequence[Sequence[dict[str, str]]],
+    step: int,
+) -> float:
+    if not conversations:
+        return 0.0
+    base_loss = sum(_dry_run_conversation_loss(conversation) for conversation in conversations)
+    mean_loss = base_loss / len(conversations)
+    return max(0.000001, mean_loss / math.sqrt(step + 1))
+
+
+def _dry_run_holdout_loss(conversations: Sequence[Sequence[dict[str, str]]]) -> float | None:
+    targets = _expand_assistant_training_targets(conversations)
+    if not targets:
+        return None
+    return sum(_dry_run_conversation_loss(conversation) for conversation in targets) / len(targets)
+
+
+def _dry_run_conversation_loss(conversation: Sequence[dict[str, str]]) -> float:
+    assistant_chars = sum(
+        len(message["content"]) for message in conversation if message["role"] == "assistant"
+    )
+    context_chars = sum(
+        len(message["content"]) for message in conversation if message["role"] != "assistant"
+    )
+    turns = max(1, len(conversation))
+    loss = 0.35 + (assistant_chars % 101) / 200.0 + (context_chars % 67) / 335.0
+    loss += turns / 1000.0
+    return float(loss)
+
+
+def _dry_run_token_count(conversation: Sequence[dict[str, str]]) -> int:
+    total = 0
+    for message in conversation:
+        total += max(1, len(message["content"].split()))
+    return total
+
+
+def _dry_run_sample(conversations: list[list[dict[str, str]]]) -> dict[str, Any]:
+    prompt_messages = [message for message in conversations[0] if message["role"] != "assistant"]
+    if not prompt_messages:
+        prompt_messages = [{"role": "user", "content": conversations[0][0]["content"]}]
+
+    first_answer = next(
+        (
+            message["content"]
+            for message in conversations[0]
+            if message["role"] == "assistant"
+        ),
+        "",
+    )
+    return {
+        "prompt": prompt_messages,
+        "text": first_answer,
+        "tokens": [len(first_answer)],
+        "backend": TINKER_DRY_RUN_BACKEND,
+    }
+
+
+def _resolve_target_steps(
+    *,
+    num_examples: int,
+    batch_size: int,
+    num_epochs: int,
+    max_steps: int | None,
+) -> int:
+    if max_steps is not None:
+        return max(0, int(max_steps))
+    batches_per_epoch = max(1, math.ceil(num_examples / max(1, batch_size)))
+    return max(1, batches_per_epoch * max(1, int(num_epochs)))
+
+
+def _conversation_batch(
+    conversations: list[list[dict[str, str]]],
+    batch_size: int,
+    step: int,
+) -> list[list[dict[str, str]]]:
+    size = max(1, int(batch_size))
+    start = step * size
+    return [conversations[(start + offset) % len(conversations)] for offset in range(size)]
+
+
+def _evaluate_holdout_loss(
+    *,
+    training_client: Any,
+    conversations: list[list[dict[str, str]]],
+    renderer: Any,
+    supervised_data: Any,
+    cfg: TrainingConfig,
+    train_on_what: Any,
+) -> float | None:
+    holdout_targets = _expand_assistant_training_targets(conversations)
+    if not holdout_targets:
+        return None
+
+    forward = getattr(training_client, "forward", None)
+    if not callable(forward):
+        return None
+
+    batch_size = max(1, int(cfg.batch_size))
+    weighted_loss = 0.0
+    total_weight = 0.0
+    for start in range(0, len(holdout_targets), batch_size):
+        batch_targets = holdout_targets[start : start + batch_size]
+        batch = [
+            supervised_data.conversation_to_datum(
+                conversation,
+                renderer,
+                cfg.max_seq_length,
+                train_on_what,
+            )
+            for conversation in batch_targets
+        ]
+        result = _future_result(forward(batch, loss_fn="cross_entropy"))
+        loss, _nonfinite_loss = _loss_for_artifact(_extract_forward_loss(result, batch))
+        weight = _batch_loss_weight(batch)
+        weighted_loss += loss * weight
+        total_weight += weight
+
+    if total_weight <= 0:
+        return None
+    return weighted_loss / total_weight
+
+
+def _future_result(value: Any) -> Any:
+    result = getattr(value, "result", None)
+    if callable(result):
+        return result()
+    return value
+
+
+def _datum_token_count(datum: Any) -> int:
+    model_input = getattr(datum, "model_input", None)
+    if model_input is None:
+        return 0
+    length = getattr(model_input, "length", None)
+    if isinstance(length, int):
+        return length
+    tokens = getattr(model_input, "tokens", None)
+    if tokens is not None:
+        return len(tokens)
+    to_ints = getattr(model_input, "to_ints", None)
+    if callable(to_ints):
+        return len(to_ints())
+    return 0
+
+
+def _extract_loss(*results: Any) -> float:
+    for result in results:
+        loss = _loss_from_result_fields(result)
+        if loss is not None:
+            return loss
+    metric_keys = [
+        sorted(result.metrics.keys())
+        for result in results
+        if result is not None and isinstance(getattr(result, "metrics", None), Mapping)
+    ]
+    raise TinkerAPIError(
+        f"Tinker forward/backward result did not include a recognized loss metric: {metric_keys}"
+    )
+
+
+def _extract_forward_loss(result: Any, datums: Sequence[Any]) -> float:
+    direct_loss = _loss_from_result_fields(result)
+    if direct_loss is not None:
+        return direct_loss
+
+    outputs = _mapping_or_attr(result, "loss_fn_outputs")
+    if not outputs:
+        raise TinkerAPIError("Tinker forward result did not include loss_fn_outputs")
+
+    total_nll = 0.0
+    total_weight = 0.0
+    for datum, output in zip(datums, outputs):
+        logprobs = _to_float_sequence(_mapping_or_attr(output, "logprobs"))
+        weights = _to_float_sequence(_datum_loss_weights(datum))
+        if logprobs is None or weights is None:
+            continue
+        for logprob, weight in zip(logprobs, weights):
+            total_nll += -logprob * weight
+            total_weight += weight
+
+    if total_weight <= 0:
+        raise TinkerAPIError("Tinker forward result did not include weighted logprobs")
+    return total_nll / total_weight
+
+
+def _loss_from_result_fields(result: Any) -> float | None:
+    if result is None:
+        return None
+    loss = _mapping_or_attr(result, "loss")
+    if isinstance(loss, (int, float)):
+        return float(loss)
+    metrics = _mapping_or_attr(result, "metrics")
+    if isinstance(metrics, Mapping):
+        for key in (
+            "loss",
+            "loss:mean",
+            "mean_loss",
+            "train_loss",
+            "val_loss",
+            "test_loss",
+            "loss:sum",
+            "nll",
+        ):
+            value = metrics.get(key)
+            if isinstance(value, (int, float)):
+                return float(value)
+    return None
+
+
+def _mapping_or_attr(value: Any, key: str) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(key)
+    return getattr(value, key, None)
+
+
+def _to_float_sequence(value: Any) -> list[float] | None:
+    if value is None:
+        return None
+    tolist = getattr(value, "tolist", None)
+    if callable(tolist):
+        value = tolist()
+    else:
+        to_torch = getattr(value, "to_torch", None)
+        if callable(to_torch):
+            tensor = to_torch()
+            tensor_tolist = getattr(tensor, "tolist", None)
+            value = tensor_tolist() if callable(tensor_tolist) else tensor
+        elif hasattr(value, "data"):
+            value = getattr(value, "data")
+
+    if isinstance(value, (int, float)):
+        return [float(value)]
+    try:
+        return [float(item) for item in value]
+    except TypeError:
+        return None
+
+
+def _datum_loss_weights(datum: Any) -> Any:
+    inputs = getattr(datum, "loss_fn_inputs", None)
+    if isinstance(inputs, Mapping):
+        return inputs.get("weights")
+    if isinstance(datum, Mapping):
+        loss_inputs = datum.get("loss_fn_inputs")
+        if isinstance(loss_inputs, Mapping):
+            return loss_inputs.get("weights")
+    return None
+
+
+def _batch_loss_weight(datums: Sequence[Any]) -> float:
+    total = 0.0
+    for datum in datums:
+        weights = _to_float_sequence(_datum_loss_weights(datum))
+        if weights is not None:
+            total += sum(max(0.0, weight) for weight in weights)
+    return total if total > 0 else float(len(datums))
+
+
+def _score_from_loss(loss: float | None) -> float:
+    if loss is None or not math.isfinite(loss) or loss < 0:
+        return 0.0
+    return 1.0 / (1.0 + loss)
+
+
+def _loss_for_artifact(loss: float | None) -> tuple[float, bool]:
+    if loss is None:
+        return _NONFINITE_LOSS_SENTINEL, True
+    loss = float(loss)
+    if not math.isfinite(loss):
+        return _NONFINITE_LOSS_SENTINEL, True
+    return loss, False
+
+
+def _save_final_artifacts(training_client: Any, run_id: str) -> tuple[dict[str, str], Any]:
+    checkpoints: dict[str, str] = {}
+    state_result = _call_optional_checkpoint(training_client, "save_state", f"{run_id}-final-state")
+    if state_result:
+        checkpoints["state_path"] = state_result
+    sampler_result = _call_optional_checkpoint(
+        training_client,
+        "save_weights_for_sampler",
+        f"{run_id}-final-sampler",
+    )
+    if sampler_result:
+        checkpoints["sampler_path"] = sampler_result
+
+    get_sampling = getattr(training_client, "save_weights_and_get_sampling_client", None)
+    if not callable(get_sampling):
+        return checkpoints, None
+    try:
+        sampling_client = _future_result(get_sampling())
+    except TypeError:
+        sampling_client = _future_result(get_sampling(name=f"{run_id}-final-sampling-client"))
+    return checkpoints, sampling_client
+
+
+def _call_optional_checkpoint(training_client: Any, method_name: str, name: str) -> str | None:
+    method = getattr(training_client, method_name, None)
+    if not callable(method):
+        return None
+    result = _future_result(method(name=name))
+    path = getattr(result, "path", None)
+    if path is not None:
+        return str(path)
+    if isinstance(result, str):
+        return result
+    return None
+
+
+def _sample_once(
+    *,
+    sampling_client: Any,
+    renderer: Any,
+    tinker_types: Any,
+    conversations: list[list[dict[str, str]]],
+) -> dict[str, Any]:
+    prompt_messages = [message for message in conversations[0] if message["role"] != "assistant"]
+    if not prompt_messages:
+        prompt_messages = [{"role": "user", "content": conversations[0][0]["content"]}]
+
+    if sampling_client is None:
+        return {"prompt": prompt_messages, "text": "", "tokens": [], "error": "no sampling client"}
+
+    model_input = renderer.build_generation_prompt(prompt_messages)
+    sampling_params = tinker_types.SamplingParams(
+        max_tokens=64,
+        stop=renderer.get_stop_sequences(),
+    )
+    response = _future_result(
+        sampling_client.sample(
+            prompt=model_input,
+            num_samples=1,
+            sampling_params=sampling_params,
+        )
+    )
+    sequences = getattr(response, "sequences", None) or getattr(response, "samples", None) or []
+    if not sequences:
+        return {"prompt": prompt_messages, "text": "", "tokens": []}
+    tokens = list(getattr(sequences[0], "tokens", []))
+    try:
+        parsed, _termination = renderer.parse_response(tokens)
+        content = parsed.get("content", "") if isinstance(parsed, Mapping) else str(parsed)
+    except Exception:
+        content = ""
+    return {"prompt": prompt_messages, "text": content, "tokens": tokens}
+
+
+def _final_metrics(
+    metrics_history: list[dict[str, Any]],
+    status: str,
+    *,
+    val_loss: float | None = None,
+    test_loss: float | None = None,
+) -> TrainingMetrics:
+    if not metrics_history:
+        loss = _NONFINITE_LOSS_SENTINEL if status == "FAILED" else 0.0
+        resolved_val_loss = loss if val_loss is None else val_loss
+        resolved_test_loss = loss if test_loss is None else test_loss
+        resolved_val_loss, _ = _loss_for_artifact(resolved_val_loss)
+        resolved_test_loss, _ = _loss_for_artifact(resolved_test_loss)
+        return {
+            "train_loss": loss,
+            "val_loss": resolved_val_loss,
+            "test_loss": resolved_test_loss,
+            "primary_metric": _score_from_loss(resolved_val_loss),
+        }
+    train_loss, _ = _loss_for_artifact(_mean_metric(metrics_history, "train_loss"))
+    resolved_val_loss = (
+        _mean_metric(metrics_history, "val_loss") if val_loss is None else val_loss
+    )
+    resolved_test_loss = (
+        _mean_metric(metrics_history, "test_loss") if test_loss is None else test_loss
+    )
+    resolved_val_loss, _ = _loss_for_artifact(resolved_val_loss)
+    resolved_test_loss, _ = _loss_for_artifact(resolved_test_loss)
+    return {
+        "train_loss": train_loss,
+        "val_loss": resolved_val_loss,
+        "test_loss": resolved_test_loss,
+        "primary_metric": _score_from_loss(resolved_val_loss),
+    }
+
+
+def _mean_metric(metrics_history: list[dict[str, Any]], key: str) -> float:
+    values = [float(step[key]) for step in metrics_history]
+    return sum(values) / len(values)
+
+
+def _dataset_path_for_manifest(
+    dataset: DatasetResult | str | os.PathLike[str] | Sequence[Mapping[str, Any]],
+) -> str | None:
+    if isinstance(dataset, (str, os.PathLike)):
+        return str(dataset)
+    if isinstance(dataset, Mapping):
+        dataset_meta = dataset.get("dataset")
+        if isinstance(dataset_meta, Mapping) and dataset_meta.get("path"):
+            return str(dataset_meta["path"])
+        if dataset.get("path"):
+            return str(dataset["path"])
+    return None
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as fh:
+        json.dump(payload, fh, indent=2, allow_nan=False)

--- a/src/tinker_api/tinker_api.py
+++ b/src/tinker_api/tinker_api.py
@@ -14,16 +14,13 @@ Reference: https://docs.tinkerlabs.ai/sdk
 
 from __future__ import annotations
 
+import importlib
+import os
 from typing import Any
 
-try:
-    import tinker                        # pip install tinker
-    from tinker import types as tinker_types
-    _TINKER_AVAILABLE = True
-except ImportError:                      # graceful degradation in test / CI envs
-    tinker = None          # type: ignore[assignment]
-    tinker_types = None    # type: ignore[assignment]
-    _TINKER_AVAILABLE = False
+tinker: Any | None = None
+tinker_types: Any | None = None
+_TINKER_AVAILABLE: bool | None = None
 
 # ── Pricing constant ───────────────────────────────────────────────────────────
 _COST_PER_MILLION_TOKENS: float = 0.40   # USD
@@ -47,9 +44,45 @@ class TinkerAPIError(Exception):
 
 
 def _require_tinker() -> None:
-    if not _TINKER_AVAILABLE:
+    global tinker, tinker_types, _TINKER_AVAILABLE
+    if _TINKER_AVAILABLE is True:
+        return
+    if _TINKER_AVAILABLE is False:
         raise TinkerAPIError(
             "tinker package not installed — run: pip install tinker",
+            status_code=0,
+        )
+    try:
+        tinker = importlib.import_module("tinker")
+        tinker_types = importlib.import_module("tinker.types")
+        _TINKER_AVAILABLE = True
+    except ImportError as exc:           # graceful degradation in test / CI envs
+        tinker = None
+        tinker_types = None
+        _TINKER_AVAILABLE = False
+        raise TinkerAPIError(
+            "tinker package not installed — run: pip install tinker",
+            status_code=0,
+        ) from exc
+
+
+def _env_flag_enabled(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _live_tinker_block_reason() -> str | None:
+    if _env_flag_enabled("NO_SPEND"):
+        return "NO_SPEND=1"
+    if os.getenv("TINKER_BACKEND", "").strip().lower().replace("-", "_") == "dry_run":
+        return "TINKER_BACKEND=dry_run"
+    return None
+
+
+def _require_live_tinker_allowed(operation: str) -> None:
+    reason = _live_tinker_block_reason()
+    if reason:
+        raise TinkerAPIError(
+            f"{operation} is blocked because live Tinker API calls are disabled by {reason}",
             status_code=0,
         )
 
@@ -61,6 +94,7 @@ def create_service_client() -> Any:
 
     Reads TINKER_API_KEY from the environment automatically.
     """
+    _require_live_tinker_allowed("create_service_client")
     _require_tinker()
     try:
         return tinker.ServiceClient()
@@ -77,6 +111,7 @@ def create_lora_training_client(
 
     Returns a client with forward_backward / optim_step / save_weights methods.
     """
+    _require_live_tinker_allowed("create_lora_training_client")
     _require_tinker()
     try:
         return service_client.create_lora_training_client(
@@ -91,6 +126,7 @@ def create_lora_training_client(
 
 def get_tokenizer(training_client: Any) -> Any:
     """Returns the tokeniser for the training client's base model."""
+    _require_live_tinker_allowed("get_tokenizer")
     return training_client.get_tokenizer()
 
 
@@ -105,6 +141,7 @@ def make_datum(
     input  = input_tokens[:-1]
     target = input_tokens[1:]
     """
+    _require_live_tinker_allowed("make_datum")
     _require_tinker()
     if target_tokens is None:
         target_tokens = input_tokens[1:]
@@ -130,6 +167,7 @@ def run_training_step(
     Optionally records token usage to the ledger under *job_id*.
     Returns ``{"tokens_processed": int, "loss": float | None}``.
     """
+    _require_live_tinker_allowed("run_training_step")
     _require_tinker()
     try:
         fwdbwd_result = training_client.forward_backward(
@@ -165,6 +203,7 @@ def run_training_loop(
     Saves a final checkpoint when done or cancelled.
     Returns ``{"steps": int, "tokens": int, "cancelled": bool}``.
     """
+    _require_live_tinker_allowed("run_training_loop")
     steps = 0
     total_tokens = 0
     cancelled = False
@@ -193,6 +232,7 @@ def run_training_loop(
 
 def save_checkpoint(training_client: Any, name: str) -> Any:
     """Saves weights and returns a SamplingClient for inference against this checkpoint."""
+    _require_live_tinker_allowed("save_checkpoint")
     _require_tinker()
     try:
         return training_client.save_weights_and_get_sampling_client(name=name)
@@ -202,6 +242,7 @@ def save_checkpoint(training_client: Any, name: str) -> Any:
 
 def save_weights(training_client: Any, name: str) -> None:
     """Saves weights without returning a sampling client (fire-and-forget)."""
+    _require_live_tinker_allowed("save_weights")
     _require_tinker()
     try:
         training_client.save_weights_for_sampler(name=name)
@@ -220,6 +261,7 @@ def sample(
 
     Returns a list of token-id lists (one per sample).
     """
+    _require_live_tinker_allowed("sample")
     _require_tinker()
     try:
         model_input = tinker_types.ModelInput.from_ints(prompt_tokens)

--- a/src/types.py
+++ b/src/types.py
@@ -6,7 +6,7 @@ See spec-site/content/spec.ts for the canonical definitions.
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Any, NotRequired, TypedDict
 
 
 # ENUMS
@@ -138,7 +138,7 @@ class CostEstimate(TypedDict):
     confidence: str  # 'low' | 'medium' | 'high'
 
 
-class TrainingPlan(TypedDict):
+class _TrainingPlanRequired(TypedDict):
     strategy: str           # 'fine-tune' | 'pre-train'
     base_model: str | None
     lora_config: LoRAConfig | None
@@ -146,6 +146,13 @@ class TrainingPlan(TypedDict):
     estimated_time_min: int
     training_script_path: str
     eval_metric: str
+
+
+class TrainingPlan(_TrainingPlanRequired, total=False):
+    backend: str            # 'tinker_sft' for the SDK-native Tinker v1 path
+    dataset_path: str       # Local JSONL path consumed by the Tinker SFT runner
+    dataset: StandardDataset  # Aggregate dataset metadata, including split counts
+    estimated_run_cost_usd: float  # Optional per-AutoResearch-launch budget guard
 
 
 class EvalScore(TypedDict):
@@ -250,27 +257,39 @@ class ManagerState(TypedDict):
     budget: float
     data_path: str | None
     has_data: bool
+    interactive_data_prompt: NotRequired[bool]
+    task_type_hint: NotRequired[str | None]
     task_reasoning: TaskReasoning | None
     config: OrchestrationConfig | None
     result: TrainedModel | None
 
 
-class DataGenState(TypedDict):
+class DataGenState(TypedDict, total=False):
     config: OrchestrationConfig
     data_path: str | None
-    mode: str | None           # 'A' | 'B' | 'C'
+    mode: str | None
     raw_data: RawData | None
     hf_candidates: list[HFCandidate]
     selected_candidate: HFCandidate | None
-    schema: DataSchema | None
-    dataset: StandardDataset | None
-    validation_report: ValidationReport | None
+    schema: dict | None
+    dataset: dict | None
+    validation_report: dict | None
     handoff: dict | None
+
+    # Mode C web acquisition fields
+    web_plan: dict | None
+    web_search_results: list[dict]
+    web_pages: list[dict]
+    human_readable: str | None
+    mode_c_fallback: str | None
+    mode_c_backend: str | None
+    web_acquisition_error: str | None
 
 
 class AutoResearchState(TypedDict):
     plan: TrainingPlan
     config: OrchestrationConfig
+    cost_manager: Any
     eval_suite: EvalSuite | None
     current_script: str        # path to the training script (never mutated by PROPOSE)
     current_config: dict       # live hyperparams; updated by keep_node after each KEPT patch
@@ -279,6 +298,7 @@ class AutoResearchState(TypedDict):
     original_content: str | None
     diary: ResearchDiary
     baseline_score: EvalScore | None
+    baseline_result: ExperimentResult | None
     best_score: EvalScore | None
     best_script: str
     last_result: ExperimentResult | None

--- a/tests/integration/test_tinker_live_smoke.py
+++ b/tests/integration/test_tinker_live_smoke.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.autoresearch.config import TrainingConfig
+from src.tinker_api.sft_runner import (
+    DEFAULT_LIVE_SMOKE_STEPS,
+    DEFAULT_TINKER_MODEL,
+    run_tinker_sft_experiment,
+)
+
+
+def _env_truthy(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def test_live_tinker_chat_sft_smoke(tmp_path):
+    if _env_truthy("NO_SPEND"):
+        pytest.skip("NO_SPEND=1 disables live Tinker smoke tests")
+    if os.getenv("RUN_LIVE_TINKER") != "1":
+        pytest.skip("set RUN_LIVE_TINKER=1 to run the live Tinker smoke test")
+    if not os.getenv("TINKER_API_KEY"):
+        pytest.skip("TINKER_API_KEY is required for the live Tinker smoke test")
+
+    model = os.getenv("TINKER_SMOKE_MODEL", DEFAULT_TINKER_MODEL)
+    steps = int(os.getenv("TINKER_SMOKE_STEPS", str(DEFAULT_LIVE_SMOKE_STEPS)))
+    data_path = tmp_path / "train.jsonl"
+    rows = [
+        {"input": "Reply with the word alpha.", "output": "alpha"},
+        {"input": "Reply with the word beta.", "output": "beta"},
+        {"input": "Reply with the word gamma.", "output": "gamma"},
+        {"input": "Reply with the word delta.", "output": "delta"},
+        {"input": "Reply with the word epsilon.", "output": "epsilon"},
+    ]
+    data_path.write_text("".join(json.dumps(row) + "\n" for row in rows))
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(
+            model_name=model,
+            learning_rate=1e-4,
+            batch_size=1,
+            num_epochs=1,
+            max_seq_length=512,
+            lora_rank=8,
+        ),
+        str(data_path),
+        run_id="live-tinker-smoke",
+        max_steps=steps,
+        output_dir=str(tmp_path / "experiments"),
+    )
+
+    run_dir = tmp_path / "experiments" / "live-tinker-smoke"
+    assert result["status"] == "COMPLETED"
+    assert result["model_path"] == str(run_dir)
+    assert (run_dir / "metrics.json").exists()
+    assert (run_dir / "metrics.jsonl").exists()
+    assert (run_dir / "manifest.json").exists()
+    assert (run_dir / "sample.json").exists()
+    manifest = json.loads((run_dir / "manifest.json").read_text())
+    assert manifest["completed_steps"] == steps
+    assert manifest["checkpoints"]

--- a/tests/test_runtime_context.py
+++ b/tests/test_runtime_context.py
@@ -1,0 +1,119 @@
+"""Tests for run-scoped mutable output routing."""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+
+from src.autoresearch import autoresearch as ar
+from src.data_generator.curation import curate_handoff_to_dataset_result
+from src.decision_engine.decision_engine import write_finetune_script
+from src.manager.manager import build_orchestration_config, log_decision
+from src.runtime_context import (
+    RunCancelled,
+    active_tinker_job,
+    cancellation_context,
+    output_root,
+    raise_if_cancelled,
+)
+
+
+def test_output_root_routes_manager_datagen_decision_and_autoresearch(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    run_root = tmp_path / "runs" / "run-123"
+
+    config = build_orchestration_config(
+        {
+            "task_type": "text-classification",
+            "data_format": "jsonl",
+            "training_type": "SFT",
+            "suggested_base_model": None,
+            "hyperparameters": {
+                "learning_rate": 1e-4,
+                "batch_size": 2,
+                "epochs": 1,
+                "max_seq_len": 128,
+            },
+            "notes": "test",
+        },
+        "classify sentiment",
+        10.0,
+        False,
+    )
+
+    with output_root(run_root):
+        log_decision("build_config", "test rationale", config)
+        dataset = curate_handoff_to_dataset_result(
+            {
+                "mode_used": "B",
+                "raw_data": {
+                    "records": [
+                        {"input": "great", "output": "positive"},
+                        {"input": "bad", "output": "negative"},
+                        {"input": "ok", "output": "neutral"},
+                    ]
+                },
+            }
+        )
+        script_path = write_finetune_script(
+            "Qwen/Qwen3.5-9B",
+            dataset,
+            {
+                "rank": 8,
+                "alpha": 16,
+                "dropout": 0.05,
+                "target_modules": ["query", "value"],
+            },
+            config,
+        )
+        ar.log_iteration(
+            [],
+            {
+                "iteration": 1,
+                "hypothesis": "test",
+                "patch": "",
+                "cost_usd": 0.0,
+                "metrics": {
+                    "train_loss": 1.0,
+                    "val_loss": 1.0,
+                    "test_loss": 1.0,
+                    "primary_metric": 0.5,
+                },
+                "decision": "PENDING",
+                "notes": "",
+            },
+        )
+
+    assert (run_root / "decisions.jsonl").is_file()
+    assert Path(dataset["dataset"]["path"]) == run_root / "datasets" / "train_data.jsonl"
+    assert Path(script_path) == run_root / "scripts" / "train.py"
+    assert (run_root / "logs" / "research_diary.jsonl").is_file()
+
+    assert not Path("decisions.jsonl").exists()
+    assert not Path("outputs/datasets/train_data.jsonl").exists()
+    assert not Path("outputs/scripts/train.py").exists()
+
+    diary_line = (run_root / "logs" / "research_diary.jsonl").read_text().strip()
+    assert json.loads(diary_line)["decision"] == "PENDING"
+
+
+def test_cancellation_context_signals_and_tracks_active_tinker_jobs():
+    event = threading.Event()
+    jobs: set[str] = set()
+
+    with cancellation_context(event, jobs):
+        with active_tinker_job("job-123"):
+            assert jobs == {"job-123"}
+            event.set()
+            try:
+                raise_if_cancelled()
+            except RunCancelled as exc:
+                assert "cancelled" in str(exc)
+            else:
+                raise AssertionError("raise_if_cancelled should raise after cancellation")
+
+    assert jobs == set()

--- a/tests/test_tinker_api.py
+++ b/tests/test_tinker_api.py
@@ -4,11 +4,15 @@ All tests mock the `tinker` package so the suite runs without the SDK
 installed (CI / dev environments).
 """
 
+import builtins
 import sys
 import types as builtin_types
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+
+_MISSING = object()
 
 
 # ---------------------------------------------------------------------------
@@ -47,18 +51,45 @@ def _remove_tinker_mock():
 # ---------------------------------------------------------------------------
 
 @pytest.fixture(autouse=True)
-def fresh_tinker_state():
+def fresh_tinker_state(monkeypatch):
     """Each test gets a clean tinker mock and a fresh import of the wrapper module."""
+    monkeypatch.delenv("NO_SPEND", raising=False)
+    monkeypatch.delenv("TINKER_BACKEND", raising=False)
+
+    parent_package = sys.modules.get("src.tinker_api")
+    previous_package_attr = (
+        getattr(parent_package, "tinker_api", _MISSING)
+        if parent_package is not None
+        else _MISSING
+    )
+    previous_modules = {
+        name: sys.modules.get(name, _MISSING)
+        for name in ("tinker", "tinker.types", "src.tinker_api.tinker_api")
+    }
+
     tinker_mod, types_mod = _make_tinker_mock()
     _install_tinker_mock(tinker_mod, types_mod)
 
     # Force re-import so the module picks up the mocked tinker
     sys.modules.pop("src.tinker_api.tinker_api", None)
+    if parent_package is not None and hasattr(parent_package, "tinker_api"):
+        delattr(parent_package, "tinker_api")
 
     yield tinker_mod, types_mod
 
     _remove_tinker_mock()
     sys.modules.pop("src.tinker_api.tinker_api", None)
+    for name, module in previous_modules.items():
+        if module is _MISSING:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = module
+    if parent_package is not None:
+        if previous_package_attr is _MISSING:
+            if hasattr(parent_package, "tinker_api"):
+                delattr(parent_package, "tinker_api")
+        else:
+            setattr(parent_package, "tinker_api", previous_package_attr)
 
 
 def _api():
@@ -298,6 +329,147 @@ def test_save_weights_calls_save_for_sampler(fresh_tinker_state):
     tc = MagicMock()
     api.save_weights(tc, name="v1")
     tc.save_weights_for_sampler.assert_called_once_with(name="v1")
+
+
+# ---------------------------------------------------------------------------
+# NO_SPEND / dry-run guards
+# ---------------------------------------------------------------------------
+
+def _assert_live_tinker_call_blocked(api, call, reason):
+    with pytest.raises(api.TinkerAPIError) as excinfo:
+        call()
+    message = str(excinfo.value)
+    assert "live Tinker API calls are disabled" in message
+    assert reason in message
+
+
+@pytest.mark.parametrize(
+    ("env_name", "env_value", "reason"),
+    [
+        ("NO_SPEND", "1", "NO_SPEND=1"),
+        ("NO_SPEND", "true", "NO_SPEND=1"),
+        ("NO_SPEND", "on", "NO_SPEND=1"),
+        ("TINKER_BACKEND", "dry_run", "TINKER_BACKEND=dry_run"),
+        ("TINKER_BACKEND", "dry-run", "TINKER_BACKEND=dry_run"),
+    ],
+)
+def test_no_spend_guards_block_sdk_helpers_before_construction_or_use(
+    fresh_tinker_state, monkeypatch, env_name, env_value, reason
+):
+    tinker_mod, types_mod = fresh_tinker_state
+    api = _api()
+    monkeypatch.setenv(env_name, env_value)
+
+    _assert_live_tinker_call_blocked(api, api.create_service_client, reason)
+    tinker_mod.ServiceClient.assert_not_called()
+
+    service_client = MagicMock()
+    _assert_live_tinker_call_blocked(
+        api,
+        lambda: api.create_lora_training_client(
+            service_client, base_model="meta-llama/Llama-3.2-1B", rank=16
+        ),
+        reason,
+    )
+    service_client.create_lora_training_client.assert_not_called()
+
+    training_client = _make_training_client(types_mod)
+    _assert_live_tinker_call_blocked(
+        api, lambda: api.get_tokenizer(training_client), reason
+    )
+    training_client.get_tokenizer.assert_not_called()
+
+    _assert_live_tinker_call_blocked(api, lambda: api.make_datum([1, 2, 3]), reason)
+    types_mod.ModelInput.from_ints.assert_not_called()
+    types_mod.Datum.assert_not_called()
+
+    batch = _make_batch(types_mod, n_batches=1, tokens_each=3)
+    _assert_live_tinker_call_blocked(
+        api,
+        lambda: api.run_training_step(
+            training_client, batch, learning_rate=1e-4, job_id="blocked-job"
+        ),
+        reason,
+    )
+    training_client.forward_backward.assert_not_called()
+    training_client.optim_step.assert_not_called()
+    types_mod.AdamParams.assert_not_called()
+    assert "blocked-job" not in api._token_ledger
+
+    _assert_live_tinker_call_blocked(
+        api,
+        lambda: api.run_training_loop(
+            training_client, [batch], learning_rate=1e-4, job_id="blocked-loop"
+        ),
+        reason,
+    )
+    training_client.forward_backward.assert_not_called()
+    training_client.optim_step.assert_not_called()
+    training_client.save_weights_for_sampler.assert_not_called()
+    assert "blocked-loop" not in api._token_ledger
+
+    _assert_live_tinker_call_blocked(
+        api, lambda: api.save_checkpoint(training_client, name="ckpt"), reason
+    )
+    training_client.save_weights_and_get_sampling_client.assert_not_called()
+
+    _assert_live_tinker_call_blocked(
+        api, lambda: api.save_weights(training_client, name="weights"), reason
+    )
+    training_client.save_weights_for_sampler.assert_not_called()
+
+    sampling_client = MagicMock()
+    _assert_live_tinker_call_blocked(
+        api, lambda: api.sample(sampling_client, prompt_tokens=[1, 2, 3]), reason
+    )
+    sampling_client.sample.assert_not_called()
+    types_mod.ModelInput.from_ints.assert_not_called()
+    types_mod.SamplingParams.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("env_name", "env_value"),
+    [
+        ("NO_SPEND", "1"),
+        ("NO_SPEND", "true"),
+        ("TINKER_BACKEND", "dry_run"),
+        ("TINKER_BACKEND", "dry-run"),
+    ],
+)
+def test_no_spend_guards_allow_ledger_and_cancel_helpers(
+    fresh_tinker_state, monkeypatch, env_name, env_value
+):
+    api = _api()
+    monkeypatch.setenv(env_name, env_value)
+
+    api.record_tokens("guarded-job", 250_000)
+    api.record_tokens("guarded-job", 250_000)
+    assert api.get_cumulative_spend("guarded-job") == pytest.approx(0.20)
+
+    api.cancel_job("guarded-job")
+    assert api.is_cancelled("guarded-job")
+
+
+def test_no_spend_guard_does_not_import_tinker_sdk(monkeypatch):
+    _remove_tinker_mock()
+    sys.modules.pop("src.tinker_api.tinker_api", None)
+    monkeypatch.setenv("NO_SPEND", "1")
+
+    real_import = builtins.__import__
+
+    def fail_tinker_import(name, *args, **kwargs):
+        if name == "tinker" or name.startswith("tinker."):
+            raise AssertionError("no-spend guard should not import tinker")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fail_tinker_import)
+
+    import importlib
+
+    api = importlib.import_module("src.tinker_api.tinker_api")
+    assert api._TINKER_AVAILABLE is None
+    _assert_live_tinker_call_blocked(api, api.create_service_client, "NO_SPEND=1")
+    assert api._TINKER_AVAILABLE is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tinker_runner.py
+++ b/tests/test_tinker_runner.py
@@ -1,0 +1,1418 @@
+from __future__ import annotations
+
+import importlib
+import json
+import math
+import sys
+import threading
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.autoresearch.config import TrainingConfig
+
+
+def _strict_json(text: str):
+    return json.loads(
+        text,
+        parse_constant=lambda value: pytest.fail(f"non-standard JSON constant: {value}"),
+    )
+
+
+def _assert_strict_json_file(path: Path):
+    text = path.read_text()
+    assert "NaN" not in text
+    assert "Infinity" not in text
+    return _strict_json(text)
+
+
+def test_record_to_conversation_accepts_messages():
+    from src.tinker_api.sft_runner import record_to_conversation
+
+    messages = [
+        {"role": "system", "content": "Be brief."},
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi"},
+    ]
+    assert record_to_conversation({"messages": messages}) == messages
+
+
+def test_record_to_conversation_converts_input_output():
+    from src.tinker_api.sft_runner import record_to_conversation
+
+    assert record_to_conversation({"input": "Classify this", "output": "positive"}) == [
+        {"role": "user", "content": "Classify this"},
+        {"role": "assistant", "content": "positive"},
+    ]
+
+
+def test_record_to_conversation_converts_input_label():
+    from src.tinker_api.sft_runner import record_to_conversation
+
+    assert record_to_conversation({"input": "Classify this", "label": 1})[-1] == {
+        "role": "assistant",
+        "content": "1",
+    }
+
+
+def test_record_to_conversation_rejects_malformed_record():
+    from src.tinker_api.sft_runner import record_to_conversation
+
+    with pytest.raises(ValueError, match="missing target"):
+        record_to_conversation({"input": "No answer"})
+
+
+def test_record_to_conversation_requires_assistant_after_user():
+    from src.tinker_api.sft_runner import record_to_conversation
+
+    with pytest.raises(ValueError, match="assistant message after a user"):
+        record_to_conversation(
+            {
+                "messages": [
+                    {"role": "assistant", "content": "A"},
+                    {"role": "user", "content": "Q"},
+                ]
+            }
+        )
+
+
+def test_load_conversations_returns_empty_for_empty_jsonl(tmp_path):
+    from src.tinker_api.sft_runner import load_conversations
+
+    path = tmp_path / "train.jsonl"
+    path.write_text("")
+    assert load_conversations(path) == []
+
+
+def test_resolve_renderer_fallback_for_qwen35_9b():
+    from src.tinker_api.sft_runner import DEFAULT_TINKER_MODEL, resolve_renderer_name
+
+    model_info = MagicMock()
+    model_info.get_recommended_renderer_name.side_effect = KeyError(DEFAULT_TINKER_MODEL)
+
+    assert resolve_renderer_name(DEFAULT_TINKER_MODEL, model_info) == "qwen3_5_disable_thinking"
+
+
+def test_tinker_search_space_can_be_restricted_to_supported_tunables():
+    from src.autoresearch.proposer import SearchSpace
+    from src.tinker_api.sft_runner import SUPPORTED_TINKER_TUNABLES
+
+    assert set(SearchSpace.tunable_params("tinker_sft")) == set(SUPPORTED_TINKER_TUNABLES)
+    assert "dropout" not in SearchSpace.tunable_params("tinker_sft")
+    assert "warmup_steps" not in SearchSpace.tunable_params("tinker_sft")
+
+
+def test_run_tinker_sft_experiment_writes_artifacts(tmp_path, monkeypatch):
+    state = _install_fake_tinker_stack(monkeypatch, losses=[0.5, 0.25])
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [
+            {"input": "Say hello", "output": "hello"},
+            {
+                "messages": [
+                    {"role": "user", "content": "2+2"},
+                    {"role": "assistant", "content": "4"},
+                ]
+            },
+        ],
+    )
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=1),
+        str(data_path),
+        run_id="unit-run",
+        max_steps=2,
+        output_dir=str(tmp_path / "experiments"),
+    )
+
+    run_dir = tmp_path / "experiments" / "unit-run"
+    assert result["status"] == "COMPLETED"
+    assert result["model_path"] == str(run_dir)
+    assert json.loads((run_dir / "metrics.json").read_text())["val_loss"] == pytest.approx(0.375)
+    assert (run_dir / "metrics.jsonl").read_text().count("\n") == 2
+    manifest = json.loads((run_dir / "manifest.json").read_text())
+    assert manifest["checkpoints"]["state_path"].startswith("tinker://state/")
+    assert manifest["checkpoints"]["sampler_path"].startswith("tinker://sampler/")
+    assert manifest["train_on_what"] == "last_assistant_message"
+    assert manifest["training_examples"] == 2
+    assert json.loads((run_dir / "sample.json").read_text())["text"] == "sample text"
+    assert state.training_client.forward_backward_calls == 2
+    assert state.training_client.optim_step_calls == 2
+    assert {call["train_on_what"] for call in state.conversions} == {
+        "last_assistant_message"
+    }
+
+
+def test_run_tinker_sft_experiment_dry_run_uses_real_dataset_without_sdk(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("TINKER_BACKEND", "dry_run")
+    from src.tinker_api import sft_runner
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    def fail_load_tinker_deps():
+        raise AssertionError("dry_run should not import Tinker SDK dependencies")
+
+    class FailingServiceClient:
+        def create_lora_training_client(self, *args, **kwargs):
+            raise AssertionError("dry_run should not construct live training clients")
+
+    monkeypatch.setattr(sft_runner, "_load_tinker_deps", fail_load_tinker_deps)
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [
+            {"input": "train one", "output": "alpha"},
+            {
+                "messages": [
+                    {"role": "user", "content": "train two"},
+                    {"role": "assistant", "content": "beta"},
+                ]
+            },
+            {"input": "validation", "output": "gamma"},
+            {"input": "test", "output": "delta"},
+        ],
+    )
+    dataset_result = {
+        "dataset": {
+            "path": str(data_path),
+            "train_size": 2,
+            "val_size": 1,
+            "test_size": 1,
+        },
+        "next_agent": "decision_engine",
+    }
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=2),
+        dataset_result,
+        run_id="dry-run",
+        max_steps=3,
+        output_dir=str(tmp_path / "experiments"),
+        service_client=FailingServiceClient(),
+    )
+
+    run_dir = tmp_path / "experiments" / "dry-run"
+    metrics = _assert_strict_json_file(run_dir / "metrics.json")
+    manifest = _assert_strict_json_file(run_dir / "manifest.json")
+    sample = _assert_strict_json_file(run_dir / "sample.json")
+    rows = [
+        _strict_json(line)
+        for line in (run_dir / "metrics.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+
+    assert result["status"] == "COMPLETED"
+    assert manifest["backend"] == "dry_run"
+    assert manifest["split_examples"] == {"train": 2, "val": 1, "test": 1}
+    assert manifest["training_examples"] == 2
+    assert manifest["completed_steps"] == 3
+    assert manifest["checkpoints"]["state_path"].startswith("dry-run://state/")
+    assert manifest["heldout_eval"]["val_loss"] is not None
+    assert manifest["heldout_eval"]["test_loss"] is not None
+    assert len(rows) == 3
+    assert [row["step"] for row in rows] == [1, 2, 3]
+    assert all(math.isfinite(row["train_loss"]) for row in rows)
+    assert all(math.isfinite(metrics[key]) for key in metrics)
+    assert sample["text"] == "alpha"
+    assert sample["backend"] == "dry_run"
+
+
+def test_run_tinker_sft_experiment_no_spend_uses_dry_run_without_sdk(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.delenv("TINKER_BACKEND", raising=False)
+    from src.tinker_api import sft_runner
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    class FailingServiceClient:
+        def create_lora_training_client(self, *args, **kwargs):
+            raise AssertionError("NO_SPEND should not construct live training clients")
+
+    monkeypatch.setattr(
+        sft_runner,
+        "_load_tinker_deps",
+        lambda: pytest.fail("NO_SPEND should not load Tinker SDK dependencies"),
+    )
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [{"input": "Question", "output": "Answer"}],
+    )
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=1),
+        str(data_path),
+        run_id="no-spend-dry-run",
+        max_steps=1,
+        output_dir=str(tmp_path / "experiments"),
+        service_client=FailingServiceClient(),
+    )
+
+    run_dir = tmp_path / "experiments" / "no-spend-dry-run"
+    manifest = _assert_strict_json_file(run_dir / "manifest.json")
+    sample = _assert_strict_json_file(run_dir / "sample.json")
+
+    assert result["status"] == "COMPLETED"
+    assert manifest["backend"] == "dry_run"
+    assert manifest["completed_steps"] == 1
+    assert sample["backend"] == "dry_run"
+
+
+def test_run_tinker_sft_experiment_dry_run_cancels_before_steps(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("TINKER_BACKEND", "dry_run")
+    from src.tinker_api import sft_runner, tinker_api
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    monkeypatch.setattr(
+        sft_runner,
+        "_load_tinker_deps",
+        lambda: pytest.fail("dry_run should not load Tinker SDK dependencies"),
+    )
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [{"input": "Question", "output": "Answer"}],
+    )
+    tinker_api.cancel_job("dry-cancel-before-run")
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=1),
+        str(data_path),
+        run_id="dry-cancel-before-run",
+        max_steps=2,
+        output_dir=str(tmp_path / "experiments"),
+    )
+
+    run_dir = tmp_path / "experiments" / "dry-cancel-before-run"
+    metrics = _assert_strict_json_file(run_dir / "metrics.json")
+    manifest = _assert_strict_json_file(run_dir / "manifest.json")
+
+    assert result["status"] == "CANCELLED"
+    assert manifest["status"] == "CANCELLED"
+    assert manifest["completed_steps"] == 0
+    assert (run_dir / "metrics.jsonl").exists()
+    assert (run_dir / "metrics.jsonl").read_text() == ""
+    assert (run_dir / "sample.json").exists()
+    assert all(math.isfinite(metrics[key]) for key in metrics)
+
+
+def test_run_tinker_sft_experiment_dry_run_cancels_between_steps(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("TINKER_BACKEND", "dry_run")
+    from src.tinker_api import sft_runner, tinker_api
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    original_record_tokens = tinker_api.record_tokens
+
+    def cancel_after_first_step(job_id: str, n_tokens: int) -> None:
+        original_record_tokens(job_id, n_tokens)
+        tinker_api.cancel_job(job_id)
+
+    monkeypatch.setattr(sft_runner, "record_tokens", cancel_after_first_step)
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [{"input": "Question", "output": "Answer"}],
+    )
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=1),
+        str(data_path),
+        run_id="dry-cancel-between-steps",
+        max_steps=3,
+        output_dir=str(tmp_path / "experiments"),
+    )
+
+    run_dir = tmp_path / "experiments" / "dry-cancel-between-steps"
+    manifest = _assert_strict_json_file(run_dir / "manifest.json")
+    rows = [
+        _strict_json(line)
+        for line in (run_dir / "metrics.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+
+    assert result["status"] == "CANCELLED"
+    assert manifest["status"] == "CANCELLED"
+    assert manifest["completed_steps"] == 1
+    assert len(rows) == 1
+
+
+def test_run_tinker_sft_experiment_dry_run_honors_runtime_cancellation(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("TINKER_BACKEND", "dry_run")
+    from src.runtime_context import cancellation_context
+    from src.tinker_api import sft_runner, tinker_api
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    cancel_event = threading.Event()
+    active_jobs: set[str] = set()
+    original_record_tokens = tinker_api.record_tokens
+
+    def request_cancel_after_first_step(job_id: str, n_tokens: int) -> None:
+        original_record_tokens(job_id, n_tokens)
+        assert job_id in active_jobs
+        cancel_event.set()
+
+    monkeypatch.setattr(sft_runner, "record_tokens", request_cancel_after_first_step)
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [{"input": "Question", "output": "Answer"}],
+    )
+
+    with cancellation_context(cancel_event, active_jobs):
+        result = run_tinker_sft_experiment(
+            TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=1),
+            str(data_path),
+            run_id="runtime-dry-cancel",
+            max_steps=3,
+            output_dir=str(tmp_path / "experiments"),
+        )
+
+    run_dir = tmp_path / "experiments" / "runtime-dry-cancel"
+    manifest = _assert_strict_json_file(run_dir / "manifest.json")
+
+    assert result["status"] == "CANCELLED"
+    assert manifest["completed_steps"] == 1
+    assert tinker_api.is_cancelled("runtime-dry-cancel")
+    assert active_jobs == set()
+
+
+def test_run_tinker_sft_experiment_writes_strict_json_for_nonfinite_training_loss(
+    tmp_path,
+    monkeypatch,
+):
+    _install_fake_tinker_stack(monkeypatch, losses=[float("nan"), 0.25])
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [{"input": "Question", "output": "Answer"}],
+    )
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=1),
+        str(data_path),
+        run_id="nonfinite-training-run",
+        max_steps=2,
+        output_dir=str(tmp_path / "experiments"),
+    )
+
+    run_dir = tmp_path / "experiments" / "nonfinite-training-run"
+    metrics = _assert_strict_json_file(run_dir / "metrics.json")
+    manifest = _assert_strict_json_file(run_dir / "manifest.json")
+    rows = [
+        _strict_json(line)
+        for line in (run_dir / "metrics.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+
+    assert result["status"] == "FAILED"
+    assert manifest["status"] == "FAILED"
+    assert rows[0]["nonfinite_loss"] is True
+    assert rows[0]["train_loss"] == 1_000_000_000.0
+    assert all(
+        math.isfinite(metrics[key])
+        for key in ("train_loss", "val_loss", "test_loss", "primary_metric")
+    )
+    assert all(
+        math.isfinite(result["metrics"][key])
+        for key in ("train_loss", "val_loss", "test_loss", "primary_metric")
+    )
+
+
+def test_run_tinker_sft_experiment_writes_strict_json_for_nonfinite_holdout_loss(
+    tmp_path,
+    monkeypatch,
+):
+    _install_fake_tinker_stack(
+        monkeypatch,
+        losses=[0.5],
+        forward_losses=[float("inf"), float("nan")],
+    )
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [
+            {"input": "train", "output": "a"},
+            {"input": "validation", "output": "b"},
+            {"input": "test", "output": "c"},
+        ],
+    )
+    dataset_result = {
+        "dataset": {
+            "path": str(data_path),
+            "train_size": 1,
+            "val_size": 1,
+            "test_size": 1,
+        },
+        "next_agent": "decision_engine",
+    }
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=1),
+        dataset_result,
+        run_id="nonfinite-holdout-run",
+        max_steps=1,
+        output_dir=str(tmp_path / "experiments"),
+    )
+
+    run_dir = tmp_path / "experiments" / "nonfinite-holdout-run"
+    metrics = _assert_strict_json_file(run_dir / "metrics.json")
+    manifest = _assert_strict_json_file(run_dir / "manifest.json")
+
+    assert result["status"] == "COMPLETED"
+    assert metrics["val_loss"] == 1_000_000_000.0
+    assert metrics["test_loss"] == 1_000_000_000.0
+    assert manifest["heldout_eval"] == {
+        "val_loss": 1_000_000_000.0,
+        "test_loss": 1_000_000_000.0,
+    }
+    assert all(
+        math.isfinite(result["metrics"][key])
+        for key in ("train_loss", "val_loss", "test_loss", "primary_metric")
+    )
+
+
+def test_run_tinker_sft_experiment_splits_multi_assistant_conversations(
+    tmp_path,
+    monkeypatch,
+):
+    state = _install_fake_tinker_stack(monkeypatch, losses=[0.5])
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [
+            {
+                "messages": [
+                    {"role": "system", "content": "Be brief."},
+                    {"role": "user", "content": "First"},
+                    {"role": "assistant", "content": "One"},
+                    {"role": "user", "content": "Second"},
+                    {"role": "assistant", "content": "Two"},
+                ]
+            },
+        ],
+    )
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=4),
+        str(data_path),
+        run_id="multi-assistant-run",
+        max_steps=1,
+        output_dir=str(tmp_path / "experiments"),
+    )
+
+    run_dir = tmp_path / "experiments" / "multi-assistant-run"
+    manifest = json.loads((run_dir / "manifest.json").read_text())
+    assert result["status"] == "COMPLETED"
+    assert manifest["training_examples"] == 2
+    assert len(state.conversions) == 4
+    converted_targets = {
+        call["conversation"][-1]["content"]
+        for call in state.conversions
+    }
+    assert converted_targets == {"One", "Two"}
+    assert {call["train_on_what"] for call in state.conversions} == {
+        "last_assistant_message"
+    }
+
+
+def test_run_tinker_sft_experiment_reads_tinker_loss_sum_metric(
+    tmp_path,
+    monkeypatch,
+):
+    _install_fake_tinker_stack(
+        monkeypatch,
+        losses=[{"loss:sum": 3.5}, {"loss:sum": 2.25}],
+    )
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [{"input": "Question", "output": "Answer"}],
+    )
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=1),
+        str(data_path),
+        run_id="loss-sum-run",
+        max_steps=2,
+        output_dir=str(tmp_path / "experiments"),
+    )
+
+    run_dir = tmp_path / "experiments" / "loss-sum-run"
+    metrics = json.loads((run_dir / "metrics.json").read_text())
+    assert result["metrics"]["train_loss"] == pytest.approx(2.875)
+    assert metrics["primary_metric"] == pytest.approx(1.0 / 3.875)
+
+
+def test_run_tinker_sft_experiment_scores_dataset_result_holdouts(
+    tmp_path,
+    monkeypatch,
+):
+    state = _install_fake_tinker_stack(
+        monkeypatch,
+        losses=[0.5, 0.25],
+        forward_losses=[0.8, 1.2],
+    )
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [
+            {"input": "train one", "output": "a"},
+            {"input": "train two", "output": "b"},
+            {"input": "validation", "output": "c"},
+            {"input": "test", "output": "d"},
+        ],
+    )
+    dataset_result = {
+        "dataset": {
+            "path": str(data_path),
+            "train_size": 2,
+            "val_size": 1,
+            "test_size": 1,
+        },
+        "next_agent": "decision_engine",
+    }
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=1),
+        dataset_result,
+        run_id="split-run",
+        max_steps=2,
+        output_dir=str(tmp_path / "experiments"),
+    )
+
+    run_dir = tmp_path / "experiments" / "split-run"
+    metrics = json.loads((run_dir / "metrics.json").read_text())
+    manifest = json.loads((run_dir / "manifest.json").read_text())
+    assert result["metrics"]["train_loss"] == pytest.approx(0.375)
+    assert metrics["val_loss"] == pytest.approx(0.8)
+    assert metrics["test_loss"] == pytest.approx(1.2)
+    assert metrics["primary_metric"] == pytest.approx(1 / 1.8)
+    assert manifest["split_examples"] == {"train": 2, "val": 1, "test": 1}
+    assert manifest["heldout_eval"] == {"val_loss": 0.8, "test_loss": 1.2}
+    assert state.training_client.forward_backward_calls == 2
+    assert state.training_client.forward_calls == 2
+    trained_prompts = [
+        batch[0].conversation[0]["content"]
+        for batch in state.training_client.batches
+    ]
+    assert trained_prompts == ["train one", "train two"]
+    heldout_prompts = [
+        batch[0].conversation[0]["content"]
+        for batch in state.training_client.forward_batches
+    ]
+    assert heldout_prompts == ["validation", "test"]
+
+
+def test_run_tinker_sft_experiment_batches_holdout_forward_passes(
+    tmp_path,
+    monkeypatch,
+):
+    state = _install_fake_tinker_stack(
+        monkeypatch,
+        losses=[0.5],
+        forward_losses=[1.0, 3.0],
+    )
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [
+            {"input": "train", "output": "a"},
+            {"input": "validation one", "output": "b"},
+            {"input": "validation two", "output": "c"},
+            {"input": "validation three", "output": "d"},
+        ],
+    )
+    dataset_result = {
+        "dataset": {
+            "path": str(data_path),
+            "train_size": 1,
+            "val_size": 3,
+            "test_size": 0,
+        },
+        "next_agent": "decision_engine",
+    }
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=2),
+        dataset_result,
+        run_id="batched-holdout-run",
+        max_steps=1,
+        output_dir=str(tmp_path / "experiments"),
+    )
+
+    metrics = result["metrics"]
+    assert metrics["val_loss"] == pytest.approx((1.0 * 2 + 3.0 * 1) / 3)
+    assert state.training_client.forward_calls == 2
+    assert [len(batch) for batch in state.training_client.forward_batches] == [2, 1]
+
+
+def test_extract_forward_loss_uses_weighted_logprobs():
+    from src.tinker_api.sft_runner import _extract_forward_loss
+
+    class TensorLike:
+        def __init__(self, values):
+            self._values = values
+
+        def tolist(self):
+            return self._values
+
+    datums = [
+        types.SimpleNamespace(loss_fn_inputs={"weights": TensorLike([0, 1, 1])}),
+        types.SimpleNamespace(loss_fn_inputs={"weights": TensorLike([1, 0])}),
+    ]
+    result = {
+        "loss_fn_outputs": [
+            {"logprobs": TensorLike([-10.0, -2.0, -4.0])},
+            {"logprobs": TensorLike([-8.0, -100.0])},
+        ]
+    }
+
+    assert _extract_forward_loss(result, datums) == pytest.approx((2 + 4 + 8) / 3)
+
+
+def test_run_tinker_sft_experiment_stops_on_cancel_and_writes_artifacts(tmp_path, monkeypatch):
+    state = _install_fake_tinker_stack(monkeypatch, losses=[0.5, 0.25, 0.1])
+    from src.tinker_api import tinker_api
+    from src.tinker_api.sft_runner import run_tinker_sft_experiment
+
+    original_record_tokens = tinker_api.record_tokens
+
+    def cancel_after_first_step(job_id: str, n_tokens: int) -> None:
+        original_record_tokens(job_id, n_tokens)
+        tinker_api.cancel_job(job_id)
+
+    monkeypatch.setattr("src.tinker_api.sft_runner.record_tokens", cancel_after_first_step)
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [{"input": "Question", "output": "Answer"}],
+    )
+
+    result = run_tinker_sft_experiment(
+        TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=1),
+        data_path,
+        run_id="cancel-run",
+        max_steps=3,
+        output_dir=str(tmp_path / "experiments"),
+    )
+
+    run_dir = tmp_path / "experiments" / "cancel-run"
+    manifest = _assert_strict_json_file(run_dir / "manifest.json")
+    sample = _assert_strict_json_file(run_dir / "sample.json")
+
+    assert result["status"] == "CANCELLED"
+    assert manifest["checkpoints"] == {"skipped": "cancelled"}
+    assert sample["status"] == "CANCELLED"
+    assert (run_dir / "metrics.jsonl").read_text().count("\n") == 1
+    assert state.training_client.save_state_calls == 0
+    assert state.training_client.save_weights_calls == 0
+    assert state.training_client.sample_calls == 0
+    assert state.training_client.forward_calls == 0
+
+
+def test_run_evals_scores_tinker_metrics(tmp_path):
+    from src.autoresearch.autoresearch import run_evals
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "metrics.json").write_text(
+        json.dumps({"train_loss": 0.5, "val_loss": 1.0, "test_loss": 1.2})
+    )
+
+    score = run_evals(
+        str(run_dir),
+        {
+            "primary_metric": "primary_metric",
+            "metrics": [],
+            "test_split_path": "",
+            "use_llm_grading": False,
+        },
+    )
+
+    assert score["scalar"] == pytest.approx(0.5)
+    assert score["metrics"]["primary_metric"] == pytest.approx(0.5)
+
+
+def test_autoresearch_run_node_calls_tinker_runner(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    data_path = _write_jsonl(tmp_path / "train.jsonl", [{"input": "x", "output": "y"}])
+    captured = {}
+
+    def fake_runner(config, dataset, *, max_steps=None, **kwargs):
+        captured["config"] = config
+        captured["dataset"] = dataset
+        captured["max_steps"] = max_steps
+        captured["run_id"] = kwargs.get("run_id")
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        (run_dir / "metrics.json").write_text(
+            json.dumps({"train_loss": 0.5, "val_loss": 0.5, "test_loss": 0.5})
+        )
+        return {
+            "job_id": "fake-run",
+            "status": "COMPLETED",
+            "metrics": {
+                "train_loss": 0.5,
+                "val_loss": 0.5,
+                "test_loss": 0.5,
+                "primary_metric": 2 / 3,
+            },
+            "model_path": str(run_dir),
+            "cost_usd": 0.01,
+            "logs_path": str(run_dir / "metrics.jsonl"),
+        }
+
+    monkeypatch.setattr(ar, "run_tinker_sft_experiment", fake_runner)
+    state = _autoresearch_state(str(data_path))
+
+    result = ar.run_node(state)
+
+    assert result["last_result"]["job_id"] == "fake-run"
+    assert captured["max_steps"] == 5
+    assert captured["run_id"].startswith("autoresearch-iteration-")
+    assert captured["dataset"]["dataset"]["path"] == str(data_path)
+    assert captured["config"].model_name == "Qwen/Qwen3.5-9B"
+
+
+def test_autoresearch_run_node_uses_pending_proposal_patch(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    data_path = _write_jsonl(tmp_path / "train.jsonl", [{"input": "x", "output": "y"}])
+    captured = {}
+
+    def fake_runner(config, dataset, *, max_steps=None, **kwargs):
+        captured["config"] = config
+        run_dir = tmp_path / "run-patched"
+        run_dir.mkdir()
+        (run_dir / "metrics.json").write_text(
+            json.dumps({"train_loss": 0.5, "val_loss": 0.5, "test_loss": 0.5})
+        )
+        return {
+            "job_id": "fake-run",
+            "status": "COMPLETED",
+            "metrics": {
+                "train_loss": 0.5,
+                "val_loss": 0.5,
+                "test_loss": 0.5,
+                "primary_metric": 2 / 3,
+            },
+            "model_path": str(run_dir),
+            "cost_usd": 0.01,
+            "logs_path": str(run_dir / "metrics.jsonl"),
+        }
+
+    monkeypatch.setattr(ar, "run_tinker_sft_experiment", fake_runner)
+    state = _autoresearch_state(str(data_path))
+    state["current_config"] = {"learning_rate": 1e-4, "batch_size": 4}
+    state["current_patch"] = json.dumps({"learning_rate": 2e-4})
+
+    ar.run_node(state)
+
+    assert captured["config"].learning_rate == pytest.approx(2e-4)
+    assert captured["config"].batch_size == 4
+
+
+def test_autoresearch_run_node_rejects_invalid_pending_patch(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    data_path = _write_jsonl(tmp_path / "train.jsonl", [{"input": "x", "output": "y"}])
+
+    def fail_runner(*_args, **_kwargs):
+        raise AssertionError("invalid patches should be rejected before Tinker runs")
+
+    monkeypatch.setattr(ar, "run_tinker_sft_experiment", fail_runner)
+    state = _autoresearch_state(str(data_path))
+    state["current_config"] = {"learning_rate": 1e-4, "batch_size": 4}
+    state["current_patch"] = json.dumps({"lora_rank": 3})
+
+    with pytest.raises(ValueError, match="candidates"):
+        ar.run_node(state)
+
+
+def test_autoresearch_propose_then_run_uses_proposed_config(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+    from src.autoresearch.config import TrainingConfig
+
+    data_path = _write_jsonl(tmp_path / "train.jsonl", [{"input": "x", "output": "y"}])
+    config_path = tmp_path / "current.json"
+    TrainingConfig(
+        model_name="Qwen/Qwen3.5-9B",
+        learning_rate=1e-4,
+        batch_size=4,
+    ).save(config_path)
+    monkeypatch.setattr(ar, "_CONFIG_PATH", config_path)
+    monkeypatch.setenv("AUTORESEARCH_PROPOSER", "claude")
+    monkeypatch.setattr(
+        ar,
+        "propose_hypothesis",
+        lambda *args, **kwargs: {
+            "description": "Increase learning rate for a bounded candidate run.",
+            "patch": json.dumps({"learning_rate": 2e-4}),
+            "expected_effect": "Lower validation loss.",
+            "search_strategy": "local",
+        },
+    )
+    captured = {}
+
+    def fake_runner(config, dataset, *, max_steps=None, **kwargs):
+        captured["config"] = config
+        run_dir = tmp_path / "run-proposed"
+        run_dir.mkdir()
+        (run_dir / "metrics.json").write_text(
+            json.dumps({"train_loss": 0.4, "val_loss": 0.4, "test_loss": 0.4})
+        )
+        return {
+            "job_id": "fake-run",
+            "status": "COMPLETED",
+            "metrics": {
+                "train_loss": 0.4,
+                "val_loss": 0.4,
+                "test_loss": 0.4,
+                "primary_metric": 1 / 1.4,
+            },
+            "model_path": str(run_dir),
+            "cost_usd": 0.01,
+            "logs_path": str(run_dir / "metrics.jsonl"),
+        }
+
+    monkeypatch.setattr(ar, "run_tinker_sft_experiment", fake_runner)
+    state = _autoresearch_state(str(data_path))
+    state["current_config"] = {"learning_rate": 1e-4, "batch_size": 4}
+    state["config"]["training_procedure"]["hyperparameters"] = dict(state["current_config"])
+
+    proposed = ar.propose_node(state)
+    ar.run_node({**state, **proposed})
+
+    assert captured["config"].learning_rate == pytest.approx(2e-4)
+    assert TrainingConfig.load(config_path).learning_rate == pytest.approx(2e-4)
+
+
+def test_autoresearch_init_node_seeds_current_config_json(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+    from src.autoresearch.config import TrainingConfig
+
+    config_path = tmp_path / "configs" / "current.json"
+    monkeypatch.setattr(ar, "_CONFIG_PATH", config_path)
+    state = _autoresearch_state(str(tmp_path / "train.jsonl"))
+    state["current_config"] = {"learning_rate": 1e-4, "batch_size": 4}
+    state["config"]["training_procedure"]["hyperparameters"] = dict(state["current_config"])
+
+    ar.init_node(state)
+
+    seeded = TrainingConfig.load(config_path)
+    assert seeded.model_name == "Qwen/Qwen3.5-9B"
+    assert seeded.learning_rate == pytest.approx(1e-4)
+    assert seeded.batch_size == 4
+
+
+def test_autoresearch_run_node_wraps_tinker_runner_with_cost_manager(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    data_path = _write_jsonl(tmp_path / "train.jsonl", [{"input": "x", "output": "y"}])
+    cost_manager = _FakeCostManager()
+    captured = {}
+
+    def fake_runner(config, dataset, *, run_id=None, max_steps=None, **kwargs):
+        captured["run_id"] = run_id
+        run_dir = tmp_path / "run-cost"
+        run_dir.mkdir()
+        (run_dir / "metrics.json").write_text(
+            json.dumps({"train_loss": 0.4, "val_loss": 0.4, "test_loss": 0.4})
+        )
+        return {
+            "job_id": run_id,
+            "status": "COMPLETED",
+            "metrics": {
+                "train_loss": 0.4,
+                "val_loss": 0.4,
+                "test_loss": 0.4,
+                "primary_metric": 1 / 1.4,
+            },
+            "model_path": str(run_dir),
+            "cost_usd": 0.01,
+            "logs_path": str(run_dir / "metrics.jsonl"),
+        }
+
+    monkeypatch.setattr(ar, "run_tinker_sft_experiment", fake_runner)
+    state = _autoresearch_state(str(data_path))
+    state["cost_manager"] = cost_manager
+
+    result = ar.run_node(state)
+
+    assert result["last_result"]["job_id"] == captured["run_id"]
+    assert cost_manager.started == [captured["run_id"]]
+    assert cost_manager.stopped == 1
+    assert cost_manager.recorded == [(0.01, "training")]
+
+
+def test_autoresearch_baseline_node_records_cost_and_budget_stop(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+    from src.cost_manager.cost_manager import CostManager
+
+    data_path = _write_jsonl(tmp_path / "train.jsonl", [{"input": "x", "output": "y"}])
+
+    def fake_runner(config, dataset, *, run_id=None, max_steps=None, **kwargs):
+        run_dir = tmp_path / "baseline-cost"
+        run_dir.mkdir()
+        (run_dir / "metrics.json").write_text(
+            json.dumps({"train_loss": 0.3, "val_loss": 0.3, "test_loss": 0.3})
+        )
+        return {
+            "job_id": run_id,
+            "status": "COMPLETED",
+            "metrics": {
+                "train_loss": 0.3,
+                "val_loss": 0.3,
+                "test_loss": 0.3,
+                "primary_metric": 1 / 1.3,
+            },
+            "model_path": str(run_dir),
+            "cost_usd": 0.02,
+            "logs_path": str(run_dir / "metrics.jsonl"),
+        }
+
+    monkeypatch.setattr(ar, "run_tinker_sft_experiment", fake_runner)
+    state = _autoresearch_state(str(data_path))
+    state["config"]["compute_budget"] = 0.01
+    state["cost_manager"] = CostManager(0.01)
+    state["plan"]["estimated_cost"] = 0.0
+
+    result = ar.baseline_node(state)
+
+    assert result["baseline_result"]["cost_usd"] == 0.02
+    assert result["should_stop"] is True
+    assert state["cost_manager"].spent_usd == 0.02
+    assert ar.continue_edge({**state, **result}) == "__end__"
+
+
+def test_autoresearch_baseline_preflight_skips_unaffordable_run(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+    from src.cost_manager.cost_manager import CostManager
+
+    data_path = _write_jsonl(tmp_path / "train.jsonl", [{"input": "x", "output": "y"}])
+
+    def fail_runner(*args, **kwargs):
+        raise AssertionError("Tinker runner should not start when preflight rejects")
+
+    monkeypatch.setattr(ar, "run_tinker_sft_experiment", fail_runner)
+    monkeypatch.chdir(tmp_path)
+    state = _autoresearch_state(str(data_path))
+    state["config"]["compute_budget"] = 0.01
+    state["cost_manager"] = CostManager(0.01)
+    state["plan"]["estimated_run_cost_usd"] = 1.0
+
+    result = ar.baseline_node(state)
+    run_dir = Path(result["baseline_result"]["model_path"])
+
+    assert result["baseline_result"]["status"] == "CANCELLED"
+    assert result["baseline_result"]["cost_usd"] == 0.0
+    assert result["baseline_score"]["scalar"] < 1e-8
+    assert result["should_stop"] is True
+    assert state["cost_manager"].spent_usd == 0.0
+    assert (run_dir / "metrics.json").exists()
+    manifest = json.loads((run_dir / "manifest.json").read_text())
+    assert manifest["budget_preflight_skipped"] is True
+    assert "estimated run cost" in manifest["budget_skip_reason"]
+
+
+def test_autoresearch_records_estimated_cost_floor(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+    from src.cost_manager.cost_manager import CostManager
+
+    data_path = _write_jsonl(tmp_path / "train.jsonl", [{"input": "x", "output": "y"}])
+
+    def fake_runner(config, dataset, *, run_id=None, max_steps=None, **kwargs):
+        run_dir = tmp_path / "estimated-floor"
+        run_dir.mkdir()
+        (run_dir / "metrics.json").write_text(
+            json.dumps({"train_loss": 0.3, "val_loss": 0.3, "test_loss": 0.3})
+        )
+        return {
+            "job_id": run_id,
+            "status": "COMPLETED",
+            "metrics": {
+                "train_loss": 0.3,
+                "val_loss": 0.3,
+                "test_loss": 0.3,
+                "primary_metric": 1 / 1.3,
+            },
+            "model_path": str(run_dir),
+            "cost_usd": 0.01,
+            "logs_path": str(run_dir / "metrics.jsonl"),
+        }
+
+    monkeypatch.setattr(ar, "run_tinker_sft_experiment", fake_runner)
+    state = _autoresearch_state(str(data_path))
+    state["config"]["compute_budget"] = 2.0
+    state["cost_manager"] = CostManager(2.0)
+    state["plan"]["estimated_run_cost_usd"] = 1.0
+
+    result = ar.baseline_node(state)
+
+    assert result["baseline_result"]["cost_usd"] == 1.0
+    assert state["cost_manager"].spent_usd == 1.0
+    assert result["should_stop"] is False
+
+def test_autoresearch_graph_uses_dry_run_tinker_backend_without_sdk(
+    monkeypatch,
+    tmp_path,
+):
+    pytest.importorskip("langgraph", reason="langgraph not installed")
+
+    import src.autoresearch.autoresearch as ar
+    import src.tinker_api.sft_runner as sft_runner
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("TINKER_BACKEND", "dry_run")
+    monkeypatch.setenv("AUTORESEARCH_PROPOSER", "claude")
+    monkeypatch.delenv("TINKER_API_KEY", raising=False)
+
+    data_path = _write_jsonl(
+        tmp_path / "train.jsonl",
+        [
+            {"input": "question one", "output": "answer one"},
+            {"input": "question two", "output": "answer two"},
+        ],
+    )
+    config_path = tmp_path / "configs" / "current.json"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "model_name": "Qwen/Qwen3.5-9B",
+                "learning_rate": 1e-4,
+                "batch_size": 1,
+                "max_steps": 1,
+            }
+        )
+    )
+
+    monkeypatch.setattr(ar, "_CONFIG_PATH", config_path)
+    monkeypatch.setattr(
+        ar,
+        "_DIARY_PATH",
+        tmp_path / "outputs" / "logs" / "diary.jsonl",
+    )
+    monkeypatch.setattr(ar, "_MAX_ITERATIONS", 1)
+
+    def fail_if_live_sdk_loads():
+        raise AssertionError("dry-run graph should not load Tinker SDK dependencies")
+
+    monkeypatch.setattr(sft_runner, "_load_tinker_deps", fail_if_live_sdk_loads)
+
+    proposed_allowed_params = []
+
+    def fake_propose_hypothesis(current_config, diary, task, allowed_params=None):
+        proposed_allowed_params.append(allowed_params)
+        return {
+            "description": "Nudge learning_rate upward for a dry-run graph smoke.",
+            "patch": json.dumps({"learning_rate": 2e-4}),
+            "expected_effect": "Dry-run loss should remain finite.",
+            "search_strategy": "local",
+        }
+
+    monkeypatch.setattr(ar, "propose_hypothesis", fake_propose_hypothesis)
+    plan = _autoresearch_state(str(data_path))["plan"]
+    config = _autoresearch_state(str(data_path))["config"]
+    config["compute_budget"] = 10.0
+    config["training_procedure"]["hyperparameters"] = {
+        "learning_rate": 1e-4,
+        "batch_size": 1,
+        "max_steps": 1,
+    }
+
+    trained_model = ar.invoke_autoresearch_graph(plan, config, cost_manager=None)
+
+    experiment_dirs = sorted((tmp_path / "outputs" / "experiments").iterdir())
+    manifests = [
+        _assert_strict_json_file(experiment_dir / "manifest.json")
+        for experiment_dir in experiment_dirs
+    ]
+    diary_path = tmp_path / "outputs" / "logs" / "diary.jsonl"
+    diary_rows = [
+        _strict_json(line)
+        for line in diary_path.read_text().splitlines()
+        if line.strip()
+    ]
+
+    assert len(experiment_dirs) == 2
+    assert {manifest["backend"] for manifest in manifests} == {"dry_run"}
+    assert all(manifest["completed_steps"] == 1 for manifest in manifests)
+    assert all(
+        (experiment_dir / "metrics.json").exists()
+        for experiment_dir in experiment_dirs
+    )
+    assert all(
+        (experiment_dir / "sample.json").exists()
+        for experiment_dir in experiment_dirs
+    )
+    assert len(diary_rows) == 1
+    assert trained_model["n_iterations"] == 1
+    assert trained_model["metrics"]["scalar"] > 0
+    assert proposed_allowed_params == [sorted(sft_runner.SUPPORTED_TINKER_TUNABLES)]
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> Path:
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows))
+    return path
+
+
+def _autoresearch_state(dataset_path: str) -> dict:
+    return {
+        "plan": {
+            "strategy": "fine-tune",
+            "base_model": "Qwen/Qwen3.5-9B",
+            "lora_config": {"rank": 8, "alpha": 16, "dropout": 0.05, "target_modules": []},
+            "estimated_cost": 1.0,
+            "estimated_time_min": 5,
+            "training_script_path": "outputs/scripts/train.py",
+            "eval_metric": "primary_metric",
+            "backend": "tinker_sft",
+            "dataset_path": dataset_path,
+        },
+        "config": {
+            "data": False,
+            "prompt": "test",
+            "compute_budget": 10.0,
+            "training_procedure": {
+                "task_type": "text-classification",
+                "data_format": "jsonl",
+                "training_type": "SFT",
+                "base_model": "Qwen/Qwen3.5-9B",
+                "hyperparameters": {"learning_rate": 1e-4, "batch_size": 1},
+                "notes": "",
+            },
+        },
+        "eval_suite": {
+            "primary_metric": "primary_metric",
+            "metrics": ["primary_metric"],
+            "test_split_path": "",
+            "use_llm_grading": False,
+        },
+        "current_script": "outputs/scripts/train.py",
+        "current_config": {"learning_rate": 1e-4, "batch_size": 1},
+        "current_patch": None,
+        "last_description": None,
+        "original_content": None,
+        "diary": [],
+        "baseline_score": None,
+        "best_score": None,
+        "best_script": "outputs/scripts/train.py",
+        "last_result": None,
+        "last_score": None,
+        "last_delta": None,
+        "iteration": 0,
+        "no_improve_streak": 0,
+        "should_stop": False,
+        "cost_manager": None,
+    }
+
+
+class _FakeCostManager:
+    def __init__(self):
+        self.started = []
+        self.stopped = 0
+        self.recorded = []
+
+    def start(self, job_id):
+        self.started.append(job_id)
+
+    def stop(self):
+        self.stopped += 1
+
+    def record_spend(self, amount, category="training"):
+        self.recorded.append((amount, category))
+        return "OK"
+
+
+class _FakeFuture:
+    def __init__(self, value):
+        self._value = value
+
+    def result(self):
+        return self._value
+
+
+class _FakeModelInput:
+    def __init__(self, length: int):
+        self.length = length
+
+
+class _FakeDatum:
+    def __init__(self, length: int, conversation=None):
+        self.model_input = _FakeModelInput(length)
+        self.conversation = conversation
+
+
+class _FakeRenderer:
+    def build_generation_prompt(self, messages):
+        return _FakeModelInput(len(messages) + 1)
+
+    def get_stop_sequences(self):
+        return [0]
+
+    def parse_response(self, tokens):
+        return {"role": "assistant", "content": "sample text"}, "stop"
+
+
+class _FakeTrainingClient:
+    def __init__(self, losses, forward_losses=None):
+        self.losses = list(losses)
+        self.forward_losses = list(forward_losses or [])
+        self.forward_backward_calls = 0
+        self.forward_calls = 0
+        self.optim_step_calls = 0
+        self.save_state_calls = 0
+        self.save_weights_calls = 0
+        self.sample_calls = 0
+        self.batches = []
+        self.forward_batches = []
+        self.sampling_client = _FakeSamplingClient()
+        self.sampling_client.training_client = self
+
+    def forward_backward(self, batch, loss_fn):
+        self.forward_backward_calls += 1
+        self.batches.append(batch)
+        loss = self.losses[min(self.forward_backward_calls - 1, len(self.losses) - 1)]
+        if isinstance(loss, dict):
+            return _FakeFuture(types.SimpleNamespace(metrics=loss))
+        return _FakeFuture(types.SimpleNamespace(loss=loss))
+
+    def forward(self, batch, loss_fn):
+        self.forward_calls += 1
+        self.forward_batches.append(batch)
+        loss = self.forward_losses[min(self.forward_calls - 1, len(self.forward_losses) - 1)]
+        if isinstance(loss, dict):
+            return _FakeFuture(types.SimpleNamespace(metrics=loss))
+        return _FakeFuture(types.SimpleNamespace(loss=loss))
+
+    def optim_step(self, adam_params):
+        self.optim_step_calls += 1
+        return _FakeFuture(types.SimpleNamespace(metrics={}))
+
+    def save_state(self, name):
+        self.save_state_calls += 1
+        return _FakeFuture(types.SimpleNamespace(path=f"tinker://state/{name}"))
+
+    def save_weights_for_sampler(self, name):
+        self.save_weights_calls += 1
+        return _FakeFuture(types.SimpleNamespace(path=f"tinker://sampler/{name}"))
+
+    def save_weights_and_get_sampling_client(self, name=None):
+        return self.sampling_client
+
+
+class _FakeSamplingClient:
+    def sample(self, prompt, num_samples, sampling_params):
+        self.training_client.sample_calls += 1
+        sequence = types.SimpleNamespace(tokens=[10, 11, 12])
+        return _FakeFuture(types.SimpleNamespace(sequences=[sequence]))
+
+
+class _FakeServiceClient:
+    def __init__(self, training_client):
+        self.training_client = training_client
+
+    def create_lora_training_client(self, base_model, rank):
+        self.base_model = base_model
+        self.rank = rank
+        return self.training_client
+
+
+def _install_fake_tinker_stack(monkeypatch, losses, forward_losses=None):
+    training_client = _FakeTrainingClient(losses, forward_losses=forward_losses)
+    service_client = _FakeServiceClient(training_client)
+
+    tinker_mod = types.ModuleType("tinker")
+    tinker_types_mod = types.ModuleType("tinker.types")
+
+    class AdamParams:
+        def __init__(self, learning_rate):
+            self.learning_rate = learning_rate
+
+    class SamplingParams:
+        def __init__(self, max_tokens, stop):
+            self.max_tokens = max_tokens
+            self.stop = stop
+
+    tinker_types_mod.AdamParams = AdamParams
+    tinker_types_mod.SamplingParams = SamplingParams
+    tinker_mod.types = tinker_types_mod
+    tinker_mod.ServiceClient = lambda: service_client
+
+    cookbook = types.ModuleType("tinker_cookbook")
+    model_info = types.ModuleType("tinker_cookbook.model_info")
+    model_info.get_recommended_renderer_name = MagicMock(side_effect=KeyError("missing"))
+    renderers = types.ModuleType("tinker_cookbook.renderers")
+    renderers.TrainOnWhat = types.SimpleNamespace(
+        ALL_ASSISTANT_MESSAGES="all_assistant_messages",
+        LAST_ASSISTANT_MESSAGE="last_assistant_message",
+    )
+    renderers.get_renderer = MagicMock(return_value=_FakeRenderer())
+    tokenizer_utils = types.ModuleType("tinker_cookbook.tokenizer_utils")
+    tokenizer_utils.get_tokenizer = MagicMock(return_value=object())
+    supervised_pkg = types.ModuleType("tinker_cookbook.supervised")
+    supervised_data = types.ModuleType("tinker_cookbook.supervised.data")
+    conversions = []
+
+    def conversation_to_datum(conversation, renderer, max_length, train_on_what):
+        conversions.append(
+            {
+                "conversation": conversation,
+                "max_length": max_length,
+                "train_on_what": train_on_what,
+            }
+        )
+        return _FakeDatum(length=len(json.dumps(conversation)), conversation=conversation)
+
+    supervised_data.conversation_to_datum = conversation_to_datum
+    supervised_pkg.data = supervised_data
+    cookbook.model_info = model_info
+    cookbook.renderers = renderers
+    cookbook.tokenizer_utils = tokenizer_utils
+
+    for name in [
+        "tinker",
+        "tinker.types",
+        "tinker_cookbook",
+        "tinker_cookbook.model_info",
+        "tinker_cookbook.renderers",
+        "tinker_cookbook.tokenizer_utils",
+        "tinker_cookbook.supervised",
+        "tinker_cookbook.supervised.data",
+    ]:
+        sys.modules.pop(name, None)
+
+    monkeypatch.setitem(sys.modules, "tinker", tinker_mod)
+    monkeypatch.setitem(sys.modules, "tinker.types", tinker_types_mod)
+    monkeypatch.setitem(sys.modules, "tinker_cookbook", cookbook)
+    monkeypatch.setitem(sys.modules, "tinker_cookbook.model_info", model_info)
+    monkeypatch.setitem(sys.modules, "tinker_cookbook.renderers", renderers)
+    monkeypatch.setitem(sys.modules, "tinker_cookbook.tokenizer_utils", tokenizer_utils)
+    monkeypatch.setitem(sys.modules, "tinker_cookbook.supervised", supervised_pkg)
+    monkeypatch.setitem(sys.modules, "tinker_cookbook.supervised.data", supervised_data)
+
+    importlib.reload(importlib.import_module("src.tinker_api.sft_runner"))
+    return types.SimpleNamespace(
+        training_client=training_client,
+        service_client=service_client,
+        conversions=conversions,
+    )


### PR DESCRIPTION
Replacement consolidated PR 1/8.

Supersedes draft PRs: #35, #43, #57, #60, #62, #65, #81, #94, #102, #107.

Scope:
- SDK-native Tinker chat/SFT runner and artifact contract.
- Dry-run backend and no-spend SDK guard behavior in Tinker boundaries.
- Loss/metric artifact robustness, heldout scoring, batching, cancellation finalization.
- Tinker/unit/live-smoke test coverage.

Validation on final replacement stack:
- `python3 -m compileall src`
- `env -u ANTHROPIC_API_KEY -u TINKER_API_KEY -u TAVILY_API_KEY UV_NO_NETWORK=1 uv run --with pytest --with fastapi --with httpx --with langgraph --with anthropic python -m pytest -q` -> `339 passed, 10 skipped`
- `ml-agent-frontend`: `npm run lint && npm run build`
- `spec-site`: `npm run lint && npm run build`

No live services or paid jobs were run for this consolidation.
