### PR TITLE
[codex] consolidated AutoResearch budgeted Tinker loop

### DIFF
--- a/src/autoresearch/__main__.py
+++ b/src/autoresearch/__main__.py
@@ -47,6 +47,10 @@ _RED    = "\033[31m"
 _BLUE   = "\033[34m"
 
 
+def _env_truthy(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 # ─── Claude strategy wrapper ──────────────────────────────────────────────────
 
 class ClaudeProposalStrategy(ProposalStrategy):
@@ -65,6 +69,8 @@ class ClaudeProposalStrategy(ProposalStrategy):
         }
 
     def propose(self, config: TrainingConfig, history: list[IterationRecord]) -> Proposal:
+        if _env_truthy("NO_SPEND"):
+            raise RuntimeError("Claude proposal strategy is disabled when NO_SPEND=1")
         from src.autoresearch.autoresearch import propose_hypothesis
         hypothesis = propose_hypothesis(config.to_dict(), history, self._task)
         patch_dict = json.loads(hypothesis["patch"])
@@ -225,6 +231,10 @@ def main() -> None:
         return
 
     if args.strategy == "claude":
+        if _env_truthy("NO_SPEND"):
+            print(f"{_RED}Error: --strategy claude is disabled when NO_SPEND=1.{_RESET}")
+            print("Use --strategy local or --strategy random, or unset NO_SPEND for a live run.")
+            sys.exit(1)
         if not os.getenv("ANTHROPIC_API_KEY"):
             print(f"{_RED}Error: ANTHROPIC_API_KEY is not set.{_RESET}")
             print(f"Export it and re-run:")

--- a/src/autoresearch/autoresearch.py
+++ b/src/autoresearch/autoresearch.py
@@ -12,15 +12,27 @@ from __future__ import annotations
 
 import json
 import math
+import os
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal, Mapping
+from uuid import uuid4
 
 import anthropic
 
+from src.autoresearch.config import TrainingConfig
+from src.autoresearch.proposer import LocalPerturbationProposalStrategy, ProposalStrategy
 from src.observability.observability import log_event
+from src.runtime_context import raise_if_cancelled, resolve_output_path
+from src.tinker_api.sft_runner import (
+    DEFAULT_LIVE_SMOKE_STEPS,
+    DEFAULT_TINKER_MODEL,
+    SUPPORTED_TINKER_TUNABLES,
+    run_tinker_sft_experiment,
+)
 from src.types import (
     AgentName,
     AutoResearchState,
+    BudgetStatus,
     CostBreakdown,
     DatasetResult,
     EvalScore,
@@ -28,7 +40,6 @@ from src.types import (
     ExperimentResult,
     Hypothesis,
     IterationRecord,
-    JobConfig,
     JobStatus,
     LogLevel,
     OrchestrationConfig,
@@ -44,6 +55,39 @@ _DIARY_PATH = Path("outputs/logs/research_diary.jsonl")
 _CONFIG_PATH = Path("configs/current.json")  # the JSON file apply_patch/revert_patch target
 _MAX_NO_IMPROVE = 3   # halt after this many consecutive non-improving iterations
 _MAX_ITERATIONS = 20  # hard cap on total iterations regardless of improvement
+_MIN_RELATIVE_IMPROVEMENT_PCT = 1.0
+_MIN_ABSOLUTE_IMPROVEMENT = 1e-9
+_BUDGET_SKIPPED_LOSS = 1_000_000_000.0
+_EXPERIMENT_CACHE: dict[str, ExperimentResult] = {}
+_TINKER_HYPERPARAMETER_ALIASES = {
+    "epochs": "num_epochs",
+    "max_seq_len": "max_seq_length",
+}
+_EVAL_ADAPTATION_ENV = "AUTORESEARCH_EVAL_ADAPTATION"
+_PROPOSER_ENV = "AUTORESEARCH_PROPOSER"
+_NO_SPEND_ENV = "NO_SPEND"
+
+
+def _env_truthy(name: str) -> bool:
+    """Return True for conventional truthy environment flag values."""
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _diary_path() -> Path:
+    return resolve_output_path(_DIARY_PATH, "logs", "research_diary.jsonl")
+
+
+def _config_path() -> Path:
+    return resolve_output_path(_CONFIG_PATH, "configs", "current.json")
+
+
+def _experiments_output_dir() -> Path:
+    return resolve_output_path(Path("outputs/experiments"), "experiments")
+
+
+def _raise_if_no_spend_live_llm(operation: str) -> None:
+    if _env_truthy(_NO_SPEND_ENV):
+        raise RuntimeError(f"{operation} is disabled when {_NO_SPEND_ENV}=1")
 
 
 def _patch_to_diff(patch_dict: dict, current_config: dict) -> str:
@@ -54,6 +98,122 @@ def _patch_to_diff(patch_dict: dict, current_config: dict) -> str:
         lines.append(f"- {key}: {old_val}")
         lines.append(f"+ {key}: {new_val}")
     return "\n".join(lines)
+
+
+def _canonicalize_tinker_hyperparameters(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Return Tinker V1 hyperparameters with legacy Manager aliases removed."""
+    canonical = dict(config)
+    for legacy_key, canonical_key in _TINKER_HYPERPARAMETER_ALIASES.items():
+        if legacy_key in canonical and canonical_key not in canonical:
+            canonical[canonical_key] = canonical[legacy_key]
+        canonical.pop(legacy_key, None)
+    return canonical
+
+
+def _eval_adaptation_setting() -> Literal["auto", "off", "required"]:
+    """Return the configured eval-suite adaptation mode."""
+    raw = os.getenv(_EVAL_ADAPTATION_ENV, "auto").strip().lower()
+    if raw in {"", "auto"}:
+        return "auto"
+    if raw in {"0", "false", "no", "off", "disabled"}:
+        return "off"
+    if raw in {"1", "true", "yes", "on", "required"}:
+        return "required"
+    raise ValueError(
+        f"{_EVAL_ADAPTATION_ENV} must be one of: auto, off, required"
+    )
+
+
+def _eval_adaptation_skip_reason() -> str | None:
+    """Return None when LLM eval adaptation may run, otherwise a skip reason."""
+    setting = _eval_adaptation_setting()
+    if setting == "off":
+        return f"{_EVAL_ADAPTATION_ENV}=off"
+    if _env_truthy(_NO_SPEND_ENV):
+        return f"{_NO_SPEND_ENV}=1"
+    if setting == "auto" and not os.getenv("ANTHROPIC_API_KEY"):
+        return "ANTHROPIC_API_KEY is not configured"
+    return None
+
+
+def _proposer_setting() -> Literal["auto", "local", "claude"]:
+    """Return the configured hypothesis proposer mode."""
+    raw = os.getenv(_PROPOSER_ENV, "auto").strip().lower()
+    if raw in {"", "auto"}:
+        return "auto"
+    if raw in {"local", "offline", "deterministic"}:
+        return "local"
+    if raw in {"claude", "anthropic", "required"}:
+        return "claude"
+    raise ValueError(
+        f"{_PROPOSER_ENV} must be one of: auto, local, claude"
+    )
+
+
+def _use_claude_proposer() -> bool:
+    """Return True when propose_node should call the live Claude proposer."""
+    setting = _proposer_setting()
+    if _env_truthy(_NO_SPEND_ENV):
+        return False
+    if setting == "claude":
+        return True
+    if setting == "local":
+        return False
+    return bool(os.getenv("ANTHROPIC_API_KEY"))
+
+
+def _current_config_for_plan(
+    plan: TrainingPlan,
+    config: OrchestrationConfig,
+) -> dict[str, Any]:
+    current_config = dict(config["training_procedure"]["hyperparameters"])
+    if plan.get("backend") == "tinker_sft":
+        return _canonicalize_tinker_hyperparameters(current_config)
+    return current_config
+
+
+def _training_config_for_proposal(state: AutoResearchState) -> TrainingConfig:
+    """Build a TrainingConfig snapshot from graph state hyperparameters."""
+    current_config = dict(state["current_config"])
+    if state["plan"].get("backend") == "tinker_sft":
+        current_config = _canonicalize_tinker_hyperparameters(current_config)
+
+    current_config.setdefault(
+        "model_name",
+        state["config"]["training_procedure"].get("base_model")
+        or state["plan"].get("base_model")
+        or DEFAULT_TINKER_MODEL,
+    )
+    return TrainingConfig.from_dict(current_config)
+
+
+def _local_proposal_strategy(state: AutoResearchState) -> ProposalStrategy:
+    """Return the deterministic offline proposer used by LangGraph local mode."""
+    return LocalPerturbationProposalStrategy(
+        seed=int(state["iteration"]),
+        backend=state["plan"].get("backend"),
+    )
+
+
+def _local_propose_hypothesis(
+    state: AutoResearchState,
+    task: TaskAnalysis,
+) -> Hypothesis:
+    """Generate a Hypothesis from ProposalStrategy without constructing Anthropic."""
+    proposal = _local_proposal_strategy(state).propose(
+        _training_config_for_proposal(state),
+        state["diary"],
+    )
+    param = proposal.metadata.get("param")
+    return Hypothesis(
+        description=proposal.hypothesis,
+        patch=json.dumps(proposal.patch),
+        expected_effect=(
+            f"Refine {task['eval_metric']} by testing a deterministic local "
+            f"perturbation of {param or 'one hyperparameter'}."
+        ),
+        search_strategy="local",
+    )
 
 
 # ─── GRAPH BUILDER ────────────────────────────────────────────────────────────
@@ -77,7 +237,11 @@ def build_autoresearch_graph():
     # Linear entry path
     graph.set_entry_point("init")
     graph.add_edge("init", "baseline")
-    graph.add_edge("baseline", "propose")
+    graph.add_conditional_edges(
+        "baseline",
+        continue_edge,
+        {"propose": "propose", "__end__": END},
+    )
 
     # Cyclic core: propose → run → (early-stop check) → evaluate → (keep/revert) → log → ...
     graph.add_edge("propose", "run")
@@ -114,14 +278,16 @@ def invoke_autoresearch_graph(
     initial_state: AutoResearchState = {
         "plan": plan,
         "config": config,
+        "cost_manager": cost_manager,
         "eval_suite": None,
         "current_script": plan["training_script_path"],
-        "current_config": config["training_procedure"]["hyperparameters"],
+        "current_config": _current_config_for_plan(plan, config),
         "current_patch": None,
         "last_description": None,
         "original_content": None,
         "diary": [],
         "baseline_score": None,
+        "baseline_result": None,
         "best_score": None,
         "best_script": plan["training_script_path"],
         "last_result": None,
@@ -132,24 +298,19 @@ def invoke_autoresearch_graph(
         "should_stop": False,
     }
 
+    raise_if_cancelled()
     final_state = graph.invoke(initial_state)
+    raise_if_cancelled()
 
-    total_cost = sum(r["cost_usd"] for r in final_state["diary"])
-    termination = "budget_limit" if final_state["should_stop"] else "training_complete"
-    cost_breakdown: CostBreakdown = {
-        "data_gen_usd": 0.0,
-        "training_usd": total_cost,
-        "llm_calls_usd": 0.0,
-        "total_usd": total_cost,
-        "termination_reason": termination,
-    }
+    termination = "budget_limit" if _budget_exhausted(final_state) else "training_complete"
+    cost_breakdown = _cost_breakdown_from_state(final_state, termination)
 
     return {
         "weights_path": final_state["best_script"],
         "metrics": final_state["best_score"],
         "cost": cost_breakdown,
         "n_iterations": final_state["iteration"],
-        "research_diary_path": str(_DIARY_PATH),
+        "research_diary_path": str(_diary_path()),
     }
 
 
@@ -157,6 +318,8 @@ def invoke_autoresearch_graph(
 
 def init_node(state: AutoResearchState) -> dict:
     """LangGraph node. Calls create_eval_suite(). Returns: { eval_suite, current_script, current_config, iteration: 0 }."""
+    raise_if_cancelled()
+    _write_current_config(_training_config_from_state(state))
     task_analysis: TaskAnalysis = {
         "task_type": state["config"]["training_procedure"]["task_type"],
         "modality": "text",
@@ -164,25 +327,7 @@ def init_node(state: AutoResearchState) -> dict:
         "eval_metric": state["plan"]["eval_metric"],
         "complexity": "medium",
     }
-    # Construct a minimal DatasetResult so create_eval_suite can derive the test path.
-    # The real dataset path comes from DataGen (F2); we point at the standard test split location.
-    script_dir = str(Path(state["plan"]["training_script_path"]).parent)
-    dataset_result: DatasetResult = {
-        "dataset": {
-            "path": script_dir,
-            "format": "jsonl",
-            "train_size": 0,
-            "val_size": 0,
-            "test_size": 0,
-        },
-        "mode_used": "A",
-        "quality_notes": "",
-        "validation_report": {
-            "passed": True,
-            "issues": [],
-            "sample_accuracy_estimate": 0.0,
-        },
-    }
+    dataset_result = _dataset_result_from_plan(state["plan"])
 
     eval_suite = create_eval_suite(task_analysis, dataset_result)
 
@@ -200,41 +345,48 @@ def init_node(state: AutoResearchState) -> dict:
     return {
         "eval_suite": eval_suite,
         "current_script": state["plan"]["training_script_path"],
-        "current_config": state["config"]["training_procedure"]["hyperparameters"],
+        "current_config": _current_config_for_plan(state["plan"], state["config"]),
         "iteration": 0,
     }
 
 
 def baseline_node(state: AutoResearchState) -> dict:
     """LangGraph node. Submits and evaluates the unmodified baseline script. Returns: { baseline_score, best_score }."""
+    raise_if_cancelled()
     log_event(
         AgentName.AUTORESEARCH,
         LogLevel.INFO,
         "BASELINE: submitting unmodified training script",
     )
 
-    job_id = submit_experiment(state["plan"]["training_script_path"], state["plan"])
-    timeout = int(state["config"]["training_procedure"].get("timeout_min", 5))
-    experiment = wait_for_experiment(job_id, timeout)
+    experiment = _run_tinker_experiment_for_state(state, phase="baseline")
+    budget_status = _record_experiment_cost(state, experiment)
+    raise_if_cancelled()
     baseline_score = run_evals(experiment["model_path"], state["eval_suite"])
 
     log_event(
         AgentName.AUTORESEARCH,
         LogLevel.INFO,
         f"BASELINE: scalar={baseline_score['scalar']:.4f}",
-        metadata={"score": baseline_score, "job_id": job_id},
+        metadata={"score": baseline_score, "job_id": experiment["job_id"]},
     )
 
     return {
         "baseline_score": baseline_score,
+        "baseline_result": experiment,
         "best_score": baseline_score,
-        "best_script": state["plan"]["training_script_path"],
+        "best_script": experiment["model_path"],
         "last_result": experiment,
+        "should_stop": (
+            budget_status == BudgetStatus.EXCEEDED
+            or experiment["status"] == JobStatus.CANCELLED
+        ),
     }
 
 
 def propose_node(state: AutoResearchState) -> dict:
     """LangGraph node. Calls propose_hypothesis() and apply_patch(). Returns: { current_script, current_patch, last_description, original_content }."""
+    raise_if_cancelled()
     task_analysis: TaskAnalysis = {
         "task_type": state["config"]["training_procedure"]["task_type"],
         "modality": "text",
@@ -248,10 +400,24 @@ def propose_node(state: AutoResearchState) -> dict:
         f"PROPOSE: generating hypothesis for iteration {state['iteration'] + 1}",
         metadata={"iteration": state["iteration"] + 1},
     )
-    hypothesis = propose_hypothesis(state["current_config"], state["diary"], task_analysis)
+    allowed_params = (
+        sorted(SUPPORTED_TINKER_TUNABLES)
+        if state["plan"].get("backend") == "tinker_sft"
+        else None
+    )
+    if _use_claude_proposer():
+        hypothesis = propose_hypothesis(
+            state["current_config"],
+            state["diary"],
+            task_analysis,
+            allowed_params=allowed_params,
+        )
+    else:
+        hypothesis = _local_propose_hypothesis(state, task_analysis)
+    raise_if_cancelled()
 
     # Bug fix: patch the config JSON, not the training script (.py files are not patchable).
-    original_content = apply_patch(str(_CONFIG_PATH), hypothesis["patch"])
+    original_content = apply_patch(str(_config_path()), hypothesis["patch"])
 
     log_event(
         AgentName.AUTORESEARCH,
@@ -275,7 +441,8 @@ def propose_node(state: AutoResearchState) -> dict:
 
 
 def run_node(state: AutoResearchState) -> dict:
-    """LangGraph node. Calls submit_experiment() and wait_for_experiment(). Returns: { last_result }."""
+    """LangGraph node. Runs a bounded SDK-native Tinker experiment. Returns: { last_result }."""
+    raise_if_cancelled()
     log_event(
         AgentName.AUTORESEARCH,
         LogLevel.INFO,
@@ -283,62 +450,60 @@ def run_node(state: AutoResearchState) -> dict:
         metadata={"iteration": state["iteration"] + 1},
     )
 
-    timeout = int(state["config"]["training_procedure"].get("timeout_min", 5))
-    job_id = submit_experiment(state["plan"]["training_script_path"], state["plan"], timeout)
-    result = wait_for_experiment(job_id, timeout)
+    result = _run_tinker_experiment_for_state(state, phase="iteration")
+    budget_status = _record_experiment_cost(state, result)
 
     log_event(
         AgentName.AUTORESEARCH,
         LogLevel.INFO,
-        f"RUN: job {job_id} finished — status={result['status']}",
-        metadata={"job_id": job_id, "cost_usd": result["cost_usd"]},
+        f"RUN: job {result['job_id']} finished — status={result['status']}",
+        metadata={"job_id": result["job_id"], "cost_usd": result["cost_usd"]},
     )
+    raise_if_cancelled()
 
-    return {"last_result": result}
+    return {
+        "last_result": result,
+        "should_stop": (
+            budget_status == BudgetStatus.EXCEEDED
+            or result["status"] == JobStatus.CANCELLED
+        ),
+    }
 
 
 def revert_and_continue_node(state: AutoResearchState) -> dict:
-    """LangGraph node (early stop path). Calls revert_patch(), logs REVERTED, increments iteration. Returns: { current_script, diary, iteration }."""
-    revert_patch(state["plan"]["training_script_path"], state["original_content"])
+    """LangGraph node (early stop path). Reverts the patch before normal logging."""
+    raise_if_cancelled()
+    revert_patch(str(_config_path()), state["original_content"])
 
+    budget_skipped = _last_result_was_budget_skipped(state)
+    reason = (
+        "budget preflight skipped iteration"
+        if budget_skipped
+        else "catastrophic failure"
+    )
     log_event(
         AgentName.AUTORESEARCH,
         LogLevel.WARN,
-        f"REVERTED (early-stop): catastrophic failure on iteration {state['iteration'] + 1}",
+        f"REVERTED (early-stop): {reason} on iteration {state['iteration'] + 1}",
         metadata={
             "iteration": state["iteration"] + 1,
             "metrics": state["last_result"]["metrics"] if state.get("last_result") else {},
         },
     )
 
-    # Build and persist the diary entry for this early-stopped iteration.
-    # last_result always exists here because run_node already wrote it.
-    patch_dict = json.loads(state.get("current_patch", "{}"))
-    diff = _patch_to_diff(patch_dict, state["current_config"])
-    record: IterationRecord = {
-        "iteration": state["iteration"] + 1,
-        "hypothesis": state.get("last_description", str(patch_dict)),
-        "patch": diff,
-        "cost_usd": state["last_result"]["cost_usd"],
-        "metrics": state["last_result"]["metrics"],
-        "decision": "REVERTED",
-        "notes": "Early-stopped: catastrophic failure (NaN/exploding loss/accuracy collapse)",
-    }
-    updated_diary = log_iteration(state["diary"], record)
-
     return {
         "current_script": state["plan"]["training_script_path"],
         "original_content": None,
-        "last_delta": None,  # signals early-stop path to log_node
-        "diary": updated_diary,
-        "iteration": state["iteration"] + 1,
+        "last_delta": None,  # signals early-stop path to log_node.
     }
 
 
 def evaluate_node(state: AutoResearchState) -> dict:
     """LangGraph node. Calls run_evals(), compare_scores(), flag_regression(). Returns: { last_score, last_delta }."""
+    raise_if_cancelled()
     last_score = run_evals(state["last_result"]["model_path"], state["eval_suite"])
-    last_delta = compare_scores(last_score, state["baseline_score"])
+    reference_score = state.get("best_score") or state["baseline_score"]
+    last_delta = compare_scores(last_score, reference_score)
     regressed = flag_regression(last_delta)
 
     log_event(
@@ -349,6 +514,7 @@ def evaluate_node(state: AutoResearchState) -> dict:
         + ("  ⚠ REGRESSION" if regressed else ""),
         metadata={
             "score": last_score,
+            "reference_score": reference_score,
             "delta": last_delta,
             "regression": regressed,
         },
@@ -368,6 +534,7 @@ def evaluate_node(state: AutoResearchState) -> dict:
 
 def keep_node(state: AutoResearchState) -> dict:
     """LangGraph node. Updates best_score and best_script. Resets no_improve_streak. Returns: { best_score, best_script, no_improve_streak: 0 }."""
+    raise_if_cancelled()
     log_event(
         AgentName.AUTORESEARCH,
         LogLevel.INFO,
@@ -379,10 +546,12 @@ def keep_node(state: AutoResearchState) -> dict:
     # call to propose_hypothesis() sees the real current state, not the original baseline.
     patch_dict = json.loads(state.get("current_patch", "{}"))
     updated_config = {**state["current_config"], **patch_dict}
+    if state["plan"].get("backend") == "tinker_sft":
+        updated_config = _canonicalize_tinker_hyperparameters(updated_config)
 
     return {
         "best_score": state["last_score"],
-        "best_script": state["plan"]["training_script_path"],
+        "best_script": state["last_result"]["model_path"],
         "current_config": updated_config,
         "no_improve_streak": 0,
     }
@@ -390,7 +559,8 @@ def keep_node(state: AutoResearchState) -> dict:
 
 def revert_node(state: AutoResearchState) -> dict:
     """LangGraph node. Calls revert_patch(). Increments no_improve_streak. Returns: { current_script, no_improve_streak }."""
-    revert_patch(str(_CONFIG_PATH), state["original_content"])
+    raise_if_cancelled()
+    revert_patch(str(_config_path()), state["original_content"])
 
     new_streak = state["no_improve_streak"] + 1
     log_event(
@@ -400,7 +570,7 @@ def revert_node(state: AutoResearchState) -> dict:
         metadata={"iteration": state["iteration"] + 1, "streak": new_streak},
     )
     return {
-        "current_script": state["best_script"],
+        "current_script": state["plan"]["training_script_path"],
         "original_content": None,
         "no_improve_streak": new_streak,
     }
@@ -408,6 +578,7 @@ def revert_node(state: AutoResearchState) -> dict:
 
 def log_node(state: AutoResearchState) -> dict:
     """LangGraph node. Calls log_iteration(). Calls adapt_eval_suite() every 10 iters. Returns: { diary, eval_suite, iteration }."""
+    raise_if_cancelled()
     iteration_number = state["iteration"] + 1
 
     # revert_and_continue_node already logged its entry and updated state["diary"].
@@ -419,6 +590,13 @@ def log_node(state: AutoResearchState) -> dict:
         if state["last_delta"] is not None and state["last_delta"]["improved"]:
             decision = "KEPT"
             notes = f"+{state['last_delta']['relative_pct']:.1f}% on {state['eval_suite']['primary_metric']}"
+        elif _last_result_was_early_stopped(state):
+            decision = "REVERTED"
+            notes = (
+                "Skipped: budget preflight rejected the Tinker run"
+                if _last_result_was_budget_skipped(state)
+                else "Early-stopped: catastrophic failure (NaN/Inf loss or primary metric collapse)"
+            )
         else:
             decision = "REVERTED"
             delta_pct = state["last_delta"]["relative_pct"] if state["last_delta"] else 0.0
@@ -430,7 +608,7 @@ def log_node(state: AutoResearchState) -> dict:
             else {"train_loss": 0.0, "val_loss": 0.0, "test_loss": 0.0, "primary_metric": 0.0}
         )
         patch_dict = json.loads(state.get("current_patch", "{}"))
-        diff = _patch_to_diff(patch_dict, state["current_config"])
+        diff = _patch_to_diff(patch_dict, _pre_patch_config_from_state(state))
         record: IterationRecord = {
             "iteration": iteration_number,
             "hypothesis": state.get("last_description", str(patch_dict)),
@@ -453,13 +631,22 @@ def log_node(state: AutoResearchState) -> dict:
         ]
         if recent_reverts:
             weaknesses = [r["notes"] for r in recent_reverts]
-            updated_suite = adapt_eval_suite(state["eval_suite"], weaknesses)
-            log_event(
-                AgentName.AUTORESEARCH,
-                LogLevel.INFO,
-                f"ADAPT: eval suite updated after {iteration_number} iterations",
-                metadata={"weaknesses": weaknesses},
-            )
+            skip_reason = _eval_adaptation_skip_reason()
+            if skip_reason:
+                log_event(
+                    AgentName.AUTORESEARCH,
+                    LogLevel.WARN,
+                    f"ADAPT: skipped eval suite update after {iteration_number} iterations",
+                    metadata={"reason": skip_reason, "weaknesses": weaknesses},
+                )
+            else:
+                updated_suite = adapt_eval_suite(state["eval_suite"], weaknesses)
+                log_event(
+                    AgentName.AUTORESEARCH,
+                    LogLevel.INFO,
+                    f"ADAPT: eval suite updated after {iteration_number} iterations",
+                    metadata={"weaknesses": weaknesses},
+                )
 
     return {
         "diary": updated_diary,
@@ -474,11 +661,39 @@ def early_stop_edge(state: AutoResearchState) -> Literal["evaluate", "revert_and
     """After run_node. Returns 'revert_and_continue' on catastrophic failure, 'evaluate' otherwise."""
     if state["last_result"] is None:
         return "revert_and_continue"
-    if state["last_result"]["status"] == JobStatus.FAILED:
+    if state["last_result"]["status"] in {JobStatus.FAILED, JobStatus.CANCELLED}:
         return "revert_and_continue"
     if check_early_stop(state["last_result"]["metrics"]):
         return "revert_and_continue"
     return "evaluate"
+
+
+def _last_result_was_early_stopped(state: AutoResearchState) -> bool:
+    if state.get("last_delta") is not None:
+        return False
+    last_result = state.get("last_result")
+    if last_result is None:
+        return True
+    if last_result["status"] in {JobStatus.FAILED, JobStatus.CANCELLED}:
+        return True
+    return check_early_stop(last_result["metrics"])
+
+
+def _last_result_was_budget_skipped(state: AutoResearchState) -> bool:
+    last_result = state.get("last_result")
+    if not last_result:
+        return False
+    try:
+        manifest_path = Path(last_result["model_path"]) / "manifest.json"
+    except (KeyError, TypeError):
+        return False
+    if not manifest_path.exists():
+        return False
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    return bool(manifest.get("budget_preflight_skipped"))
 
 
 def decision_edge(state: AutoResearchState) -> Literal["keep", "revert"]:
@@ -489,12 +704,13 @@ def decision_edge(state: AutoResearchState) -> Literal["keep", "revert"]:
 
 def continue_edge(state: AutoResearchState) -> Literal["propose", "__end__"]:
     """After log_node. Returns '__end__' if budget exhausted / convergence, else 'propose' to loop."""
+    raise_if_cancelled()
     if state["should_stop"]:
         return "__end__"
 
     budget = state["config"].get("compute_budget", float("inf"))
-    spent = sum(r["cost_usd"] for r in state["diary"])
-    if spent >= budget:
+    spent = _spent_usd_from_state(state)
+    if _budget_exhausted(state):
         log_event(
             AgentName.AUTORESEARCH,
             LogLevel.INFO,
@@ -521,24 +737,100 @@ def continue_edge(state: AutoResearchState) -> Literal["propose", "__end__"]:
     return "propose"
 
 
+def _pre_patch_config_from_state(state: AutoResearchState) -> dict[str, Any]:
+    original_content = state.get("original_content")
+    if original_content:
+        try:
+            original_config = json.loads(original_content)
+        except json.JSONDecodeError:
+            original_config = None
+        if isinstance(original_config, dict):
+            return original_config
+    return state["current_config"]
+
+
+def _spent_usd_from_state(state: AutoResearchState) -> float:
+    cost_manager = state.get("cost_manager")
+    if cost_manager is not None and hasattr(cost_manager, "spent_usd"):
+        return float(cost_manager.spent_usd)
+    baseline_cost = (
+        state.get("baseline_result", {}).get("cost_usd", 0.0)
+        if state.get("baseline_result")
+        else 0.0
+    )
+    return baseline_cost + sum(r["cost_usd"] for r in state["diary"])
+
+
+def _budget_exhausted(state: AutoResearchState) -> bool:
+    if state.get("should_stop"):
+        return True
+    cost_manager = state.get("cost_manager")
+    if cost_manager is not None and getattr(cost_manager, "status", None) == BudgetStatus.EXCEEDED:
+        return True
+    budget = state["config"].get("compute_budget", float("inf"))
+    return _spent_usd_from_state(state) >= budget
+
+
+def _cost_breakdown_from_state(
+    state: AutoResearchState,
+    termination_reason: str,
+) -> CostBreakdown:
+    cost_manager = state.get("cost_manager")
+    if cost_manager is not None and hasattr(cost_manager, "cost_breakdown"):
+        return cost_manager.cost_breakdown(termination_reason=termination_reason)
+
+    total_cost = _spent_usd_from_state(state)
+    return {
+        "data_gen_usd": 0.0,
+        "training_usd": total_cost,
+        "llm_calls_usd": 0.0,
+        "total_usd": total_cost,
+        "termination_reason": termination_reason,
+    }
+
+
 # ─── PROPOSE HELPERS ──────────────────────────────────────────────────────────
 
 def propose_hypothesis(
     current_config: dict,
     diary: ResearchDiary,
     task: TaskAnalysis,
+    allowed_params: list[str] | None = None,
 ) -> Hypothesis:
     """Calls Claude API (claude-haiku-4-5-20251001) to generate a single testable hypothesis as a code/config diff."""
+    _raise_if_no_spend_live_llm("Claude hypothesis proposal")
     client = anthropic.Anthropic()
     recent = diary[-5:] if len(diary) > 5 else diary
+    prompt_config = (
+        _canonicalize_tinker_hyperparameters(current_config)
+        if allowed_params
+        else current_config
+    )
 
     system = (
         "You are an ML hyperparameter optimization assistant for the AutoResearch Loop. "
         "You propose exactly ONE config-level change per iteration, grounded in the "
         "experiment history. Return only valid JSON — no prose, no markdown fences."
     )
+    change_rule = (
+        f"Change exactly ONE of these supported hyperparameters: {', '.join(allowed_params)}."
+        if allowed_params
+        else "Change exactly ONE hyperparameter."
+    )
+    if allowed_params:
+        bounds_rule = (
+            "Stay within safe bounds: learning_rate [1e-6, 1e-2], batch_size [4, 8192], "
+            "max_seq_length [128, 4096], lora_rank in [4,8,16,32,64,128], "
+            "num_epochs [1, 100]."
+        )
+    else:
+        bounds_rule = (
+            "Stay within safe bounds: learning_rate [1e-6, 1e-2], batch_size [4, 8192], "
+            "max_seq_length [128, 4096], lora_rank in [4,8,16,32,64,128], "
+            "warmup_steps [0, 2000], dropout [0, 0.5]."
+        )
     user = f"""Current training configuration:
-{json.dumps(current_config, indent=2)}
+{json.dumps(prompt_config, indent=2)}
 
 Task:
 - type: {task['task_type']}
@@ -549,10 +841,8 @@ Recent experiment history ({len(recent)} entries):
 {json.dumps(recent, indent=2) if recent else "No history yet — this is the first iteration."}
 
 Rules:
-- Change exactly ONE hyperparameter.
-- Stay within safe bounds: learning_rate [1e-6, 1e-2], batch_size [4, 8192],
-  max_seq_length [128, 4096], lora_rank in [4,8,16,32,64,128],
-  warmup_steps [0, 2000], dropout [0, 0.5].
+- {change_rule}
+- {bounds_rule}
 - Avoid repeating a change that recently caused a REVERTED outcome.
 - Prefer evidence-based choices over random exploration when history exists.
 
@@ -578,9 +868,18 @@ Respond with this JSON object and nothing else:
             if not line.startswith("```")
         )
     parsed = json.loads(raw)
+    patch = parsed["patch"]
+    if allowed_params:
+        patch = _canonicalize_tinker_hyperparameters(patch)
+        unsupported = [key for key in patch if key not in set(allowed_params)]
+        if unsupported:
+            raise ValueError(
+                f"Unsupported Tinker SFT hyperparameter(s): {unsupported}. "
+                f"Allowed: {allowed_params}"
+            )
     return Hypothesis(
         description=parsed["description"],
-        patch=json.dumps(parsed["patch"]),
+        patch=json.dumps(patch),
         expected_effect=parsed["expected_effect"],
         search_strategy=parsed["search_strategy"],
     )
@@ -602,7 +901,7 @@ def apply_patch(script_path: str, patch: str) -> str:
     if path.suffix == ".json":
         config_dict = json.loads(original)
         patch_dict = json.loads(patch)
-        config_dict.update(patch_dict)
+        config_dict = TrainingConfig.from_dict(config_dict).apply_patch(patch_dict).to_dict()
         # Write atomically via a temp file + rename so a crash mid-write
         # never leaves a partially-written config on disk.
         tmp = path.with_suffix(".json.tmp")
@@ -616,7 +915,7 @@ def apply_patch(script_path: str, patch: str) -> str:
         #     raise RuntimeError(f"patch failed: {result.stderr}")
         raise NotImplementedError(
             "Script-level patching not yet implemented. "
-            "Requires RUN phase and Tinker job submission."
+            "The Tinker SFT v1 path patches JSON config only."
         )
     else:
         raise ValueError(f"Unsupported file type for patching: {path.suffix!r}")
@@ -631,84 +930,357 @@ def revert_patch(script_path: str, original_content: str) -> None:
 
 # ─── RUN HELPERS ──────────────────────────────────────────────────────────────
 
+def _dataset_result_from_plan(plan: TrainingPlan) -> DatasetResult:
+    dataset_meta = plan.get("dataset")
+    if isinstance(dataset_meta, Mapping):
+        dataset_path = str(
+            dataset_meta.get("path")
+            or plan.get("dataset_path")
+            or Path(plan["training_script_path"]).parent
+        )
+        dataset_format = str(dataset_meta.get("format") or "jsonl")
+        train_size = max(0, int(dataset_meta.get("train_size") or 0))
+        val_size = max(0, int(dataset_meta.get("val_size") or 0))
+        test_size = max(0, int(dataset_meta.get("test_size") or 0))
+    else:
+        dataset_path = plan.get("dataset_path") or str(
+            Path(plan["training_script_path"]).parent
+        )
+        dataset_format = "jsonl"
+        train_size = 0
+        val_size = 0
+        test_size = 0
+
+    return {
+        "dataset": {
+            "path": dataset_path,
+            "format": dataset_format,
+            "train_size": train_size,
+            "val_size": val_size,
+            "test_size": test_size,
+        },
+        "mode_used": "A",
+        "quality_notes": "AutoResearch Tinker SFT dataset",
+        "validation_report": {
+            "passed": True,
+            "issues": [],
+            "sample_accuracy_estimate": 0.0,
+        },
+    }
+
+
+def _training_config_from_state(
+    state: AutoResearchState,
+    *,
+    include_pending_patch: bool = False,
+) -> TrainingConfig:
+    data: dict[str, Any] = (
+        _canonicalize_tinker_hyperparameters(state["current_config"])
+        if state["plan"].get("backend") == "tinker_sft"
+        else dict(state["current_config"])
+    )
+    data.setdefault("model_name", state["plan"].get("base_model") or DEFAULT_TINKER_MODEL)
+    lora = state["plan"].get("lora_config")
+    if lora and "lora_rank" not in data:
+        data["lora_rank"] = lora["rank"]
+    if lora and "lora_alpha" not in data:
+        data["lora_alpha"] = lora["alpha"]
+    config = TrainingConfig.from_dict(data)
+    if include_pending_patch and state.get("current_patch"):
+        config = config.apply_patch(json.loads(state["current_patch"]))
+    return config
+
+
+def _write_current_config(config: TrainingConfig) -> None:
+    config.save(_config_path())
+
+
+def _training_config_from_plan(plan: TrainingPlan) -> TrainingConfig:
+    config_path = _config_path()
+    if config_path.exists():
+        data = TrainingConfig.load(config_path).to_dict()
+    else:
+        data = {"model_name": plan.get("base_model") or DEFAULT_TINKER_MODEL}
+    data["model_name"] = plan.get("base_model") or data.get("model_name") or DEFAULT_TINKER_MODEL
+    lora = plan.get("lora_config")
+    if lora:
+        data.setdefault("lora_rank", lora["rank"])
+        data.setdefault("lora_alpha", lora["alpha"])
+    return TrainingConfig.from_dict(data)
+
+
+def _max_steps_from_state(state: AutoResearchState) -> int:
+    procedure = state["config"].get("training_procedure", {})
+    hyperparameters = procedure.get("hyperparameters", {})
+    for source in (state["current_config"], hyperparameters, procedure):
+        value = source.get("max_steps") if isinstance(source, dict) else None
+        if value is not None:
+            return max(1, int(value))
+    return DEFAULT_LIVE_SMOKE_STEPS
+
+
+def _estimated_run_cost_from_state(state: AutoResearchState) -> float:
+    """Returns the best available USD estimate for the next Tinker launch."""
+    plan = state.get("plan", {})
+    procedure = state.get("config", {}).get("training_procedure", {})
+    hyperparameters = (
+        procedure.get("hyperparameters", {})
+        if isinstance(procedure, Mapping)
+        else {}
+    )
+    candidates = (
+        plan.get("estimated_run_cost_usd"),
+        hyperparameters.get("estimated_run_cost_usd")
+        if isinstance(hyperparameters, Mapping)
+        else None,
+    )
+    for value in candidates:
+        if value is None:
+            continue
+        try:
+            return max(0.0, float(value))
+        except (TypeError, ValueError):
+            continue
+    return 0.0
+
+
+def _remaining_budget_from_state(state: AutoResearchState) -> float:
+    cost_manager = state.get("cost_manager")
+    if cost_manager is not None and hasattr(cost_manager, "remaining_budget"):
+        try:
+            return max(0.0, float(cost_manager.remaining_budget))
+        except (TypeError, ValueError):
+            pass
+
+    budget = state.get("config", {}).get("compute_budget", float("inf"))
+    try:
+        return max(0.0, float(budget) - _spent_usd_from_state(state))
+    except (TypeError, ValueError):
+        return float("inf")
+
+
+def _budget_preflight_skip_reason(
+    state: AutoResearchState,
+    estimated_cost: float,
+) -> str | None:
+    cost_manager = state.get("cost_manager")
+    remaining = _remaining_budget_from_state(state)
+
+    if cost_manager is not None and hasattr(cost_manager, "can_start_run"):
+        can_start = cost_manager.can_start_run(estimated_cost)
+    else:
+        can_start = remaining > 0 and estimated_cost <= remaining
+
+    if can_start:
+        return None
+    if remaining <= 0:
+        return "remaining budget is exhausted before launch"
+    if estimated_cost > remaining:
+        return (
+            f"estimated run cost ${estimated_cost:.2f} exceeds remaining "
+            f"budget ${remaining:.2f}"
+        )
+    return "budget preflight rejected launch"
+
+
+def _budget_limited_experiment_result(
+    run_id: str,
+    *,
+    reason: str,
+    estimated_cost: float,
+    remaining_budget: float,
+    output_dir: str = "outputs/experiments",
+) -> ExperimentResult:
+    run_dir = Path(output_dir) / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    metrics: TrainingMetrics = {
+        "train_loss": _BUDGET_SKIPPED_LOSS,
+        "val_loss": _BUDGET_SKIPPED_LOSS,
+        "test_loss": _BUDGET_SKIPPED_LOSS,
+        "primary_metric": 0.0,
+    }
+    metrics_row = {
+        "step": 0,
+        **metrics,
+        "budget_preflight_skipped": True,
+        "reason": reason,
+    }
+    metrics_path = run_dir / "metrics.jsonl"
+    metrics_path.write_text(json.dumps(metrics_row, allow_nan=False) + "\n")
+    (run_dir / "metrics.json").write_text(json.dumps(metrics, indent=2, allow_nan=False))
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "run_id": run_id,
+                "status": JobStatus.CANCELLED,
+                "backend": "tinker_sft",
+                "budget_preflight_skipped": True,
+                "budget_skip_reason": reason,
+                "estimated_cost_usd": round(float(estimated_cost), 6),
+                "remaining_budget_usd": round(float(remaining_budget), 6),
+                "completed_steps": 0,
+                "checkpoints": {},
+            },
+            indent=2,
+        )
+    )
+    (run_dir / "sample.json").write_text(
+        json.dumps({"prompt": [], "text": "", "tokens": [], "error": reason}, indent=2)
+    )
+    return {
+        "job_id": run_id,
+        "status": JobStatus.CANCELLED,
+        "metrics": metrics,
+        "model_path": str(run_dir),
+        "cost_usd": 0.0,
+        "logs_path": str(metrics_path),
+    }
+
+
+def _run_tinker_experiment_for_state(
+    state: AutoResearchState,
+    *,
+    phase: str,
+) -> ExperimentResult:
+    run_id = f"autoresearch-{phase}-{state['iteration']}-{uuid4().hex[:8]}"
+    estimated_cost = _estimated_run_cost_from_state(state)
+    remaining_budget = _remaining_budget_from_state(state)
+    skip_reason = _budget_preflight_skip_reason(state, estimated_cost)
+    if skip_reason:
+        log_event(
+            AgentName.AUTORESEARCH,
+            LogLevel.WARN,
+            "BUDGET: skipped Tinker launch before spend",
+            metadata={
+                "run_id": run_id,
+                "phase": phase,
+                "estimated_cost_usd": estimated_cost,
+                "remaining_budget_usd": remaining_budget,
+                "reason": skip_reason,
+            },
+        )
+        return _budget_limited_experiment_result(
+            run_id,
+            reason=skip_reason,
+            estimated_cost=estimated_cost,
+            remaining_budget=remaining_budget,
+            output_dir=str(_experiments_output_dir()),
+        )
+
+    cost_manager = state.get("cost_manager")
+    if cost_manager is not None and hasattr(cost_manager, "start"):
+        cost_manager.start(run_id)
+    try:
+        return run_tinker_sft_experiment(
+            _training_config_from_state(
+                state,
+                include_pending_patch=phase == "iteration",
+            ),
+            _dataset_result_from_plan(state["plan"]),
+            run_id=run_id,
+            max_steps=_max_steps_from_state(state),
+            output_dir=str(_experiments_output_dir()),
+        )
+    finally:
+        if cost_manager is not None and hasattr(cost_manager, "stop"):
+            cost_manager.stop()
+
+
+def _record_experiment_cost(
+    state: AutoResearchState,
+    result: ExperimentResult,
+    category: str = "training",
+) -> str | None:
+    cost_manager = state.get("cost_manager")
+    if cost_manager is None or not hasattr(cost_manager, "record_spend"):
+        return None
+    accounted_cost = _accounted_experiment_cost(state, result)
+    result["cost_usd"] = accounted_cost
+    return cost_manager.record_spend(accounted_cost, category=category)
+
+
+def _accounted_experiment_cost(
+    state: AutoResearchState,
+    result: ExperimentResult,
+) -> float:
+    actual_cost = max(0.0, float(result.get("cost_usd", 0.0)))
+    if _experiment_result_was_budget_skipped(result):
+        return actual_cost
+    return max(actual_cost, _estimated_run_cost_from_state(state))
+
+
+def _experiment_result_was_budget_skipped(result: ExperimentResult) -> bool:
+    try:
+        manifest_path = Path(result["model_path"]) / "manifest.json"
+    except (KeyError, TypeError):
+        return False
+    if not manifest_path.exists():
+        return False
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    return bool(manifest.get("budget_preflight_skipped"))
+
+
 def submit_experiment(
     script_path: str,
     plan: TrainingPlan,
     timeout_min: int = 5,
 ) -> str:
-    """Submits a constrained training run to Tinker. Returns the Tinker job ID."""
-    # Translate our TrainingPlan into a Tinker JobConfig.
-    # GPU allocation is kept minimal: single A100 with the plan's time budget.
-    from src.tinker_api.tinker_api import submit_job
+    """Run a constrained SDK-native Tinker experiment and return its run ID.
 
-    job_config: JobConfig = {
-        "gpu_type": "A100",
-        "num_gpus": 1,
-        "timeout_min": timeout_min,
-        "env_vars": {},
-        "output_dir": "outputs/experiments",
-    }
-    return submit_job(script_path, job_config)
+    Kept as a compatibility wrapper for older call sites; it no longer submits
+    a REST job.
+    """
+    _ = script_path, timeout_min
+    result = run_tinker_sft_experiment(
+        _training_config_from_plan(plan),
+        _dataset_result_from_plan(plan),
+        max_steps=DEFAULT_LIVE_SMOKE_STEPS,
+        output_dir=str(_experiments_output_dir()),
+    )
+    _EXPERIMENT_CACHE[result["job_id"]] = result
+    return result["job_id"]
 
 
 def wait_for_experiment(job_id: str, timeout_min: int) -> ExperimentResult:
-    """Polls Tinker for job completion. Raises TimeoutError if timeout_min exceeded."""
-    import time
-    from src.tinker_api.tinker_api import get_job_status, get_cumulative_spend
+    """Return a completed SDK-native Tinker experiment result."""
+    _ = timeout_min
+    if job_id in _EXPERIMENT_CACHE:
+        return _EXPERIMENT_CACHE[job_id]
 
-    deadline = time.time() + timeout_min * 60
-    poll_interval = 15  # seconds between status checks
-
-    while time.time() < deadline:
-        status = get_job_status(job_id)
-        if status == JobStatus.COMPLETED:
-            cost = get_cumulative_spend(job_id)
-            # Tinker writes metrics to outputs/experiments/<job_id>/metrics.json.
-            metrics_path = Path("outputs/experiments") / job_id / "metrics.json"
-            metrics: TrainingMetrics = json.loads(metrics_path.read_text())
-            model_path = str(Path("outputs/experiments") / job_id / "model")
-            return {
-                "job_id": job_id,
-                "status": status,
-                "metrics": metrics,
-                "model_path": model_path,
-                "cost_usd": cost,
-                "logs_path": str(Path("outputs/experiments") / job_id / "logs.txt"),
-            }
-        if status == JobStatus.FAILED:
-            return {
-                "job_id": job_id,
-                "status": status,
-                "metrics": {
-                    "train_loss": float("nan"),
-                    "val_loss": float("nan"),
-                    "test_loss": float("nan"),
-                    "primary_metric": 0.0,
-                },
-                "model_path": "",
-                "cost_usd": get_cumulative_spend(job_id),
-                "logs_path": str(Path("outputs/experiments") / job_id / "logs.txt"),
-            }
-        time.sleep(poll_interval)
-
-    raise TimeoutError(
-        f"Tinker job {job_id} did not finish within {timeout_min} minutes"
-    )
+    run_dir = _experiments_output_dir() / job_id
+    metrics_path = run_dir / "metrics.json"
+    if not metrics_path.exists():
+        raise TimeoutError(f"Tinker run {job_id} has no metrics artifact")
+    metrics: TrainingMetrics = json.loads(metrics_path.read_text())
+    manifest_path = run_dir / "manifest.json"
+    status = JobStatus.COMPLETED
+    if manifest_path.exists():
+        manifest = json.loads(manifest_path.read_text())
+        status = manifest.get("status", status)
+    return {
+        "job_id": job_id,
+        "status": status,
+        "metrics": metrics,
+        "model_path": str(run_dir),
+        "cost_usd": 0.0,
+        "logs_path": str(run_dir / "metrics.jsonl"),
+    }
 
 
 def check_early_stop(metrics: TrainingMetrics) -> bool:
-    """Returns True on catastrophic failure: exploding loss (>10× baseline), NaN, or accuracy collapse."""
+    """Returns True on catastrophic failure: non-finite loss or primary metric collapse."""
     for key in ("train_loss", "val_loss"):
         val = metrics.get(key)
         if val is not None and (math.isnan(val) or math.isinf(val)):
             return True
 
-    train_loss = metrics.get("train_loss")
-    if train_loss is not None and train_loss > 10.0:
-        return True
-
     primary = metrics.get("primary_metric")
-    if primary is not None and primary < 0.01:
+    if primary is not None and (
+        math.isnan(primary) or math.isinf(primary) or primary < 0.01
+    ):
         return True
 
     return False
@@ -717,21 +1289,25 @@ def check_early_stop(metrics: TrainingMetrics) -> bool:
 # ─── EVALUATE HELPERS ─────────────────────────────────────────────────────────
 
 def run_evals(model_path: str, eval_suite: EvalSuite) -> EvalScore:
-    """Runs the evaluation suite against the model and returns a scalar score + per-metric breakdown."""
-    # Wire-in point for the model inference layer (transformers / PEFT / Tinker artifacts).
-    #
-    # Expected implementation:
-    #   1. Load the model from model_path (AutoModelForSequenceClassification or equivalent).
-    #   2. Load the test split from eval_suite["test_split_path"].
-    #   3. Run inference and compute each metric in eval_suite["metrics"].
-    #   4. If eval_suite["use_llm_grading"], call Claude to score free-form outputs.
-    #   5. Return EvalScore with scalar = primary metric value, metrics = per-metric dict.
-    #
-    # Blocked on: transformers model loading + Tinker artifact download (F4).
-    raise NotImplementedError(
-        "run_evals not yet implemented. "
-        "Requires model loading from Tinker artifacts and inference infrastructure."
-    )
+    """Score Tinker SFT artifacts using val loss as the v1 proxy metric."""
+    _ = eval_suite
+    metrics_path = Path(model_path) / "metrics.json"
+    if not metrics_path.exists():
+        raise FileNotFoundError(f"Missing Tinker metrics artifact: {metrics_path}")
+    raw_metrics = json.loads(metrics_path.read_text())
+    val_loss = float(raw_metrics.get("val_loss", raw_metrics.get("train_loss", float("nan"))))
+    scalar = 0.0 if not math.isfinite(val_loss) or val_loss < 0 else 1.0 / (1.0 + val_loss)
+    metrics = {
+        "train_loss": float(raw_metrics.get("train_loss", val_loss)),
+        "val_loss": val_loss,
+        "test_loss": float(raw_metrics.get("test_loss", val_loss)),
+        "primary_metric": scalar,
+    }
+    return {
+        "scalar": scalar,
+        "metrics": metrics,
+        "critique": "Tinker SFT v1 score uses primary_metric = 1 / (1 + val_loss).",
+    }
 
 
 def compare_scores(new_score: EvalScore, baseline_score: EvalScore) -> ScoreDelta:
@@ -740,10 +1316,17 @@ def compare_scores(new_score: EvalScore, baseline_score: EvalScore) -> ScoreDelt
     base_val = baseline_score["scalar"]
     absolute = new_val - base_val
     relative_pct = (absolute / base_val * 100.0) if base_val != 0.0 else 0.0
+    if base_val == 0.0:
+        improved = absolute > _MIN_ABSOLUTE_IMPROVEMENT
+    else:
+        improved = (
+            absolute > _MIN_ABSOLUTE_IMPROVEMENT
+            and relative_pct >= _MIN_RELATIVE_IMPROVEMENT_PCT
+        )
     return {
         "absolute": absolute,
         "relative_pct": relative_pct,
-        "improved": absolute > 0.0,
+        "improved": improved,
     }
 
 
@@ -756,8 +1339,9 @@ def decide_keep_or_revert(delta: ScoreDelta) -> Literal["KEEP", "REVERT"]:
 
 def log_iteration(diary: ResearchDiary, record: IterationRecord) -> ResearchDiary:
     """Appends an IterationRecord to the research diary and writes to disk as JSONL."""
-    _DIARY_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with open(_DIARY_PATH, "a") as f:
+    diary_path = _diary_path()
+    diary_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(diary_path, "a") as f:
         f.write(json.dumps(record) + "\n")
     return [*diary, record]
 
@@ -803,6 +1387,7 @@ def create_eval_suite(task: TaskAnalysis, dataset: DatasetResult) -> EvalSuite:
 
 def adapt_eval_suite(suite: EvalSuite, weaknesses: list[str]) -> EvalSuite:
     """Adds harder eval examples targeting systematic weaknesses detected across recent iterations."""
+    _raise_if_no_spend_live_llm("Claude eval suite adaptation")
     client = anthropic.Anthropic()
 
     user = f"""You are an ML evaluation expert reviewing an AutoResearch experiment loop.

--- a/src/autoresearch/loop.py
+++ b/src/autoresearch/loop.py
@@ -132,21 +132,21 @@ class AutoResearchLoop:
 
     def run_experiment(self, config: TrainingConfig) -> None:
         """
-        TODO: Submit job to Tinker and block until completion.
+        TODO: Run a bounded SDK-native Tinker experiment and block until completion.
 
         Not implemented in the PROPOSE-only phase.
 
         When RUN is ready, this should:
-          1. Serialise config to a temp JSON and pass to tinker_api.submit_job().
-          2. Poll tinker_api.get_job_status(job_id) until COMPLETED or FAILED.
+          1. Build a TrainingConfig from the candidate config.
+          2. Call run_tinker_sft_experiment() and collect ExperimentResult artifacts.
           3. Respect Cost Manager (F4): if CostManager signals budget exceeded,
-             call tinker_api.cancel_job(job_id) and raise BudgetExceededError.
+             call tinker_api.cancel_job(run_id) and raise BudgetExceededError.
           4. Return ExperimentResult (job_id, metrics, model_path, cost_usd).
 
         See: src/tinker_api/tinker_api.py, src/cost_manager/cost_manager.py.
         """
         raise NotImplementedError(
-            "run_experiment not yet implemented. Requires Tinker job submission (F4)."
+            "run_experiment not yet implemented. Requires the Tinker SFT runner (F4)."
         )
 
     # ──────────────────────────────────────────────────────────────────────────

--- a/src/autoresearch/proposer.py
+++ b/src/autoresearch/proposer.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from src.autoresearch.config import BOUNDS, TrainingConfig
+from src.tinker_api.sft_runner import SUPPORTED_TINKER_TUNABLES
 from src.types import IterationRecord
 
 
@@ -67,8 +68,11 @@ class SearchSpace:
     NON_TUNABLE: frozenset[str] = frozenset({"model_name"})
 
     @classmethod
-    def tunable_params(cls) -> list[str]:
-        return [k for k in BOUNDS if k not in cls.NON_TUNABLE]
+    def tunable_params(cls, backend: str | None = None) -> list[str]:
+        params = [k for k in BOUNDS if k not in cls.NON_TUNABLE]
+        if backend == "tinker_sft":
+            return [k for k in params if k in SUPPORTED_TINKER_TUNABLES]
+        return params
 
     @classmethod
     def sample_value(cls, param: str, rng: random.Random) -> Any:
@@ -84,6 +88,31 @@ class SearchSpace:
         if spec.get("type") == int:
             val = int(round(val))
         return val
+
+    @classmethod
+    def sample_value_except(cls, param: str, current: Any, rng: random.Random) -> Any:
+        """Sample a valid value that differs from current when the space allows it."""
+        spec = BOUNDS[param]
+        if "candidates" in spec:
+            candidates = [value for value in spec["candidates"] if value != current]
+            return rng.choice(candidates or spec["candidates"])
+
+        for _ in range(16):
+            val = cls.sample_value(param, rng)
+            if val != current:
+                return val
+
+        lo = spec.get("min", current)
+        hi = spec.get("max", current)
+        if spec.get("type") == int:
+            current_int = int(current)
+            if current_int < hi:
+                return current_int + 1
+            if current_int > lo:
+                return current_int - 1
+        if current != lo:
+            return lo
+        return hi
 
     @classmethod
     def perturb_value(cls, param: str, current: Any, factor: float, rng: random.Random) -> Any:
@@ -102,21 +131,38 @@ class SearchSpace:
             try:
                 idx = candidates.index(current)
             except ValueError:
-                idx = 0
-            delta = rng.choice([-1, 0, 1])
-            new_idx = max(0, min(len(candidates) - 1, idx + delta))
+                return cls.sample_value_except(param, current, rng)
+            neighbor_indices = [i for i in (idx - 1, idx + 1) if 0 <= i < len(candidates)]
+            if not neighbor_indices:
+                return current
+            new_idx = rng.choice(neighbor_indices)
             return candidates[new_idx]
         # current=None or current=0 with a multiplicative scheme would get stuck;
         # fall back to sampling from the full range in those cases.
         if current is None or current == 0:
-            return cls.sample_value(param, rng)
-        multiplier = 1.0 + rng.uniform(-factor, factor)
-        val = current * multiplier
-        lo = spec.get("min", val)
-        hi = spec.get("max", val)
-        val = max(lo, min(hi, val))
+            return cls.sample_value_except(param, current, rng)
+        lo = spec.get("min", current)
+        hi = spec.get("max", current)
         if spec.get("type") == int:
-            val = int(round(val))
+            current_int = int(current)
+            direction = rng.choice([-1, 1])
+            if current_int <= lo:
+                direction = 1
+            elif current_int >= hi:
+                direction = -1
+            max_step = max(1, int(round(abs(current_int) * factor)))
+            step = rng.randint(1, max_step) * direction
+            val = max(lo, min(hi, current_int + step))
+            if val == current_int:
+                return cls.sample_value_except(param, current_int, rng)
+            return int(val)
+        direction = rng.choice([-1.0, 1.0])
+        magnitude = rng.uniform(max(factor * 0.1, 1e-12), factor)
+        multiplier = 1.0 + direction * magnitude
+        val = current * multiplier
+        val = max(lo, min(hi, val))
+        if val == current:
+            return cls.sample_value_except(param, current, rng)
         return val
 
 
@@ -151,11 +197,12 @@ class RandomSearchProposalStrategy(ProposalStrategy):
     stored in Proposal.metadata makes any iteration reproducible.
     """
 
-    def __init__(self, seed: int | None = None) -> None:
+    def __init__(self, seed: int | None = None, backend: str | None = None) -> None:
         # _next_seed advances on each call so a fixed initial seed still
         # produces a distinct proposal every iteration.
         self._next_seed = seed
         self._initial_seed = seed
+        self._backend = backend
 
     def propose(self, config: TrainingConfig, history: list[IterationRecord]) -> Proposal:
         if self._next_seed is not None:
@@ -164,9 +211,9 @@ class RandomSearchProposalStrategy(ProposalStrategy):
         else:
             seed = random.randint(0, 2**32 - 1)
         rng = random.Random(seed)
-        param = rng.choice(SearchSpace.tunable_params())
+        param = rng.choice(SearchSpace.tunable_params(self._backend))
         old_val = getattr(config, param, None)
-        new_val = SearchSpace.sample_value(param, rng)
+        new_val = SearchSpace.sample_value_except(param, old_val, rng)
         hypothesis = (
             f"Change {param} from {old_val} to {new_val} via random search "
             f"to explore a different region of the hyperparameter space."
@@ -198,10 +245,12 @@ class LocalPerturbationProposalStrategy(ProposalStrategy):
         perturbation_factor: float = 0.2,
         seed: int | None = None,
         history_window: int = 5,
+        backend: str | None = None,
     ) -> None:
         self._factor = perturbation_factor
         self._next_seed = seed
         self._window = history_window
+        self._backend = backend
 
     def propose(self, config: TrainingConfig, history: list[IterationRecord]) -> Proposal:
         if self._next_seed is not None:
@@ -210,7 +259,7 @@ class LocalPerturbationProposalStrategy(ProposalStrategy):
         else:
             seed = random.randint(0, 2**32 - 1)
         rng = random.Random(seed)
-        candidates = SearchSpace.tunable_params()
+        candidates = SearchSpace.tunable_params(self._backend)
 
         # Collect params that appeared in recently REVERTED patches.
         # The diary "patch" field is a diff string (format_patch_as_diff output),

--- a/src/cost_manager/__init__.py
+++ b/src/cost_manager/__init__.py
@@ -1,3 +1,3 @@
-from .cost_manager import start_cost_monitor, generate_cost_report
+from .cost_manager import CostManager, generate_cost_report, start_cost_monitor
 
-__all__ = ["start_cost_monitor", "generate_cost_report"]
+__all__ = ["CostManager", "start_cost_monitor", "generate_cost_report"]

--- a/src/cost_manager/cost_manager.py
+++ b/src/cost_manager/cost_manager.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import os
 import threading
-import time
 
 from src.types import BudgetStatus, CostBreakdown
 
@@ -41,7 +40,8 @@ def start_cost_monitor(
                     return
             except Exception:
                 pass  # don't crash the monitor on transient errors
-            time.sleep(poll_interval_sec)
+            if stop_event.wait(poll_interval_sec):
+                return
 
     thread = threading.Thread(target=_monitor, daemon=True, name=f"cost-monitor-{job_id}")
     thread.stop_event = stop_event  # type: ignore[attr-defined]
@@ -57,6 +57,8 @@ def poll_spend(job_id: str) -> float:
 
 def check_budget_status(spent: float, budget: float) -> str:
     """Returns BudgetStatus: OK (< 90%), WARNING (90–99%), EXCEEDED (>= 100%)."""
+    if budget <= 0:
+        return BudgetStatus.EXCEEDED if spent > 0 else BudgetStatus.OK
     ratio = spent / budget if budget > 0 else 0.0
     if ratio >= 1.0:
         return BudgetStatus.EXCEEDED
@@ -103,10 +105,84 @@ class CostManager:
     def __init__(self, budget: float):
         self.budget = budget
         self._thread: threading.Thread | None = None
+        self._lock = threading.Lock()
+        self._category_totals: dict[str, float] = {}
+
+    @property
+    def category_totals(self) -> dict[str, float]:
+        """Returns a snapshot of in-process spend by category."""
+        with self._lock:
+            return dict(self._category_totals)
+
+    @property
+    def spent_usd(self) -> float:
+        """Returns total in-process spend recorded through this manager."""
+        with self._lock:
+            return round(sum(self._category_totals.values()), 6)
+
+    @property
+    def remaining_budget(self) -> float:
+        """Returns the remaining budget after in-process spend."""
+        return max(0.0, round(self.budget - self.spent_usd, 6))
+
+    @property
+    def status(self) -> str:
+        """Returns the current in-process budget status."""
+        return check_budget_status(self.spent_usd, self.budget)
+
+    def can_start_run(self, estimated_cost: float = 0.0) -> bool:
+        """Returns whether a new run can start without exceeding remaining budget."""
+        try:
+            estimate = max(0.0, float(estimated_cost))
+        except (TypeError, ValueError):
+            estimate = 0.0
+
+        if self.status == BudgetStatus.EXCEEDED:
+            return False
+        if self.remaining_budget <= 0:
+            return False
+        return estimate <= self.remaining_budget
+
+    def record_spend(self, amount: float, category: str = "training") -> str:
+        """Records completed in-process spend and returns the updated budget status."""
+        amount = float(amount)
+        if amount < 0:
+            raise ValueError("CostManager.record_spend amount must be non-negative")
+        with self._lock:
+            self._category_totals[category] = (
+                self._category_totals.get(category, 0.0) + amount
+            )
+        return self.status
+
+    def cost_breakdown(self, termination_reason: str | None = None) -> CostBreakdown:
+        """Returns a CostBreakdown from in-process spend totals."""
+        totals = self.category_totals
+        data_gen = totals.get("data_gen", 0.0) + totals.get("data_generation", 0.0)
+        training = totals.get("training", 0.0)
+        llm_calls = totals.get("llm_calls", 0.0) + totals.get("llm", 0.0)
+        total = self.spent_usd
+        other = max(0.0, total - data_gen - training - llm_calls)
+        training += other
+        reason = termination_reason or (
+            "budget_limit" if self.status == BudgetStatus.EXCEEDED else "training_complete"
+        )
+        return {
+            "data_gen_usd": round(data_gen, 6),
+            "training_usd": round(training, 6),
+            "llm_calls_usd": round(llm_calls, 6),
+            "total_usd": total,
+            "termination_reason": reason,
+        }
 
     def start(self, job_id: str) -> None:
-        self._thread = start_cost_monitor(job_id, self.budget)
+        self.stop()
+        monitor_budget = self.remaining_budget if self.spent_usd > 0 else self.budget
+        self._thread = start_cost_monitor(job_id, monitor_budget)
 
     def stop(self) -> None:
         if self._thread:
+            stop_event = getattr(self._thread, "stop_event", None)
+            if stop_event is not None:
+                stop_event.set()
             self._thread.join(timeout=5)
+            self._thread = None

--- a/src/decision_engine/decision_engine.py
+++ b/src/decision_engine/decision_engine.py
@@ -8,9 +8,12 @@ estimates cost, and writes the training script passed to AutoResearch.
 
 from __future__ import annotations
 
+import math
 import os
+from pathlib import Path
 from textwrap import dedent
 
+from src.runtime_context import get_output_root
 from src.types import (
     CostEstimate,
     DatasetResult,
@@ -19,12 +22,14 @@ from src.types import (
     TaskAnalysis,
     TrainingPlan,
 )
+from src.tinker_api.sft_runner import DEFAULT_TINKER_MODEL
 
 # Cost per GPU-hour on Tinker (USD) — update when Tinker docs confirm pricing
 _TINKER_GPU_COST_PER_HOUR = 2.50
 
 # Rough model-size → GPU-hours-per-epoch lookup (for cost estimation)
 _MODEL_COST_PROFILE = {
+    DEFAULT_TINKER_MODEL:           {"gpu_hours_per_epoch": 0.15, "strategy": "fine-tune"},
     "bert-base-uncased":        {"gpu_hours_per_epoch": 0.1,  "strategy": "fine-tune"},
     "bert-large-uncased":       {"gpu_hours_per_epoch": 0.3,  "strategy": "fine-tune"},
     "distilbert-base-uncased":  {"gpu_hours_per_epoch": 0.05, "strategy": "fine-tune"},
@@ -34,12 +39,13 @@ _MODEL_COST_PROFILE = {
 }
 
 _TASK_TO_BASE_MODEL = {
-    "text-classification":       "distilbert-base-uncased",
-    "token-classification":      "bert-base-uncased",
-    "seq2seq":                   "t5-small",
-    "question-answering":        "bert-base-uncased",
-    "summarization":             "t5-base",
-    "translation":               "t5-small",
+    "text-classification":       DEFAULT_TINKER_MODEL,
+    "token-classification":      DEFAULT_TINKER_MODEL,
+    "seq2seq":                   DEFAULT_TINKER_MODEL,
+    "question-answering":        DEFAULT_TINKER_MODEL,
+    "summarization":             DEFAULT_TINKER_MODEL,
+    "translation":               DEFAULT_TINKER_MODEL,
+    "custom":                    DEFAULT_TINKER_MODEL,
 }
 
 _TASK_TO_METRIC = {
@@ -59,7 +65,10 @@ def run_decision_engine(
     """Top-level dispatcher. Runs task analysis → model selection → cost estimation → script generation."""
     task = analyze_task(config)
     budget = config["compute_budget"]
+    backend = "tinker_sft"
     model_id = find_base_model(task, budget)
+    if backend == "tinker_sft" and model_id is None:
+        model_id = _tinker_base_model_for_task(task)
     strategy = "fine-tune" if model_id else "pre-train"
     cost = estimate_training_cost(model_id, dataset, strategy)
 
@@ -75,10 +84,51 @@ def run_decision_engine(
         base_model=model_id,
         lora_config=lora,
         estimated_cost=cost["estimated_usd"],
+        estimated_run_cost_usd=estimate_autoresearch_run_cost(cost, config, dataset),
         estimated_time_min=cost["estimated_time_min"],
         training_script_path=script_path,
-        eval_metric=task["eval_metric"],
+        eval_metric="primary_metric" if backend == "tinker_sft" else task["eval_metric"],
+        backend=backend,
+        dataset_path=dataset["dataset"]["path"],
+        dataset=dataset["dataset"],
     )
+
+
+def _tinker_base_model_for_task(task: TaskAnalysis) -> str:
+    """Return the SDK-native Tinker SFT base model for V1 plans."""
+    return _TASK_TO_BASE_MODEL.get(task["task_type"], DEFAULT_TINKER_MODEL)
+
+
+def estimate_autoresearch_run_cost(
+    cost: CostEstimate,
+    config: OrchestrationConfig,
+    dataset: DatasetResult,
+) -> float:
+    """Estimate one bounded AutoResearch Tinker launch from the full plan cost."""
+    total_cost = max(0.0, float(cost["estimated_usd"]))
+    if total_cost == 0.0:
+        return 0.0
+
+    hp = config["training_procedure"].get("hyperparameters", {})
+    max_steps = hp.get("max_steps")
+    if max_steps is None:
+        return round(total_cost, 4)
+
+    train_size = _positive_int(dataset["dataset"].get("train_size"), default=1)
+    batch_size = _positive_int(hp.get("batch_size"), default=16)
+    epochs = _positive_int(hp.get("num_epochs", hp.get("epochs")), default=3)
+    full_steps = max(1, math.ceil(train_size / batch_size) * epochs)
+    bounded_steps = _positive_int(max_steps, default=full_steps)
+    ratio = min(1.0, bounded_steps / full_steps)
+    return round(min(total_cost, max(0.01, total_cost * ratio)), 4)
+
+
+def _positive_int(value, *, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
 
 
 def analyze_task(config: OrchestrationConfig) -> TaskAnalysis:
@@ -152,8 +202,7 @@ def write_finetune_script(
     config: OrchestrationConfig,
 ) -> str:
     """Generates a complete LoRA fine-tuning train.py. Returns the path to the written script."""
-    os.makedirs("outputs/scripts", exist_ok=True)
-    path = "outputs/scripts/train.py"
+    path = _training_script_path()
     hp = config["training_procedure"]["hyperparameters"]
 
     script = dedent(f"""\
@@ -217,8 +266,7 @@ def write_pretrain_script(
     config: OrchestrationConfig,
 ) -> str:
     """Generates a from-scratch train.py for pre-training. Returns the path to the written script."""
-    os.makedirs("outputs/scripts", exist_ok=True)
-    path = "outputs/scripts/train.py"
+    path = _training_script_path()
     hp = config["training_procedure"]["hyperparameters"]
 
     script = dedent(f"""\
@@ -262,3 +310,14 @@ def write_pretrain_script(
     with open(path, "w") as f:
         f.write(script)
     return os.path.abspath(path)
+
+
+def _training_script_path() -> str:
+    root = get_output_root()
+    path = (
+        root / "scripts" / "train.py"
+        if root is not None
+        else Path("outputs/scripts/train.py")
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return str(path)

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -2,6 +2,7 @@
 
 import json
 import math
+import sys
 from pathlib import Path
 
 import pytest
@@ -59,6 +60,13 @@ def _minimal_dataset(path="/tmp/data"):
     }
 
 
+def _fail_live_service(name: str):
+    def _fail(*_args, **_kwargs):
+        raise AssertionError(f"{name} should not be used in this test")
+
+    return _fail
+
+
 # ─── build_autoresearch_graph ─────────────────────────────────────────────────
 
 def test_build_autoresearch_graph_returns_compiled_graph():
@@ -67,6 +75,151 @@ def test_build_autoresearch_graph_returns_compiled_graph():
     from src.autoresearch.autoresearch import build_autoresearch_graph
     graph = build_autoresearch_graph()
     assert graph is not None
+
+
+def test_autoresearch_graph_stops_on_budget_boundary_after_tinker_run(
+    monkeypatch,
+    tmp_path,
+):
+    pytest.importorskip("langgraph", reason="langgraph not installed")
+
+    import threading
+
+    import src.autoresearch.autoresearch as ar
+    import src.cost_manager.cost_manager as cost_module
+    from src.cost_manager.cost_manager import CostManager
+    from src.tinker_api.sft_runner import DEFAULT_TINKER_MODEL
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("TINKER_API_KEY", raising=False)
+    monkeypatch.setenv("AUTORESEARCH_PROPOSER", "claude")
+    monkeypatch.setattr("anthropic.Anthropic", _fail_live_service("Claude"))
+
+    def fake_cost_monitor(*_args, **_kwargs):
+        thread = threading.Thread(target=lambda: None)
+        thread.stop_event = threading.Event()  # type: ignore[attr-defined]
+        thread.start()
+        return thread
+
+    monkeypatch.setattr(cost_module, "start_cost_monitor", fake_cost_monitor)
+
+    dataset_path = tmp_path / "train.jsonl"
+    dataset_path.write_text(
+        json.dumps({"input": "urgent ticket", "output": "escalate"}) + "\n",
+        encoding="utf-8",
+    )
+
+    runner_calls = []
+    proposal_calls = []
+
+    def fake_propose_hypothesis(current_config, diary, task, allowed_params=None):
+        proposal_calls.append(
+            {
+                "current_config": dict(current_config),
+                "diary_len": len(diary),
+                "allowed_params": allowed_params,
+            }
+        )
+        if len(proposal_calls) > 1:
+            raise AssertionError("graph should stop at the budget boundary before another proposal")
+        assert "learning_rate" in allowed_params
+        return {
+            "description": "Increase learning_rate for one bounded fake Tinker run.",
+            "patch": json.dumps({"learning_rate": 2e-4}),
+            "expected_effect": "Improve the fake validation metric.",
+            "search_strategy": "test-double",
+        }
+
+    def fake_tinker_runner(config, dataset, *, run_id=None, max_steps=None, **_kwargs):
+        assert dataset["dataset"]["path"] == str(dataset_path)
+        assert config.model_name == DEFAULT_TINKER_MODEL
+        assert max_steps == 2
+
+        call_number = len(runner_calls) + 1
+        runner_calls.append(
+            {
+                "run_id": run_id,
+                "learning_rate": config.learning_rate,
+            }
+        )
+
+        val_loss = 0.50 if call_number == 1 else 0.25
+        metrics = {
+            "train_loss": val_loss + 0.05,
+            "val_loss": val_loss,
+            "test_loss": val_loss + 0.02,
+            "primary_metric": 1.0 / (1.0 + val_loss),
+        }
+        run_dir = Path("outputs/experiments") / str(run_id)
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "metrics.json").write_text(json.dumps(metrics), encoding="utf-8")
+        (run_dir / "metrics.jsonl").write_text(
+            json.dumps({"step": 1, **metrics}) + "\n",
+            encoding="utf-8",
+        )
+        return {
+            "job_id": str(run_id),
+            "status": "COMPLETED",
+            "metrics": metrics,
+            "model_path": str(run_dir),
+            "cost_usd": 0.01,
+            "logs_path": str(run_dir / "metrics.jsonl"),
+        }
+
+    monkeypatch.setattr(ar, "propose_hypothesis", fake_propose_hypothesis)
+    monkeypatch.setattr(ar, "run_tinker_sft_experiment", fake_tinker_runner)
+
+    plan = {
+        "strategy": "fine-tune",
+        "base_model": DEFAULT_TINKER_MODEL,
+        "lora_config": {"rank": 8, "alpha": 16, "dropout": 0.05, "target_modules": []},
+        "estimated_cost": 0.02,
+        "estimated_time_min": 5,
+        "training_script_path": str(tmp_path / "train.py"),
+        "eval_metric": "primary_metric",
+        "backend": "tinker_sft",
+        "dataset_path": str(dataset_path),
+    }
+    config = {
+        "data": False,
+        "prompt": "classify support tickets",
+        "compute_budget": 0.02,
+        "training_procedure": {
+            "task_type": "text-classification",
+            "data_format": "jsonl",
+            "training_type": "SFT",
+            "base_model": DEFAULT_TINKER_MODEL,
+            "hyperparameters": {
+                "learning_rate": 1e-4,
+                "batch_size": 4,
+                "num_epochs": 1,
+                "max_seq_length": 256,
+                "max_steps": 2,
+            },
+            "notes": "offline graph budget-boundary test",
+        },
+    }
+
+    result = ar.invoke_autoresearch_graph(plan, config, CostManager(0.02))
+
+    assert result["n_iterations"] == 1
+    assert result["cost"]["total_usd"] == pytest.approx(0.02)
+    assert result["cost"]["termination_reason"] == "budget_limit"
+    assert result["metrics"]["scalar"] == pytest.approx(0.8)
+    assert len(proposal_calls) == 1
+    assert len(runner_calls) == 2
+    assert runner_calls[0]["run_id"].startswith("autoresearch-baseline-0-")
+    assert runner_calls[1]["run_id"].startswith("autoresearch-iteration-0-")
+    assert [call["learning_rate"] for call in runner_calls] == [1e-4, 2e-4]
+
+    diary_records = [
+        json.loads(line)
+        for line in Path(result["research_diary_path"]).read_text().splitlines()
+        if line.strip()
+    ]
+    assert len(diary_records) == 1
+    assert diary_records[0]["decision"] == "KEPT"
 
 
 # ─── apply_patch / revert_patch ───────────────────────────────────────────────
@@ -100,14 +253,14 @@ def test_check_early_stop_true_on_inf_loss():
     assert check_early_stop(metrics) is True
 
 
-def test_check_early_stop_true_on_exploding_loss():
+def test_check_early_stop_false_on_high_finite_sft_loss():
     metrics = {
         "train_loss": 15.0,
         "val_loss": 14.0,
         "test_loss": 14.5,
         "primary_metric": 0.10,
     }
-    assert check_early_stop(metrics) is True
+    assert check_early_stop(metrics) is False
 
 
 def test_check_early_stop_true_on_accuracy_collapse():
@@ -116,6 +269,16 @@ def test_check_early_stop_true_on_accuracy_collapse():
         "val_loss": 0.45,
         "test_loss": 0.50,
         "primary_metric": 0.001,
+    }
+    assert check_early_stop(metrics) is True
+
+
+def test_check_early_stop_true_on_nonfinite_primary_metric():
+    metrics = {
+        "train_loss": 0.4,
+        "val_loss": 0.45,
+        "test_loss": 0.50,
+        "primary_metric": float("nan"),
     }
     assert check_early_stop(metrics) is True
 
@@ -146,6 +309,21 @@ def test_compare_scores_not_improved_when_lower():
     baseline  = {"scalar": 0.85, "metrics": {}, "critique": ""}
     delta = compare_scores(new_score, baseline)
     assert delta["improved"] is False
+
+
+def test_compare_scores_tiny_positive_delta_is_not_improved():
+    new_score = {"scalar": 0.057829344672345545, "metrics": {}, "critique": ""}
+    baseline = {"scalar": 0.0577940194157755, "metrics": {}, "critique": ""}
+    delta = compare_scores(new_score, baseline)
+    assert delta["relative_pct"] == pytest.approx(0.0611, abs=0.001)
+    assert delta["improved"] is False
+
+
+def test_compare_scores_zero_baseline_allows_positive_improvement():
+    new_score = {"scalar": 0.01, "metrics": {}, "critique": ""}
+    baseline = {"scalar": 0.0, "metrics": {}, "critique": ""}
+    delta = compare_scores(new_score, baseline)
+    assert delta["improved"] is True
 
 
 def test_compare_scores_tie_not_improved():
@@ -188,6 +366,36 @@ def test_flag_regression_at_boundary_is_not_triggered():
     # absolute == threshold: strict < means no flag
     delta = {"absolute": -0.01, "relative_pct": -1.0, "improved": False}
     assert flag_regression(delta, threshold=-0.01) is False
+
+
+def test_evaluate_node_compares_against_current_best(monkeypatch):
+    import src.autoresearch.autoresearch as ar
+
+    monkeypatch.setattr(
+        ar,
+        "run_evals",
+        lambda _model_path, _suite: {"scalar": 0.70, "metrics": {}, "critique": ""},
+    )
+    state = _make_state(
+        eval_suite={"primary_metric": "accuracy", "metrics": [], "test_split_path": "",
+                    "use_llm_grading": False},
+        baseline_score={"scalar": 0.50, "metrics": {}, "critique": ""},
+        best_score={"scalar": 0.80, "metrics": {}, "critique": ""},
+        last_result={
+            "job_id": "candidate",
+            "status": "COMPLETED",
+            "metrics": {"train_loss": 0.3, "val_loss": 0.4,
+                        "test_loss": 0.5, "primary_metric": 0.70},
+            "model_path": "candidate-model",
+            "cost_usd": 0.01,
+            "logs_path": "candidate.jsonl",
+        },
+    )
+
+    out = ar.evaluate_node(state)
+
+    assert out["last_delta"]["improved"] is False
+    assert out["last_delta"]["absolute"] == pytest.approx(-0.10)
 
 
 # ─── log_iteration ────────────────────────────────────────────────────────────
@@ -237,6 +445,563 @@ def test_log_iteration_returns_extended_diary(tmp_path, monkeypatch):
         ar._DIARY_PATH = original_path
 
 
+def test_log_node_uses_pre_patch_config_for_kept_diff(tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    original_path = ar._DIARY_PATH
+    ar._DIARY_PATH = tmp_path / "diary.jsonl"
+    try:
+        state = _make_state(
+            eval_suite={"primary_metric": "accuracy", "metrics": [], "test_split_path": "",
+                        "use_llm_grading": False},
+            current_config={"learning_rate": 2e-4, "batch_size": 4},
+            current_patch=json.dumps({"learning_rate": 2e-4}),
+            original_content=json.dumps({"learning_rate": 1e-4, "batch_size": 4}),
+            last_description="Increase learning rate.",
+            last_delta={"absolute": 0.1, "relative_pct": 20.0, "improved": True},
+            last_result={
+                "job_id": "candidate",
+                "status": "COMPLETED",
+                "metrics": {"train_loss": 0.3, "val_loss": 0.4,
+                            "test_loss": 0.5, "primary_metric": 0.70},
+                "model_path": "candidate-model",
+                "cost_usd": 0.01,
+                "logs_path": "candidate.jsonl",
+            },
+        )
+
+        out = ar.log_node(state)
+
+        assert out["diary"][0]["decision"] == "KEPT"
+        assert "- learning_rate: 0.0001" in out["diary"][0]["patch"]
+        assert "+ learning_rate: 0.0002" in out["diary"][0]["patch"]
+    finally:
+        ar._DIARY_PATH = original_path
+
+
+def test_log_node_records_early_stop_once(tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    original_path = ar._DIARY_PATH
+    ar._DIARY_PATH = tmp_path / "diary.jsonl"
+    try:
+        state = _make_state(
+            eval_suite={"primary_metric": "primary_metric", "metrics": [], "test_split_path": "",
+                        "use_llm_grading": False},
+            current_config={"learning_rate": 1e-4, "batch_size": 4},
+            current_patch=json.dumps({"learning_rate": 2e-4}),
+            original_content=None,
+            last_description="Increase learning rate.",
+            last_delta=None,
+            last_result={
+                "job_id": "candidate",
+                "status": "COMPLETED",
+                "metrics": {"train_loss": float("inf"), "val_loss": 0.4,
+                            "test_loss": 0.5, "primary_metric": 0.70},
+                "model_path": "candidate-model",
+                "cost_usd": 0.01,
+                "logs_path": "candidate.jsonl",
+            },
+        )
+
+        out = ar.log_node(state)
+
+        assert out["iteration"] == 1
+        assert len(out["diary"]) == 1
+        assert out["diary"][0]["iteration"] == 1
+        assert out["diary"][0]["decision"] == "REVERTED"
+        assert "Early-stopped" in out["diary"][0]["notes"]
+        lines = [l for l in ar._DIARY_PATH.read_text().splitlines() if l.strip()]
+        assert len(lines) == 1
+    finally:
+        ar._DIARY_PATH = original_path
+
+
+def test_log_node_labels_budget_preflight_skip(tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    run_dir = tmp_path / "budget-skip"
+    run_dir.mkdir()
+    (run_dir / "manifest.json").write_text(
+        json.dumps({"budget_preflight_skipped": True})
+    )
+    original_path = ar._DIARY_PATH
+    ar._DIARY_PATH = tmp_path / "diary.jsonl"
+    try:
+        state = _make_state(
+            eval_suite={"primary_metric": "primary_metric", "metrics": [], "test_split_path": "",
+                        "use_llm_grading": False},
+            current_config={"learning_rate": 1e-4, "batch_size": 4},
+            current_patch=json.dumps({"learning_rate": 2e-4}),
+            last_description="Increase learning rate.",
+            last_delta=None,
+            last_result={
+                "job_id": "candidate",
+                "status": "CANCELLED",
+                "metrics": {"train_loss": 1e9, "val_loss": 1e9,
+                            "test_loss": 1e9, "primary_metric": 0.0},
+                "model_path": str(run_dir),
+                "cost_usd": 0.0,
+                "logs_path": str(run_dir / "metrics.jsonl"),
+            },
+        )
+
+        out = ar.log_node(state)
+
+        assert out["diary"][0]["decision"] == "REVERTED"
+        assert "budget preflight" in out["diary"][0]["notes"]
+    finally:
+        ar._DIARY_PATH = original_path
+
+
+def test_log_node_skips_eval_adaptation_without_anthropic_key(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    def fail_anthropic():
+        raise AssertionError("Anthropic should not be constructed in auto mode without a key")
+
+    events = []
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("AUTORESEARCH_EVAL_ADAPTATION", raising=False)
+    monkeypatch.setattr(ar.anthropic, "Anthropic", fail_anthropic)
+    monkeypatch.setattr(
+        ar,
+        "log_event",
+        lambda agent, level, message, metadata=None, **kwargs: events.append(
+            {"level": level, "message": message, "metadata": metadata or {}}
+        ),
+    )
+
+    original_path = ar._DIARY_PATH
+    ar._DIARY_PATH = tmp_path / "diary.jsonl"
+    suite = {"primary_metric": "accuracy", "metrics": ["accuracy"],
+             "test_split_path": "", "use_llm_grading": False}
+    try:
+        state = _make_state(
+            eval_suite=suite,
+            diary=[
+                {"iteration": i, "hypothesis": "", "patch": "", "cost_usd": 0.0,
+                 "metrics": {}, "decision": "REVERTED", "notes": f"revert {i}"}
+                for i in range(1, 10)
+            ],
+            iteration=9,
+            current_config={"learning_rate": 1e-4},
+            current_patch=json.dumps({"learning_rate": 2e-4}),
+            last_description="Increase learning rate.",
+            last_delta={"absolute": -0.01, "relative_pct": -2.0, "improved": False},
+            last_result={
+                "job_id": "candidate",
+                "status": "COMPLETED",
+                "metrics": {"train_loss": 0.4, "val_loss": 0.5,
+                            "test_loss": 0.6, "primary_metric": 0.65},
+                "model_path": "candidate-model",
+                "cost_usd": 0.01,
+                "logs_path": "candidate.jsonl",
+            },
+        )
+
+        out = ar.log_node(state)
+
+        assert out["iteration"] == 10
+        assert out["eval_suite"] == suite
+        assert any("skipped eval suite update" in event["message"] for event in events)
+        assert events[-1]["metadata"]["reason"] == "ANTHROPIC_API_KEY is not configured"
+    finally:
+        ar._DIARY_PATH = original_path
+
+
+def test_log_node_no_spend_skips_eval_adaptation_even_when_required(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    def fail_adapt_eval_suite(*args, **kwargs):
+        raise AssertionError("Eval adaptation should not run when NO_SPEND=1")
+
+    events = []
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-present")
+    monkeypatch.setenv("AUTORESEARCH_EVAL_ADAPTATION", "required")
+    monkeypatch.setattr(ar, "adapt_eval_suite", fail_adapt_eval_suite)
+    monkeypatch.setattr(
+        ar,
+        "log_event",
+        lambda agent, level, message, metadata=None, **kwargs: events.append(
+            {"level": level, "message": message, "metadata": metadata or {}}
+        ),
+    )
+
+    original_path = ar._DIARY_PATH
+    ar._DIARY_PATH = tmp_path / "diary.jsonl"
+    suite = {"primary_metric": "accuracy", "metrics": ["accuracy"],
+             "test_split_path": "", "use_llm_grading": False}
+    try:
+        state = _make_state(
+            eval_suite=suite,
+            diary=[
+                {"iteration": i, "hypothesis": "", "patch": "", "cost_usd": 0.0,
+                 "metrics": {}, "decision": "REVERTED", "notes": f"revert {i}"}
+                for i in range(1, 10)
+            ],
+            iteration=9,
+            current_config={"learning_rate": 1e-4},
+            current_patch=json.dumps({"learning_rate": 2e-4}),
+            last_description="Increase learning rate.",
+            last_delta={"absolute": -0.01, "relative_pct": -2.0, "improved": False},
+            last_result={
+                "job_id": "candidate",
+                "status": "COMPLETED",
+                "metrics": {"train_loss": 0.4, "val_loss": 0.5,
+                            "test_loss": 0.6, "primary_metric": 0.65},
+                "model_path": "candidate-model",
+                "cost_usd": 0.01,
+                "logs_path": "candidate.jsonl",
+            },
+        )
+
+        out = ar.log_node(state)
+
+        assert out["iteration"] == 10
+        assert out["eval_suite"] == suite
+        assert any("skipped eval suite update" in event["message"] for event in events)
+        assert events[-1]["metadata"]["reason"] == "NO_SPEND=1"
+    finally:
+        ar._DIARY_PATH = original_path
+
+
+def test_log_node_required_eval_adaptation_calls_adaptor(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    calls = []
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("AUTORESEARCH_EVAL_ADAPTATION", "required")
+    monkeypatch.setattr(ar, "log_event", lambda *args, **kwargs: None)
+
+    def fake_adapt_eval_suite(suite, weaknesses):
+        calls.append({"suite": suite, "weaknesses": weaknesses})
+        return {**suite, "metrics": suite["metrics"] + ["hard_case"]}
+
+    monkeypatch.setattr(ar, "adapt_eval_suite", fake_adapt_eval_suite)
+
+    original_path = ar._DIARY_PATH
+    ar._DIARY_PATH = tmp_path / "diary.jsonl"
+    suite = {"primary_metric": "accuracy", "metrics": ["accuracy"],
+             "test_split_path": "", "use_llm_grading": False}
+    try:
+        state = _make_state(
+            eval_suite=suite,
+            diary=[
+                {"iteration": i, "hypothesis": "", "patch": "", "cost_usd": 0.0,
+                 "metrics": {}, "decision": "REVERTED", "notes": f"revert {i}"}
+                for i in range(1, 10)
+            ],
+            iteration=9,
+            current_config={"learning_rate": 1e-4},
+            current_patch=json.dumps({"learning_rate": 2e-4}),
+            last_description="Increase learning rate.",
+            last_delta={"absolute": -0.01, "relative_pct": -2.0, "improved": False},
+            last_result={
+                "job_id": "candidate",
+                "status": "COMPLETED",
+                "metrics": {"train_loss": 0.4, "val_loss": 0.5,
+                            "test_loss": 0.6, "primary_metric": 0.65},
+                "model_path": "candidate-model",
+                "cost_usd": 0.01,
+                "logs_path": "candidate.jsonl",
+            },
+        )
+
+        out = ar.log_node(state)
+
+        assert calls
+        assert calls[0]["weaknesses"][-1] == "-2.0% \u2014 no improvement"
+        assert out["eval_suite"]["metrics"] == ["accuracy", "hard_case"]
+    finally:
+        ar._DIARY_PATH = original_path
+
+
+def test_completed_high_finite_sft_loss_flows_to_evaluate():
+    import src.autoresearch.autoresearch as ar
+
+    state = _make_state(
+        last_result={
+            "job_id": "candidate",
+            "status": "COMPLETED",
+            "metrics": {"train_loss": 24.8, "val_loss": 24.8,
+                        "test_loss": 24.8, "primary_metric": 0.0387},
+            "model_path": "candidate-model",
+            "cost_usd": 0.01,
+            "logs_path": "candidate.jsonl",
+        },
+    )
+
+    assert ar.early_stop_edge(state) == "evaluate"
+
+
+def test_run_node_preflight_skips_unaffordable_candidate(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+    from src.cost_manager.cost_manager import CostManager
+
+    def fail_runner(*args, **kwargs):
+        raise AssertionError("Tinker runner should not start when preflight rejects")
+
+    monkeypatch.setattr(ar, "run_tinker_sft_experiment", fail_runner)
+    monkeypatch.chdir(tmp_path)
+    state = _make_state(
+        plan={
+            "strategy": "fine-tune",
+            "base_model": "Qwen/Qwen3.5-9B",
+            "lora_config": None,
+            "estimated_cost": 2.0,
+            "estimated_time_min": 5,
+            "training_script_path": "outputs/scripts/train.py",
+            "eval_metric": "primary_metric",
+            "backend": "tinker_sft",
+            "dataset_path": str(tmp_path / "train.jsonl"),
+            "estimated_run_cost_usd": 2.0,
+        },
+        config={
+            "compute_budget": 1.0,
+            "prompt": "",
+            "data": False,
+            "training_procedure": {
+                "task_type": "text-classification",
+                "data_format": "jsonl",
+                "training_type": "SFT",
+                "base_model": "Qwen/Qwen3.5-9B",
+                "hyperparameters": {"learning_rate": 1e-4, "batch_size": 1},
+                "notes": "",
+            },
+        },
+        current_config={"learning_rate": 1e-4, "batch_size": 1},
+        current_patch=json.dumps({"learning_rate": 2e-4}),
+        cost_manager=CostManager(1.0),
+    )
+
+    out = ar.run_node(state)
+    run_dir = Path(out["last_result"]["model_path"])
+    manifest = json.loads((run_dir / "manifest.json").read_text())
+    metrics = json.loads((run_dir / "metrics.json").read_text())
+    metrics_row = json.loads((run_dir / "metrics.jsonl").read_text())
+
+    assert out["last_result"]["status"] == "CANCELLED"
+    assert out["last_result"]["cost_usd"] == 0.0
+    assert out["should_stop"] is True
+    assert manifest["budget_preflight_skipped"] is True
+    assert all(
+        math.isfinite(out["last_result"]["metrics"][key])
+        for key in ("train_loss", "val_loss", "test_loss")
+    )
+    assert all(math.isfinite(metrics[key]) for key in ("train_loss", "val_loss", "test_loss"))
+    assert all(math.isfinite(metrics_row[key]) for key in ("train_loss", "val_loss", "test_loss"))
+    json.dumps(metrics, allow_nan=False)
+    json.dumps(metrics_row, allow_nan=False)
+
+
+def test_invoke_autoresearch_graph_canonicalizes_tinker_initial_config(monkeypatch):
+    import src.autoresearch.autoresearch as ar
+
+    captured = {}
+
+    class FakeGraph:
+        def invoke(self, initial_state):
+            captured.update(initial_state["current_config"])
+            return {
+                **initial_state,
+                "baseline_result": {
+                    "job_id": "baseline",
+                    "status": "COMPLETED",
+                    "metrics": {"train_loss": 0.5, "val_loss": 0.5,
+                                "test_loss": 0.5, "primary_metric": 0.5},
+                    "model_path": "baseline-model",
+                    "cost_usd": 0.0,
+                    "logs_path": "baseline.jsonl",
+                },
+                "baseline_score": {"scalar": 0.5, "metrics": {}, "critique": ""},
+                "best_score": {"scalar": 0.5, "metrics": {}, "critique": ""},
+                "best_script": "baseline-model",
+            }
+
+    monkeypatch.setattr(ar, "build_autoresearch_graph", lambda: FakeGraph())
+    state = _make_state()
+    plan = {
+        **state["plan"],
+        "base_model": "Qwen/Qwen3.5-9B",
+        "backend": "tinker_sft",
+        "eval_metric": "primary_metric",
+    }
+    config = {
+        **state["config"],
+        "training_procedure": {
+            **state["config"]["training_procedure"],
+            "base_model": "Qwen/Qwen3.5-9B",
+            "hyperparameters": {
+                "learning_rate": 1e-4,
+                "epochs": 2,
+                "max_seq_len": 256,
+            },
+        },
+    }
+
+    ar.invoke_autoresearch_graph(plan, config, None)
+
+    assert captured["learning_rate"] == 1e-4
+    assert captured["num_epochs"] == 2
+    assert captured["max_seq_length"] == 256
+    assert "epochs" not in captured
+    assert "max_seq_len" not in captured
+
+
+def test_propose_hypothesis_canonicalizes_tinker_alias_patch(monkeypatch):
+    import src.autoresearch.autoresearch as ar
+
+    captured = {}
+
+    class FakeContent:
+        text = json.dumps(
+            {
+                "description": "Increase epochs for a longer bounded run.",
+                "patch": {"epochs": 5, "max_seq_len": 1024},
+                "expected_effect": "Improve validation loss.",
+                "search_strategy": "local",
+            }
+        )
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return type("FakeMessage", (), {"content": [FakeContent()]})()
+
+    class FakeAnthropic:
+        def __init__(self):
+            self.messages = FakeMessages()
+
+    monkeypatch.setattr(ar.anthropic, "Anthropic", FakeAnthropic)
+
+    hypothesis = ar.propose_hypothesis(
+        {"learning_rate": 1e-4, "epochs": 3, "max_seq_len": 512},
+        [],
+        _minimal_task(),
+        allowed_params=["learning_rate", "max_seq_length", "num_epochs"],
+    )
+
+    assert json.loads(hypothesis["patch"]) == {
+        "num_epochs": 5,
+        "max_seq_length": 1024,
+    }
+    assert '"num_epochs": 3' in captured["messages"][0]["content"]
+    assert '"max_seq_length": 512' in captured["messages"][0]["content"]
+    assert '"max_seq_len":' not in captured["messages"][0]["content"]
+
+
+def test_propose_hypothesis_no_spend_blocks_anthropic_client(monkeypatch):
+    import src.autoresearch.autoresearch as ar
+
+    def fail_client():
+        raise AssertionError("Anthropic client should not be constructed")
+
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.setattr(ar.anthropic, "Anthropic", fail_client)
+
+    with pytest.raises(RuntimeError, match="NO_SPEND=1"):
+        ar.propose_hypothesis({"learning_rate": 1e-4}, [], _minimal_task())
+
+
+def test_propose_hypothesis_still_rejects_unsupported_tinker_patch(monkeypatch):
+    import src.autoresearch.autoresearch as ar
+
+    class FakeContent:
+        text = json.dumps(
+            {
+                "description": "Change dropout.",
+                "patch": {"dropout": 0.2},
+                "expected_effect": "Improve validation loss.",
+                "search_strategy": "local",
+            }
+        )
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            return type("FakeMessage", (), {"content": [FakeContent()]})()
+
+    class FakeAnthropic:
+        def __init__(self):
+            self.messages = FakeMessages()
+
+    monkeypatch.setattr(ar.anthropic, "Anthropic", FakeAnthropic)
+
+    with pytest.raises(ValueError, match="Unsupported Tinker SFT hyperparameter"):
+        ar.propose_hypothesis(
+            {"learning_rate": 1e-4},
+            [],
+            _minimal_task(),
+            allowed_params=["learning_rate", "num_epochs"],
+        )
+
+
+def test_adapt_eval_suite_no_spend_blocks_anthropic_client(monkeypatch):
+    import src.autoresearch.autoresearch as ar
+
+    def fail_client():
+        raise AssertionError("Anthropic client should not be constructed")
+
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.setattr(ar.anthropic, "Anthropic", fail_client)
+
+    suite = {
+        "primary_metric": "accuracy",
+        "metrics": ["accuracy"],
+        "test_split_path": "",
+        "use_llm_grading": False,
+    }
+    with pytest.raises(RuntimeError, match="NO_SPEND=1"):
+        ar.adapt_eval_suite(suite, ["weakness"])
+
+
+def test_cli_no_spend_rejects_claude_strategy_before_api_key_check(monkeypatch):
+    import src.autoresearch.__main__ as cli
+
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "present-but-no-spend")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["python -m src.autoresearch", "--strategy", "claude", "--n-iters", "1"],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main()
+
+    assert exc_info.value.code == 1
+
+
+def test_keep_node_canonicalizes_tinker_alias_patch():
+    import src.autoresearch.autoresearch as ar
+
+    state = _make_state(
+        plan={"training_script_path": "train.py", "base_model": "Qwen/Qwen3.5-9B",
+              "lora_config": None, "estimated_cost": 0.0,
+              "estimated_time_min": 5, "eval_metric": "primary_metric",
+              "backend": "tinker_sft"},
+        current_config={"learning_rate": 1e-4, "epochs": 2},
+        current_patch=json.dumps({"epochs": 3}),
+        last_score={"scalar": 0.6, "metrics": {}, "critique": ""},
+        best_score={"scalar": 0.5, "metrics": {}, "critique": ""},
+        last_result={
+            "job_id": "candidate",
+            "status": "COMPLETED",
+            "metrics": {"train_loss": 0.4, "val_loss": 0.4,
+                        "test_loss": 0.4, "primary_metric": 0.6},
+            "model_path": "candidate-model",
+            "cost_usd": 0.01,
+            "logs_path": "candidate.jsonl",
+        },
+    )
+
+    out = ar.keep_node(state)
+
+    assert out["current_config"]["num_epochs"] == 3
+    assert "epochs" not in out["current_config"]
+
+
 # ─── continue_edge ────────────────────────────────────────────────────────────
 
 def _make_state(**overrides):
@@ -257,6 +1022,7 @@ def _make_state(**overrides):
         "original_content": None,
         "diary": [],
         "baseline_score": None,
+        "baseline_result": None,
         "best_score": None,
         "best_script": "train.py",
         "last_result": None,
@@ -265,9 +1031,188 @@ def _make_state(**overrides):
         "iteration": 0,
         "no_improve_streak": 0,
         "should_stop": False,
+        "cost_manager": None,
     }
     base.update(overrides)
     return base
+
+
+def _tinker_propose_state():
+    return _make_state(
+        plan={
+            "strategy": "fine-tune",
+            "base_model": "Qwen/Qwen3.5-9B",
+            "lora_config": {"rank": 8, "alpha": 16, "dropout": 0.05, "target_modules": []},
+            "estimated_cost": 1.0,
+            "estimated_time_min": 5,
+            "training_script_path": "outputs/scripts/train.py",
+            "eval_metric": "primary_metric",
+            "backend": "tinker_sft",
+            "dataset_path": "/tmp/train.jsonl",
+        },
+        config={
+            "data": False,
+            "prompt": "test",
+            "compute_budget": 10.0,
+            "training_procedure": {
+                "task_type": "text-classification",
+                "data_format": "jsonl",
+                "training_type": "SFT",
+                "base_model": "Qwen/Qwen3.5-9B",
+                "hyperparameters": {"learning_rate": 1e-4, "batch_size": 4},
+                "notes": "",
+            },
+        },
+        current_script="outputs/scripts/train.py",
+        current_config={"learning_rate": 1e-4, "batch_size": 4},
+    )
+
+
+def test_propose_node_auto_without_anthropic_key_uses_local_proposer(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+    from src.tinker_api.sft_runner import SUPPORTED_TINKER_TUNABLES
+
+    config_path = tmp_path / "current.json"
+    TrainingConfig(
+        model_name="Qwen/Qwen3.5-9B",
+        learning_rate=1e-4,
+        batch_size=4,
+    ).save(config_path)
+    monkeypatch.setattr(ar, "_CONFIG_PATH", config_path)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("AUTORESEARCH_PROPOSER", raising=False)
+    monkeypatch.setattr(
+        ar.anthropic,
+        "Anthropic",
+        lambda: pytest.fail("Anthropic should not be constructed in auto mode without a key"),
+    )
+    monkeypatch.setattr(
+        ar,
+        "propose_hypothesis",
+        lambda *args, **kwargs: pytest.fail("Claude proposer should not run without a key"),
+    )
+
+    out = ar.propose_node(_tinker_propose_state())
+    patch = json.loads(out["current_patch"])
+    key, value = next(iter(patch.items()))
+
+    assert len(patch) == 1
+    assert key in SUPPORTED_TINKER_TUNABLES
+    assert out["current_script"] == "outputs/scripts/train.py"
+    assert out["last_description"]
+    before_config = TrainingConfig(
+        model_name="Qwen/Qwen3.5-9B",
+        learning_rate=1e-4,
+        batch_size=4,
+    ).to_dict()
+    patched_config = TrainingConfig.load(config_path).to_dict()
+    assert value != before_config[key]
+    if isinstance(value, (int, float)):
+        assert patched_config[key] == pytest.approx(value)
+    else:
+        assert patched_config[key] == value
+
+def test_propose_node_no_spend_uses_local_proposer_even_when_claude_requested(
+    monkeypatch, tmp_path
+):
+    import src.autoresearch.autoresearch as ar
+    from src.tinker_api.sft_runner import SUPPORTED_TINKER_TUNABLES
+
+    config_path = tmp_path / "current.json"
+    TrainingConfig(
+        model_name="Qwen/Qwen3.5-9B",
+        learning_rate=1e-4,
+        batch_size=4,
+    ).save(config_path)
+    monkeypatch.setattr(ar, "_CONFIG_PATH", config_path)
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-present")
+    monkeypatch.setenv("AUTORESEARCH_PROPOSER", "claude")
+    monkeypatch.setattr(
+        ar,
+        "propose_hypothesis",
+        lambda *args, **kwargs: pytest.fail("NO_SPEND=1 should block Claude proposer"),
+    )
+
+    out = ar.propose_node(_tinker_propose_state())
+    patch = json.loads(out["current_patch"])
+    key, value = next(iter(patch.items()))
+
+    assert len(patch) == 1
+    assert key in SUPPORTED_TINKER_TUNABLES
+    assert out["last_description"]
+    before_config = TrainingConfig(
+        model_name="Qwen/Qwen3.5-9B",
+        learning_rate=1e-4,
+        batch_size=4,
+    ).to_dict()
+    assert value != before_config[key]
+    TrainingConfig.load(config_path).apply_patch(patch)
+
+
+def test_propose_node_local_mode_produces_tinker_supported_patch(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+    from src.tinker_api.sft_runner import SUPPORTED_TINKER_TUNABLES
+
+    config_path = tmp_path / "current.json"
+    TrainingConfig(
+        model_name="Qwen/Qwen3.5-9B",
+        learning_rate=1e-4,
+        batch_size=4,
+    ).save(config_path)
+    monkeypatch.setattr(ar, "_CONFIG_PATH", config_path)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-present")
+    monkeypatch.setenv("AUTORESEARCH_PROPOSER", "local")
+    monkeypatch.setattr(
+        ar,
+        "propose_hypothesis",
+        lambda *args, **kwargs: pytest.fail("Explicit local proposer should not call Claude"),
+    )
+
+    out = ar.propose_node(_tinker_propose_state())
+    patch = json.loads(out["current_patch"])
+
+    assert len(patch) == 1
+    assert set(patch).issubset(SUPPORTED_TINKER_TUNABLES)
+    key, value = next(iter(patch.items()))
+    before_config = TrainingConfig(
+        model_name="Qwen/Qwen3.5-9B",
+        learning_rate=1e-4,
+        batch_size=4,
+    ).to_dict()
+    assert value != before_config[key]
+    TrainingConfig.load(config_path).apply_patch(patch)
+
+
+def test_propose_node_explicit_claude_uses_propose_hypothesis(monkeypatch, tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    config_path = tmp_path / "current.json"
+    TrainingConfig(
+        model_name="Qwen/Qwen3.5-9B",
+        learning_rate=1e-4,
+        batch_size=4,
+    ).save(config_path)
+    calls = []
+    monkeypatch.setattr(ar, "_CONFIG_PATH", config_path)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("AUTORESEARCH_PROPOSER", "claude")
+
+    def fake_propose_hypothesis(*args, **kwargs):
+        calls.append((args, kwargs))
+        return {
+            "description": "Increase learning rate for a bounded candidate run.",
+            "patch": json.dumps({"learning_rate": 2e-4}),
+            "expected_effect": "Lower validation loss.",
+            "search_strategy": "local",
+        }
+
+    monkeypatch.setattr(ar, "propose_hypothesis", fake_propose_hypothesis)
+
+    out = ar.propose_node(_tinker_propose_state())
+
+    assert len(calls) == 1
+    assert json.loads(out["current_patch"]) == {"learning_rate": 2e-4}
 
 
 def test_continue_edge_ends_when_budget_exhausted():
@@ -298,3 +1243,217 @@ def test_continue_edge_ends_at_max_iterations():
     from src.autoresearch.autoresearch import _MAX_ITERATIONS
     state = _make_state(iteration=_MAX_ITERATIONS)
     assert continue_edge(state) == "__end__"
+
+
+def test_dataset_result_from_plan_preserves_split_counts(tmp_path):
+    import src.autoresearch.autoresearch as ar
+
+    dataset_path = tmp_path / "train.jsonl"
+    dataset_path.write_text('{"input": "x", "output": "y"}\n')
+    plan = {
+        "strategy": "fine-tune",
+        "base_model": "Qwen/Qwen3.5-9B",
+        "lora_config": {"rank": 8, "alpha": 16, "dropout": 0.05, "target_modules": []},
+        "estimated_cost": 1.0,
+        "estimated_time_min": 5,
+        "training_script_path": "outputs/scripts/train.py",
+        "eval_metric": "primary_metric",
+        "backend": "tinker_sft",
+        "dataset_path": "ignored-when-dataset-present.jsonl",
+        "dataset": {
+            "path": str(dataset_path),
+            "format": "jsonl",
+            "train_size": 2,
+            "val_size": 1,
+            "test_size": 1,
+        },
+    }
+
+    dataset_result = ar._dataset_result_from_plan(plan)
+
+    assert dataset_result["dataset"] == plan["dataset"]
+
+
+def test_autoresearch_graph_passes_plan_dataset_splits_to_tinker(monkeypatch, tmp_path):
+    pytest.importorskip("langgraph", reason="langgraph not installed")
+    import src.autoresearch.autoresearch as ar
+
+    config_path = tmp_path / "configs" / "current.json"
+    monkeypatch.setattr(ar, "_CONFIG_PATH", config_path)
+    dataset_path = tmp_path / "train.jsonl"
+    dataset_path.write_text(
+        "".join(
+            json.dumps({"input": f"row {i}", "output": "label"}) + "\n"
+            for i in range(4)
+        )
+    )
+    calls = []
+
+    class FakeCostManager:
+        def __init__(self, budget):
+            self.budget = budget
+            self.spent_usd = 0.0
+
+        @property
+        def status(self):
+            return "EXCEEDED" if self.spent_usd >= self.budget else "OK"
+
+        def start(self, job_id):
+            self.job_id = job_id
+
+        def stop(self):
+            pass
+
+        def record_spend(self, amount, category="training"):
+            self.spent_usd += amount
+            return self.status
+
+        def cost_breakdown(self, termination_reason=None):
+            return {
+                "data_gen_usd": 0.0,
+                "training_usd": self.spent_usd,
+                "llm_calls_usd": 0.0,
+                "total_usd": self.spent_usd,
+                "termination_reason": termination_reason or "training_complete",
+            }
+
+    def fake_runner(config, dataset, *, run_id=None, max_steps=None, **kwargs):
+        index = len(calls)
+        calls.append(
+            {
+                "path": dataset["dataset"]["path"],
+                "splits": {
+                    "train": dataset["dataset"]["train_size"],
+                    "val": dataset["dataset"]["val_size"],
+                    "test": dataset["dataset"]["test_size"],
+                },
+            }
+        )
+        val_loss = 0.5 if index == 0 else 0.4
+        run_dir = tmp_path / f"run-{index}"
+        run_dir.mkdir()
+        (run_dir / "metrics.json").write_text(
+            json.dumps({"train_loss": val_loss, "val_loss": val_loss, "test_loss": val_loss})
+        )
+        return {
+            "job_id": run_id,
+            "status": "COMPLETED",
+            "metrics": {
+                "train_loss": val_loss,
+                "val_loss": val_loss,
+                "test_loss": val_loss,
+                "primary_metric": 1 / (1 + val_loss),
+            },
+            "model_path": str(run_dir),
+            "cost_usd": 0.02,
+            "logs_path": str(run_dir / "metrics.jsonl"),
+        }
+
+    monkeypatch.setattr(ar, "run_tinker_sft_experiment", fake_runner)
+    monkeypatch.setenv("AUTORESEARCH_PROPOSER", "claude")
+    monkeypatch.setattr(
+        ar,
+        "propose_hypothesis",
+        lambda *args, **kwargs: {
+            "description": "Increase learning rate for a bounded candidate run.",
+            "patch": json.dumps({"learning_rate": 2e-4}),
+            "expected_effect": "Improve heldout loss.",
+            "search_strategy": "playbook",
+        },
+    )
+
+    plan = {
+        "strategy": "fine-tune",
+        "base_model": "Qwen/Qwen3.5-9B",
+        "lora_config": {"rank": 8, "alpha": 16, "dropout": 0.05, "target_modules": []},
+        "estimated_cost": 0.005,
+        "estimated_time_min": 5,
+        "training_script_path": "outputs/scripts/train.py",
+        "eval_metric": "primary_metric",
+        "backend": "tinker_sft",
+        "dataset_path": str(dataset_path),
+        "dataset": {
+            "path": str(dataset_path),
+            "format": "jsonl",
+            "train_size": 2,
+            "val_size": 1,
+            "test_size": 1,
+        },
+    }
+    config = {
+        "data": False,
+        "prompt": "test",
+        "compute_budget": 0.03,
+        "training_procedure": {
+            "task_type": "text-classification",
+            "data_format": "jsonl",
+            "training_type": "SFT",
+            "base_model": "Qwen/Qwen3.5-9B",
+            "hyperparameters": {"learning_rate": 1e-4, "batch_size": 1},
+            "notes": "",
+        },
+    }
+
+    result = ar.invoke_autoresearch_graph(plan, config, FakeCostManager(0.03))
+
+    assert [call["path"] for call in calls] == [str(dataset_path), str(dataset_path)]
+    assert [call["splits"] for call in calls] == [
+        {"train": 2, "val": 1, "test": 1},
+        {"train": 2, "val": 1, "test": 1},
+    ]
+    assert result["n_iterations"] == 1
+    assert result["cost"]["termination_reason"] == "budget_limit"
+
+
+def test_invoke_autoresearch_graph_cost_breakdown_includes_baseline_cost(monkeypatch):
+    import src.autoresearch.autoresearch as ar
+    from src.cost_manager.cost_manager import CostManager
+
+    class FakeGraph:
+        def invoke(self, initial_state):
+            cost_manager = initial_state["cost_manager"]
+            cost_manager.record_spend(0.20, category="training")
+            cost_manager.record_spend(0.30, category="training")
+            baseline_result = {
+                "job_id": "baseline",
+                "status": "COMPLETED",
+                "metrics": {"train_loss": 0.5, "val_loss": 0.5,
+                            "test_loss": 0.5, "primary_metric": 0.5},
+                "model_path": "baseline-model",
+                "cost_usd": 0.20,
+                "logs_path": "baseline.jsonl",
+            }
+            return {
+                **initial_state,
+                "baseline_result": baseline_result,
+                "baseline_score": {"scalar": 0.5, "metrics": {}, "critique": ""},
+                "best_score": {"scalar": 0.6, "metrics": {}, "critique": ""},
+                "best_script": "iteration-model",
+                "diary": [
+                    {
+                        "iteration": 1,
+                        "hypothesis": "x",
+                        "patch": "",
+                        "cost_usd": 0.30,
+                        "metrics": {},
+                        "decision": "KEPT",
+                        "notes": "",
+                    }
+                ],
+                "iteration": 1,
+            }
+
+    monkeypatch.setattr(ar, "build_autoresearch_graph", lambda: FakeGraph())
+    state = _make_state()
+    plan = {
+        **state["plan"],
+        "strategy": "fine-tune",
+        "training_script_path": "train.py",
+    }
+    cost_manager = CostManager(10.0)
+
+    result = ar.invoke_autoresearch_graph(plan, state["config"], cost_manager)
+
+    assert result["cost"]["training_usd"] == pytest.approx(0.50)
+    assert result["cost"]["total_usd"] == pytest.approx(0.50)
+    assert result["cost"]["termination_reason"] == "training_complete"

--- a/tests/test_cost_manager.py
+++ b/tests/test_cost_manager.py
@@ -4,6 +4,7 @@ import threading
 import pytest
 from unittest.mock import patch
 from src.cost_manager.cost_manager import (
+    CostManager,
     check_budget_status,
     generate_cost_report,
     save_checkpoint,
@@ -27,6 +28,7 @@ def test_check_budget_status_warning_at_90_percent():
 def test_check_budget_status_exceeded_at_100_percent():
     assert check_budget_status(100.0, 100.0) == BudgetStatus.EXCEEDED
     assert check_budget_status(110.0, 100.0) == BudgetStatus.EXCEEDED
+    assert check_budget_status(0.01, 0.0) == BudgetStatus.EXCEEDED
 
 
 def test_start_cost_monitor_returns_thread():
@@ -35,6 +37,71 @@ def test_start_cost_monitor_returns_thread():
     assert isinstance(thread, threading.Thread)
     assert thread.is_alive()
     thread.stop_event.set()  # type: ignore[attr-defined]
+    thread.join(timeout=1)
+
+
+def test_cost_manager_stop_signals_monitor_thread():
+    with patch("src.cost_manager.cost_manager.poll_spend", return_value=0.0):
+        manager = CostManager(50.0)
+        manager.start("job-456")
+        thread = manager._thread
+        assert isinstance(thread, threading.Thread)
+        assert thread.is_alive()
+
+        manager.stop()
+
+    assert manager._thread is None
+    assert not thread.is_alive()
+
+
+def test_cost_manager_records_in_process_spend_by_category():
+    manager = CostManager(1.0)
+
+    assert manager.spent_usd == 0.0
+    assert manager.remaining_budget == 1.0
+    assert manager.record_spend(0.25) == BudgetStatus.OK
+    assert manager.record_spend(0.05, category="llm_calls") == BudgetStatus.OK
+    assert manager.record_spend(0.70) == BudgetStatus.EXCEEDED
+
+    assert manager.category_totals == {"training": 0.95, "llm_calls": 0.05}
+    assert manager.spent_usd == 1.0
+    assert manager.remaining_budget == 0.0
+    assert manager.status == BudgetStatus.EXCEEDED
+
+
+def test_cost_manager_can_start_run_respects_remaining_budget():
+    manager = CostManager(1.0)
+
+    assert manager.can_start_run(0.25) is True
+    manager.record_spend(0.80)
+
+    assert manager.can_start_run(0.20) is True
+    assert manager.can_start_run(0.21) is False
+
+    manager.record_spend(0.20)
+    assert manager.remaining_budget == 0.0
+    assert manager.can_start_run(0.0) is False
+
+
+def test_cost_manager_cost_breakdown_uses_recorded_totals():
+    manager = CostManager(10.0)
+    manager.record_spend(1.25, category="training")
+    manager.record_spend(0.50, category="data_gen")
+    manager.record_spend(0.10, category="llm")
+
+    assert manager.cost_breakdown("training_complete") == {
+        "data_gen_usd": 0.5,
+        "training_usd": 1.25,
+        "llm_calls_usd": 0.1,
+        "total_usd": 1.85,
+        "termination_reason": "training_complete",
+    }
+
+
+def test_cost_manager_rejects_negative_spend():
+    manager = CostManager(10.0)
+    with pytest.raises(ValueError, match="non-negative"):
+        manager.record_spend(-0.01)
 
 
 def test_save_checkpoint_returns_path(tmp_path):

--- a/tests/test_decision_engine.py
+++ b/tests/test_decision_engine.py
@@ -5,12 +5,14 @@ import pytest
 from src.decision_engine.decision_engine import (
     analyze_task,
     configure_lora,
+    estimate_autoresearch_run_cost,
     estimate_training_cost,
     find_base_model,
     run_decision_engine,
     write_finetune_script,
     write_pretrain_script,
 )
+from src.tinker_api.sft_runner import DEFAULT_TINKER_MODEL
 from src.types import DatasetResult, OrchestrationConfig, StandardDataset, ValidationReport
 
 
@@ -66,6 +68,44 @@ def test_estimate_training_cost_finetune_cheaper_than_pretrain():
     assert fine_tune_cost["confidence"] == "medium"
 
 
+def test_estimate_autoresearch_run_cost_scales_bounded_steps():
+    config = _make_config()
+    config["training_procedure"]["hyperparameters"]["max_steps"] = 5
+    dataset = _make_dataset(train_size=1000)
+    cost = estimate_training_cost("Qwen/Qwen3.5-9B", dataset, "fine-tune")
+
+    run_cost = estimate_autoresearch_run_cost(cost, config, dataset)
+
+    assert cost["estimated_usd"] == 1.12
+    assert run_cost == 0.0296
+
+
+def test_estimate_autoresearch_run_cost_uses_full_cost_when_unbounded():
+    config = _make_config()
+    dataset = _make_dataset(train_size=1000)
+    cost = estimate_training_cost("Qwen/Qwen3.5-9B", dataset, "fine-tune")
+
+    assert estimate_autoresearch_run_cost(cost, config, dataset) == cost["estimated_usd"]
+
+
+def test_estimate_autoresearch_run_cost_caps_at_full_cost():
+    config = _make_config()
+    config["training_procedure"]["hyperparameters"]["max_steps"] = 10_000
+    dataset = _make_dataset(train_size=42)
+    cost = estimate_training_cost("Qwen/Qwen3.5-9B", dataset, "fine-tune")
+
+    assert estimate_autoresearch_run_cost(cost, config, dataset) == cost["estimated_usd"]
+
+
+def test_estimate_autoresearch_run_cost_treats_invalid_max_steps_as_unbounded():
+    config = _make_config()
+    config["training_procedure"]["hyperparameters"]["max_steps"] = "many"
+    dataset = _make_dataset(train_size=1000)
+    cost = estimate_training_cost("Qwen/Qwen3.5-9B", dataset, "fine-tune")
+
+    assert estimate_autoresearch_run_cost(cost, config, dataset) == cost["estimated_usd"]
+
+
 def test_configure_lora_returns_valid_config():
     config = _make_config("text-classification")
     task = analyze_task(config)
@@ -101,8 +141,41 @@ def test_write_pretrain_script_creates_file(tmp_path, monkeypatch):
 def test_run_decision_engine_returns_training_plan(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     config = _make_config("text-classification", budget=50.0)
-    plan = run_decision_engine(config, _make_dataset())
-    assert plan["strategy"] in ("fine-tune", "pre-train")
-    assert plan["eval_metric"] == "accuracy"
+    dataset = _make_dataset(train_size=42)
+    plan = run_decision_engine(config, dataset)
+    assert plan["strategy"] == "fine-tune"
+    assert plan["base_model"] == DEFAULT_TINKER_MODEL
+    assert plan["lora_config"] is not None
+    assert plan["eval_metric"] == "primary_metric"
+    assert plan["backend"] == "tinker_sft"
     assert os.path.exists(plan["training_script_path"])
     assert plan["estimated_cost"] > 0
+    assert plan["estimated_run_cost_usd"] == plan["estimated_cost"]
+    assert plan["dataset_path"] == dataset["dataset"]["path"]
+    assert plan["dataset"] == dataset["dataset"]
+
+
+def test_run_decision_engine_keeps_low_budget_plan_on_tinker_sft(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config = _make_config("text-classification", budget=0.01)
+    dataset = _make_dataset(train_size=42)
+
+    plan = run_decision_engine(config, dataset)
+
+    assert plan["strategy"] == "fine-tune"
+    assert plan["backend"] == "tinker_sft"
+    assert plan["base_model"] == DEFAULT_TINKER_MODEL
+    assert plan["lora_config"] is not None
+    assert plan["estimated_cost"] > config["compute_budget"]
+    assert "SimpleModel" not in open(plan["training_script_path"]).read()
+
+
+def test_run_decision_engine_sets_bounded_run_cost(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config = _make_config("text-classification", budget=50.0)
+    config["training_procedure"]["hyperparameters"]["max_steps"] = 5
+    dataset = _make_dataset(train_size=1000)
+
+    plan = run_decision_engine(config, dataset)
+
+    assert 0.0 < plan["estimated_run_cost_usd"] < plan["estimated_cost"]

--- a/tests/test_e2e_propose.py
+++ b/tests/test_e2e_propose.py
@@ -47,9 +47,13 @@ from src.autoresearch.proposer import (
 
 # ─── Markers ─────────────────────────────────────────────────────────────────
 
+def _env_truthy(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 integration = pytest.mark.skipif(
-    not os.getenv("ANTHROPIC_API_KEY"),
-    reason="ANTHROPIC_API_KEY not set — skipping live API test",
+    _env_truthy("NO_SPEND") or not os.getenv("ANTHROPIC_API_KEY"),
+    reason="NO_SPEND=1 or ANTHROPIC_API_KEY not set — skipping live API test",
 )
 
 

--- a/tests/test_propose_infra.py
+++ b/tests/test_propose_infra.py
@@ -336,6 +336,28 @@ def test_ar_apply_patch_returns_valid_original_json(tmp_path, base_config):
     assert old["batch_size"] == 16  # TrainingConfig default
 
 
+def test_ar_apply_patch_rejects_invalid_patch_without_writing(tmp_path, base_config):
+    config_path = tmp_path / "config.json"
+    base_config.save(config_path)
+    before = config_path.read_text()
+
+    with pytest.raises(ValueError, match="above maximum"):
+        ar_apply_patch(str(config_path), json.dumps({"learning_rate": 1.0}))
+
+    assert config_path.read_text() == before
+
+
+def test_ar_apply_patch_rejects_unknown_patch_without_writing(tmp_path, base_config):
+    config_path = tmp_path / "config.json"
+    base_config.save(config_path)
+    before = config_path.read_text()
+
+    with pytest.raises(ValueError, match="Unknown hyperparameter"):
+        ar_apply_patch(str(config_path), json.dumps({"not_a_real_param": 42}))
+
+    assert config_path.read_text() == before
+
+
 def test_ar_revert_patch_restores_original(tmp_path, base_config):
     config_path = tmp_path / "config.json"
     base_config.save(config_path)


### PR DESCRIPTION
Replacement consolidated PR 3/8.

Supersedes draft PRs: #39, #45, #47, #48, #59, #61, #63, #66, #69, #70, #72, #79, #80, #91, #95, #97.

Scope:
- Cost Manager integration for Tinker runs.
- Candidate config execution, best-vs-current comparison, patch validation, early stop, material improvement threshold.
- Dataset split preservation and primary metric scoring for Tinker SFT.
- Budget preflight, estimated run costs, spend floor, finite skip metrics.
- Local/no-spend proposer and optional eval adaptation guard.

Validation on final replacement stack:
- `python3 -m compileall src`
- `env -u ANTHROPIC_API_KEY -u TINKER_API_KEY -u TAVILY_API_KEY UV_NO_NETWORK=1 uv run --with pytest --with fastapi --with httpx --with langgraph --with anthropic python -m pytest -q` -> `339 passed, 10 skipped`
- `ml-agent-frontend`: `npm run lint && npm run build`
- `spec-site`: `npm run lint && npm run build`

No live services or paid jobs were run for this consolidation.
