### PR TITLE
[codex] consolidated Manager API backend

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,9 @@ transformers>=4.40.0
 peft>=0.10.0
 torch>=2.2.0
 pytest>=8.0.0
-
 # Tinker SDK path
 tinker
 tinker-cookbook
+fastapi>=0.115.0
+uvicorn>=0.30.0
+httpx>=0.27.0

--- a/src/manager/manager.py
+++ b/src/manager/manager.py
@@ -10,19 +10,22 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from datetime import datetime, timezone
+from pathlib import Path
 
+from src.data_sources import looks_like_local_data_path, normalize_hf_dataset_source
+from src.runtime_context import get_output_root, raise_if_cancelled
 from src.types import (
     DatasetResult,
     ManagerState,
     OrchestrationConfig,
-    StandardDataset,
     TaskReasoning,
     TrainedModel,
-    ValidationReport,
 )
 
 LOG_PATH = os.environ.get("DECISIONS_LOG", "decisions.jsonl")
+_MANAGER_REASONER_ENV = "MANAGER_REASONER"
 
 
 def build_manager_graph():
@@ -52,19 +55,31 @@ def invoke_manager_graph(
     prompt: str,
     budget: float,
     data_path: str | None = None,
+    *,
+    interactive_data_prompt: bool = False,
+    task_type_hint: str | None = None,
 ) -> TrainedModel:
-    """Main entry point for the entire system. Builds and invokes the Manager graph."""
+    """Main entry point for the system.
+
+    Programmatic callers default to no-data Mode C when ``data_path`` is not
+    supplied. CLI-style callers can opt into the legacy stdin prompt with
+    ``interactive_data_prompt=True``.
+    """
     graph = build_manager_graph()
     initial_state: ManagerState = {
         "prompt": prompt,
         "budget": budget,
         "data_path": data_path,
         "has_data": data_path is not None,
+        "interactive_data_prompt": interactive_data_prompt,
+        "task_type_hint": task_type_hint,
         "task_reasoning": None,
         "config": None,
         "result": None,
     }
+    raise_if_cancelled()
     final_state = graph.invoke(initial_state)
+    raise_if_cancelled()
     return final_state["result"]
 
 
@@ -72,18 +87,46 @@ def invoke_manager_graph(
 
 def query_data_node(state: ManagerState) -> dict:
     """LangGraph node. Calls query_user_for_data(). Returns: { has_data, data_path }."""
-    path = query_user_for_data()
+    raise_if_cancelled()
+    existing_path = state.get("data_path")
+    if existing_path:
+        expanded_path = Path(existing_path).expanduser()
+        if expanded_path.exists():
+            resolved_path = str(expanded_path.resolve())
+            return {"has_data": True, "data_path": resolved_path}
+        if looks_like_local_data_path(existing_path):
+            return {"has_data": False, "data_path": None}
+        hf_source = normalize_hf_dataset_source(existing_path)
+        if hf_source:
+            return {"has_data": True, "data_path": hf_source}
+        return {"has_data": False, "data_path": None}
+
+    if not state.get("interactive_data_prompt", True):
+        return {"has_data": False, "data_path": None}
+
+    try:
+        path = query_user_for_data()
+    except EOFError:
+        path = None
     return {"has_data": path is not None, "data_path": path}
 
 
 def reason_node(state: ManagerState) -> dict:
     """LangGraph node. Calls reason_about_task() via Claude API. Returns: { task_reasoning }."""
-    reasoning = reason_about_task(state["prompt"], state["budget"], state["has_data"])
+    raise_if_cancelled()
+    reasoning = reason_about_task(
+        state["prompt"],
+        state["budget"],
+        state["has_data"],
+        task_type_hint=state.get("task_type_hint"),
+    )
+    raise_if_cancelled()
     return {"task_reasoning": reasoning}
 
 
 def build_config_node(state: ManagerState) -> dict:
     """LangGraph node. Builds OrchestrationConfig and logs the decision. Returns: { config }."""
+    raise_if_cancelled()
     config = build_orchestration_config(
         state["task_reasoning"],
         state["prompt"],
@@ -95,6 +138,7 @@ def build_config_node(state: ManagerState) -> dict:
         rationale=state["task_reasoning"]["notes"],
         config=config,
     )
+    raise_if_cancelled()
     return {"config": config}
 
 
@@ -111,13 +155,18 @@ def orchestrate_node(state: ManagerState) -> dict:
     budget = config["compute_budget"]
 
     # ── 1. Data acquisition ──────────────────────────────────────────────────
+    raise_if_cancelled()
     log_event(AgentName.MANAGER, LogLevel.INFO, "Starting DataGen sub-agent", {})
     handoff = invoke_data_generator_graph(config, state.get("data_path"))
+    raise_if_cancelled()
     dataset = _handoff_to_dataset_result(handoff)
+    _ensure_dataset_is_trainable(dataset)
 
     # ── 2. Decision Engine — pick model, estimate cost, write training script
+    raise_if_cancelled()
     log_event(AgentName.MANAGER, LogLevel.INFO, "Running Decision Engine", {})
     plan = run_decision_engine(config, dataset)
+    raise_if_cancelled()
     log_decision(
         step="orchestrate",
         rationale=f"strategy={plan['strategy']} model={plan['base_model']} "
@@ -129,13 +178,22 @@ def orchestrate_node(state: ManagerState) -> dict:
     cost_manager = CostManager(budget)
 
     # ── 4. AutoResearch loop ─────────────────────────────────────────────────
+    raise_if_cancelled()
     log_event(AgentName.MANAGER, LogLevel.INFO, "Launching AutoResearch loop", {})
     result = invoke_autoresearch_graph(plan, config, cost_manager)
+    raise_if_cancelled()
 
+    termination = result["cost"].get("termination_reason")
+    if termination == "budget_limit" and result["n_iterations"] == 0:
+        summary = "Training skipped by budget guard"
+    elif termination == "budget_limit":
+        summary = "Training stopped at budget limit"
+    else:
+        summary = "Training complete"
     log_event(
         AgentName.MANAGER,
         LogLevel.INFO,
-        f"Training complete — {result['n_iterations']} iterations, "
+        f"{summary} — {result['n_iterations']} iterations, "
         f"cost=${result['cost']['total_usd']:.2f}",
         {},
     )
@@ -166,14 +224,33 @@ def log_decision(step: str, rationale: str, config: OrchestrationConfig) -> None
         "rationale": rationale,
         "config_snapshot": dict(config),
     }
-    with open(LOG_PATH, "a") as f:
+    log_path = _decision_log_path()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(log_path, "a") as f:
         f.write(json.dumps(entry) + "\n")
 
 
-def reason_about_task(prompt: str, budget: float, has_data: bool) -> TaskReasoning:
-    """Calls Claude API to infer task type, training type, base model, and starting hyperparams."""
+def _decision_log_path() -> Path:
+    root = get_output_root()
+    if root is not None:
+        return root / "decisions.jsonl"
+    return Path(os.environ.get("DECISIONS_LOG", LOG_PATH))
+
+
+def reason_about_task(
+    prompt: str,
+    budget: float,
+    has_data: bool,
+    *,
+    task_type_hint: str | None = None,
+) -> TaskReasoning:
+    """Infer task type, training type, base model, and starting hyperparams."""
+    if _use_local_reasoner():
+        return _local_task_reasoning(prompt, budget, has_data)
+
     import anthropic
 
+    hint = _normalize_task_type_hint(task_type_hint)
     client = anthropic.Anthropic()
     system = (
         "You are an ML infrastructure planner. Given a task description and budget, "
@@ -184,6 +261,10 @@ def reason_about_task(prompt: str, budget: float, has_data: bool) -> TaskReasoni
         "  suggested_base_model: str or null (HuggingFace model ID, e.g. 'bert-base-uncased')\n"
         "  hyperparameters: dict with keys learning_rate, batch_size, epochs, max_seq_len\n"
         "  notes: str (one sentence reasoning summary)\n"
+        "If a requested UI task type is provided, treat it as an operator hint: "
+        "classification usually maps to text-classification, regression may be "
+        "a custom supervised task, and fine-tuning means infer the concrete task "
+        "from the objective and data.\n"
         "Respond with raw JSON only. No markdown, no explanation."
     )
     user_msg = (
@@ -191,13 +272,154 @@ def reason_about_task(prompt: str, budget: float, has_data: bool) -> TaskReasoni
         f"Budget: ${budget:.2f}\n"
         f"User has existing data: {has_data}"
     )
+    if hint:
+        user_msg += f"\nRequested UI task type: {hint}"
     message = client.messages.create(
         model="claude-haiku-4-5",
         max_tokens=512,
         system=system,
         messages=[{"role": "user", "content": user_msg}],
     )
-    return json.loads(message.content[0].text)
+    raw_text = message.content[0].text
+    return _parse_task_reasoning_response(raw_text)
+
+
+def _manager_reasoner_mode() -> str:
+    raw = os.getenv(_MANAGER_REASONER_ENV, "auto").strip().lower()
+    if raw in {"", "auto"}:
+        return "auto"
+    if raw in {"local", "offline", "heuristic"}:
+        return "local"
+    if raw in {"claude", "anthropic", "live", "required"}:
+        return "claude"
+    raise ValueError(f"{_MANAGER_REASONER_ENV} must be one of: auto, local, claude")
+
+
+def _use_local_reasoner() -> bool:
+    mode = _manager_reasoner_mode()
+    if _env_flag_enabled("NO_SPEND"):
+        return True
+    if mode == "local":
+        return True
+    if mode == "claude":
+        return False
+    return not bool(os.getenv("ANTHROPIC_API_KEY"))
+
+
+def _env_flag_enabled(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _local_task_reasoning(prompt: str, budget: float, has_data: bool) -> TaskReasoning:
+    """Deterministic fallback planner for no-live Manager runs."""
+    task_type = _infer_local_task_type(prompt)
+    data_format = (
+        "jsonl with messages or input/output fields"
+        if has_data
+        else "generated jsonl with messages or input/output fields"
+    )
+    hyperparameters = {
+        "learning_rate": 1e-4,
+        "batch_size": 4,
+        "epochs": 1,
+        "num_epochs": 1,
+        "max_seq_len": 512,
+        "max_seq_length": 512,
+        "lora_rank": 8,
+        "max_steps": 5,
+    }
+    return TaskReasoning(
+        task_type=task_type,
+        data_format=data_format,
+        training_type="SFT",
+        suggested_base_model=None,
+        hyperparameters=hyperparameters,
+        notes=(
+            "Local deterministic planner used because live Manager reasoning "
+            "was not enabled."
+        ),
+    )
+
+
+def _infer_local_task_type(prompt: str) -> str:
+    text = prompt.lower()
+    if any(term in text for term in ("translate", "translation")):
+        return "translation"
+    if any(term in text for term in ("summarize", "summarise", "summary")):
+        return "summarization"
+    if any(term in text for term in ("question answering", "question-answering", "qa")):
+        return "question-answering"
+    if any(
+        term in text
+        for term in (
+            "classify",
+            "classification",
+            "sentiment",
+            "label",
+            "category",
+            "categorize",
+            "categorise",
+            "intent",
+        )
+    ):
+        return "text-classification"
+    return "custom"
+
+
+def _parse_task_reasoning_response(raw_text: str) -> TaskReasoning:
+    """Parse and validate the Manager LLM's task-reasoning JSON."""
+    try:
+        parsed = json.loads(_extract_json_payload(raw_text))
+    except json.JSONDecodeError as exc:
+        preview = raw_text.strip().replace("\n", " ")[:200]
+        raise ValueError(
+            f"Manager reasoning response was not valid JSON: {preview!r}"
+        ) from exc
+
+    if not isinstance(parsed, dict):
+        raise ValueError("Manager reasoning response must be a JSON object.")
+
+    required = {
+        "task_type",
+        "data_format",
+        "training_type",
+        "suggested_base_model",
+        "hyperparameters",
+        "notes",
+    }
+    missing = sorted(required - parsed.keys())
+    if missing:
+        raise ValueError(f"Manager reasoning response missing keys: {missing}")
+    if not isinstance(parsed["hyperparameters"], dict):
+        raise ValueError("Manager reasoning hyperparameters must be a JSON object.")
+
+    return TaskReasoning(
+        task_type=str(parsed["task_type"]),
+        data_format=str(parsed["data_format"]),
+        training_type=str(parsed["training_type"]),
+        suggested_base_model=(
+            None
+            if parsed["suggested_base_model"] is None
+            else str(parsed["suggested_base_model"])
+        ),
+        hyperparameters=dict(parsed["hyperparameters"]),
+        notes=str(parsed["notes"]),
+    )
+
+
+def _extract_json_payload(raw_text: str) -> str:
+    text = raw_text.strip()
+    fenced = re.fullmatch(r"```(?:json)?\s*(.*?)\s*```", text, re.DOTALL)
+    if fenced:
+        return fenced.group(1).strip()
+    return text
+
+
+def _normalize_task_type_hint(task_type_hint: str | None) -> str | None:
+    if task_type_hint is None:
+        return None
+    value = str(task_type_hint).strip().lower()
+    return value if value in {"classification", "regression", "fine-tuning"} else None
 
 
 def _handoff_to_dataset_result(handoff: dict) -> DatasetResult:
@@ -205,40 +427,21 @@ def _handoff_to_dataset_result(handoff: dict) -> DatasetResult:
 
     Persists records to outputs/datasets/train_data.jsonl and computes an 80/10/10 split.
     """
-    mode = handoff.get("mode_used", "C")
-    raw_data = handoff.get("raw_data") or {}
-    records: list = raw_data.get("records", []) if isinstance(raw_data, dict) else []
+    from src.data_generator.curation import curate_handoff_to_dataset_result
 
-    os.makedirs("outputs/datasets", exist_ok=True)
-    dataset_path = os.path.abspath("outputs/datasets/train_data.jsonl")
-    with open(dataset_path, "w") as fh:
-        for rec in records:
-            import json as _json
-            fh.write(_json.dumps(rec) + "\n")
+    return curate_handoff_to_dataset_result(handoff)
 
-    n = len(records)
-    train_n = max(1, int(n * 0.8))
-    val_n   = max(1, int(n * 0.1))
-    test_n  = max(1, n - train_n - val_n)
 
-    dataset: StandardDataset = {
-        "path": dataset_path,
-        "format": "jsonl",
-        "train_size": train_n,
-        "val_size": val_n,
-        "test_size": test_n,
-    }
-    validation_report: ValidationReport = {
-        "passed": n > 0,
-        "issues": [] if n > 0 else ["DataGen returned 0 records"],
-        "sample_accuracy_estimate": 0.9 if n > 0 else 0.0,
-    }
-    return DatasetResult(
-        dataset=dataset,
-        mode_used=mode,
-        quality_notes=f"DataGen mode {mode}, {n} records",
-        validation_report=validation_report,
-    )
+def _ensure_dataset_is_trainable(dataset: DatasetResult) -> None:
+    validation = dataset["validation_report"]
+    split = dataset["dataset"]
+    if validation["passed"] and split["train_size"] > 0:
+        return
+
+    issues = "; ".join(validation.get("issues") or [])
+    if not issues:
+        issues = "no trainable examples were produced"
+    raise ValueError(f"DataGen did not produce a trainable dataset: {issues}")
 
 
 def build_orchestration_config(

--- a/src/observability/observability.py
+++ b/src/observability/observability.py
@@ -17,6 +17,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+from src.runtime_context import resolve_output_path
 from src.types import LogEntry
 
 # ANSI color codes by agent name
@@ -41,7 +42,7 @@ def log_event(
     level: str,
     message: str,
     metadata: dict = {},
-    log_path: str = "outputs/logs/run.jsonl",
+    log_path: str | Path | None = None,
 ) -> None:
     """Central logging function called by every agent. Writes JSON to disk and colored line to stdout."""
     entry: LogEntry = {
@@ -52,7 +53,12 @@ def log_event(
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
     emit_cli(entry)
-    write_json_log(entry, log_path)
+    path = Path(log_path) if log_path is not None else resolve_output_path(
+        "outputs/logs/run.jsonl",
+        "logs",
+        "run.jsonl",
+    )
+    write_json_log(entry, path)
 
 
 def format_cli_line(entry: LogEntry) -> str:
@@ -72,7 +78,7 @@ def emit_cli(entry: LogEntry) -> None:
     print(format_cli_line(entry), file=sys.stdout, flush=True)
 
 
-def write_json_log(entry: LogEntry, log_path: str) -> None:
+def write_json_log(entry: LogEntry, log_path: str | Path) -> None:
     """Appends the LogEntry as a JSON line to the structured log file."""
     path = Path(log_path)
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/server/__init__.py
+++ b/src/server/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP server entrypoints for the ML agent frontend bridge."""

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -1,0 +1,1059 @@
+"""FastAPI bridge between the Vite frontend and the Manager graph.
+
+The server deliberately keeps the v1 contract small: start a run, poll its
+state, and surface the final Manager result. Detailed live log streaming can be
+added later once observability emits run-scoped events.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import threading
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
+from fastapi.middleware.cors import CORSMiddleware
+
+from src.data_sources import looks_like_local_data_path, normalize_hf_dataset_source
+from src.manager.manager import invoke_manager_graph
+from src.runtime_context import (
+    RunCancelled,
+    cancellation_context,
+    output_root,
+    raise_if_cancelled,
+)
+from src.server.schemas import (
+    ArtifactView,
+    IterationView,
+    LogEntryView,
+    MetricPoint,
+    PipelineStage,
+    RunArtifactsView,
+    RunProvenanceView,
+    RunCreated,
+    RunRequest,
+    RunState,
+)
+from src.tinker_api.tinker_api import cancel_job
+
+
+STAGE_LABELS = [
+    "Manager Init",
+    "Data Discovery",
+    "Model Selection",
+    "Training",
+    "AutoResearch",
+    "Finalization",
+]
+RUN_OUTPUT_ROOT = Path(os.getenv("MANAGER_RUN_OUTPUT_ROOT", "outputs/api-runs"))
+ARTIFACT_DEFINITIONS = {
+    "manifest": ("Manifest", "manifest.json", "application/json"),
+    "metrics": ("Metrics", "metrics.json", "application/json"),
+    "metrics_log": ("Metrics Log", "metrics.jsonl", "application/x-ndjson"),
+    "sample": ("Sample", "sample.json", "application/json"),
+    "diary": ("Research Diary", None, "application/x-ndjson"),
+}
+DATA_GENERATOR_ARTIFACT_DEFINITIONS = {
+    "data_manifest": (
+        "Data Manifest",
+        "manifest",
+        "artifact_manifest.json",
+        "application/json",
+    ),
+    "data_handoff": (
+        "Data Handoff",
+        "handoff_payload",
+        "raw_handoff_data.json",
+        "application/json",
+    ),
+    "data_curation_report": (
+        "Data Curation Report",
+        "curation_human_readable",
+        "human_readable.md",
+        "text/markdown",
+    ),
+    "data_debug_context": (
+        "Data Debug Context",
+        "debug_context",
+        "debug_context.json",
+        "application/json",
+    ),
+    "data_source_report": (
+        "Data Source Report",
+        "source_human_readable",
+        "source_human_readable.md",
+        "text/markdown",
+    ),
+}
+LOCAL_DEV_ORIGIN_REGEX = r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$"
+
+
+def _cors_origins_from_env() -> list[str]:
+    origins = [
+        "http://localhost:5173",
+        "http://127.0.0.1:5173",
+    ]
+    extra_origins = os.getenv("MANAGER_API_CORS_ORIGINS", "")
+    for origin in extra_origins.split(","):
+        normalized = origin.strip().rstrip("/")
+        if normalized and normalized not in origins:
+            origins.append(normalized)
+    return origins
+
+
+app = FastAPI(title="Nemoral ML Agent API")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_cors_origins_from_env(),
+    allow_origin_regex=LOCAL_DEV_ORIGIN_REGEX,
+    allow_credentials=False,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@dataclass
+class _RunRecord:
+    run_id: str
+    request: RunRequest
+    output_dir: Path
+    status: str = "running"
+    stage: int = 0
+    cost_spent: float = 0.0
+    metrics: list[MetricPoint] = field(default_factory=list)
+    iterations: list[IterationView] = field(default_factory=list)
+    logs: list[LogEntryView] = field(default_factory=list)
+    result: dict[str, Any] | None = None
+    artifacts: RunArtifactsView | None = None
+    artifact_paths: dict[str, Path] = field(default_factory=dict)
+    artifact_content_types: dict[str, str] = field(default_factory=dict)
+    error: str | None = None
+    stages: list[PipelineStage] = field(default_factory=list)
+    cancel_event: threading.Event = field(default_factory=threading.Event)
+    active_tinker_jobs: set[str] = field(default_factory=set)
+    worker_thread: threading.Thread | None = None
+
+
+_RUNS: dict[str, _RunRecord] = {}
+_LOCK = threading.RLock()
+
+
+def _initial_stages() -> list[PipelineStage]:
+    return [
+        PipelineStage(id=index, label=label, status="pending")
+        for index, label in enumerate(STAGE_LABELS)
+    ]
+
+
+def _time_label() -> str:
+    return datetime.now().strftime("%H:%M:%S")
+
+
+def _append_log(record: _RunRecord, component: str, message: str, kind: str = "default") -> None:
+    record.logs.insert(
+        0,
+        LogEntryView(time=_time_label(), component=component, message=message, type=kind),
+    )
+    record.logs = record.logs[:100]
+
+
+def _is_terminal(record: _RunRecord) -> bool:
+    return record.status in {"cancelled", "complete", "failed"}
+
+
+def _mark_cancelled(record: _RunRecord, message: str = "Run cancelled") -> None:
+    record.status = "cancelled"
+    record.error = None
+    _mark_current_stage_terminal(record, "cancelled")
+    _append_log(record, "Manager", message, "warning")
+
+
+def _request_cancel(record: _RunRecord) -> None:
+    if _is_terminal(record):
+        return
+    record.cancel_event.set()
+    for job_id in list(record.active_tinker_jobs):
+        cancel_job(job_id)
+    if record.status != "cancelling":
+        record.status = "cancelling"
+        _append_log(record, "Manager", "Cancellation requested", "warning")
+
+
+def _copy_request_with_data_path(request: RunRequest, data_path: str | None) -> RunRequest:
+    if hasattr(request, "model_copy"):
+        return request.model_copy(update={"data_path": data_path})
+    return request.copy(update={"data_path": data_path})
+
+
+def _normalize_data_path_for_run(data_path: str | None) -> str | None:
+    if data_path is None:
+        return None
+
+    value = data_path.strip()
+    if not value:
+        return None
+
+    local_path = Path(value).expanduser()
+    if local_path.exists():
+        return str(local_path.resolve())
+
+    if looks_like_local_data_path(value):
+        raise HTTPException(
+            status_code=400,
+            detail="data_path must be an existing local path or Hugging Face source",
+        )
+
+    hf_source = normalize_hf_dataset_source(value)
+    if hf_source:
+        return hf_source
+
+    raise HTTPException(
+        status_code=400,
+        detail="data_path must be an existing local path or Hugging Face source",
+    )
+
+
+def _mark_stage(record: _RunRecord, stage: int, status: str = "in-progress") -> None:
+    record.stage = stage
+    updated = []
+    for item in record.stages:
+        if item.id < stage:
+            updated.append(PipelineStage(id=item.id, label=item.label, status="complete"))
+        elif item.id == stage:
+            updated.append(PipelineStage(id=item.id, label=item.label, status=status))
+        else:
+            updated.append(PipelineStage(id=item.id, label=item.label, status="pending"))
+    record.stages = updated
+
+
+def _complete_all_stages(record: _RunRecord) -> None:
+    record.stage = len(STAGE_LABELS) - 1
+    record.stages = [
+        PipelineStage(id=item.id, label=item.label, status="complete")
+        for item in record.stages
+    ]
+
+
+def _mark_current_stage_terminal(record: _RunRecord, status: str) -> None:
+    def stage_status(item: PipelineStage) -> str:
+        if item.id < record.stage:
+            return "complete"
+        if item.id == record.stage:
+            return status
+        return "pending"
+
+    record.stages = [
+        PipelineStage(id=item.id, label=item.label, status=stage_status(item))
+        for item in record.stages
+    ]
+
+
+def _fail_current_stage(record: _RunRecord, message: str) -> None:
+    record.status = "failed"
+    record.error = message
+    _mark_current_stage_terminal(record, "failed")
+    _append_log(record, "Manager", message, "error")
+
+
+def _primary_metric_value_and_label(
+    metrics: dict[str, Any],
+    *,
+    scalar: Any = None,
+) -> tuple[float, str]:
+    for key, label in (
+        ("accuracy", "Accuracy"),
+        ("f1", "F1"),
+        ("primary_metric", "Primary Score"),
+    ):
+        value = metrics.get(key)
+        if value is None:
+            continue
+        try:
+            score = float(value)
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(score):
+            return score, label
+
+    try:
+        score = float(scalar)
+    except (TypeError, ValueError):
+        return 0.0, "Primary Score"
+    return (score, "Primary Score") if math.isfinite(score) else (0.0, "Primary Score")
+
+
+def _metric_from_result(result: dict[str, Any]) -> MetricPoint | None:
+    score = result.get("metrics") or {}
+    metrics = score.get("metrics") or {}
+    primary_metric, primary_metric_label = _primary_metric_value_and_label(
+        metrics,
+        scalar=score.get("scalar"),
+    )
+
+    loss = metrics.get("val_loss")
+    if loss is None:
+        loss = metrics.get("train_loss")
+    if loss is None:
+        loss = max(0.0, 1.0 - primary_metric)
+
+    return MetricPoint(
+        loss=float(loss),
+        accuracy=primary_metric,
+        primaryMetric=primary_metric,
+        primaryMetricLabel=primary_metric_label,
+        iteration=1,
+    )
+
+
+def _iterations_from_diary(path: str | None) -> list[IterationView]:
+    if not path:
+        return []
+
+    diary_path = Path(path)
+    if not diary_path.exists():
+        return []
+
+    iterations: list[IterationView] = []
+    for line in diary_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        if _is_budget_preflight_skip(row):
+            continue
+
+        metrics = row.get("metrics") or {}
+        iteration = int(row.get("iteration") or len(iterations) + 1)
+        decision = row.get("decision") or "PENDING"
+        if decision not in {"KEPT", "REVERTED", "PENDING"}:
+            decision = "PENDING"
+        primary_metric, primary_metric_label = _primary_metric_value_and_label(metrics)
+
+        iterations.append(
+            IterationView(
+                id=f"iter-{iteration}",
+                experiment=str(row.get("hypothesis") or "AutoResearch iteration"),
+                diff=row.get("patch"),
+                loss=float(metrics.get("val_loss") or metrics.get("train_loss") or 0.0),
+                f1=primary_metric,
+                primaryMetric=primary_metric,
+                primaryMetricLabel=primary_metric_label,
+                status=decision,
+            )
+        )
+    return list(reversed(iterations))
+
+
+def _jsonl_rows(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+
+    rows: list[dict[str, Any]] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(row, dict):
+            rows.append(row)
+    return rows
+
+
+def _log_time(timestamp: Any) -> str:
+    if isinstance(timestamp, str) and len(timestamp) >= 19:
+        return timestamp[11:19]
+    return _time_label()
+
+
+def _log_kind(level: Any) -> str:
+    if level == "ERROR":
+        return "error"
+    if level == "WARN":
+        return "warning"
+    return "default"
+
+
+def _logs_from_observability(record: _RunRecord) -> list[LogEntryView]:
+    rows = _jsonl_rows(record.output_dir / "logs" / "run.jsonl")
+    return [
+        LogEntryView(
+            time=_log_time(row.get("timestamp")),
+            component=str(row.get("agent") or "System"),
+            message=str(row.get("message") or ""),
+            type=_log_kind(row.get("level")),
+        )
+        for row in reversed(rows[-100:])
+        if row.get("message")
+    ]
+
+
+def _merge_logs(record: _RunRecord, file_logs: list[LogEntryView]) -> None:
+    if not file_logs:
+        return
+    seen = {(item.time, item.component, item.message, item.type) for item in file_logs}
+    merged = file_logs + [
+        item
+        for item in record.logs
+        if (item.time, item.component, item.message, item.type) not in seen
+    ]
+    record.logs = merged[:100]
+
+
+def _cost_from_diary(path: Path) -> float:
+    return sum(float(row.get("cost_usd") or 0.0) for row in _jsonl_rows(path))
+
+
+def _is_budget_preflight_skip(row: dict[str, Any] | None) -> bool:
+    if not row:
+        return False
+    if row.get("budget_preflight_skipped") is True:
+        return True
+    note = str(row.get("notes") or row.get("reason") or "").lower()
+    return "budget preflight" in note and "skipped" in note
+
+
+def _experiment_dirs(record: _RunRecord) -> list[Path]:
+    root = record.output_dir / "experiments"
+    if not root.is_dir():
+        return []
+    return sorted(
+        [path for path in root.iterdir() if path.is_dir()],
+        key=lambda path: path.stat().st_mtime,
+    )
+
+
+def _latest_experiment_dir(record: _RunRecord) -> Path | None:
+    dirs = _experiment_dirs(record)
+    return dirs[-1] if dirs else None
+
+
+def _has_complete_experiment_artifacts(run_dir: Path) -> bool:
+    return all(
+        (run_dir / filename).is_file()
+        for name, (_, filename, _) in ARTIFACT_DEFINITIONS.items()
+        if name != "diary" and filename is not None
+    )
+
+
+def _latest_artifact_experiment_dir(record: _RunRecord) -> Path | None:
+    for run_dir in reversed(_experiment_dirs(record)):
+        if _has_complete_experiment_artifacts(run_dir):
+            return run_dir
+    return None
+
+
+def _metric_point(row: dict[str, Any], iteration: int) -> MetricPoint | None:
+    loss = row.get("val_loss", row.get("train_loss"))
+    primary_metric, primary_metric_label = _primary_metric_value_and_label(row)
+    try:
+        loss_value = float(loss)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(loss_value):
+        return None
+    return MetricPoint(
+        loss=loss_value,
+        accuracy=primary_metric,
+        primaryMetric=primary_metric,
+        primaryMetricLabel=primary_metric_label,
+        iteration=iteration,
+    )
+
+
+def _metrics_from_experiments(record: _RunRecord) -> list[MetricPoint]:
+    points: list[MetricPoint] = []
+    for run_dir in _experiment_dirs(record):
+        manifest = _read_json_if_exists(run_dir / "manifest.json")
+        if _is_budget_preflight_skip(manifest):
+            continue
+        rows = _jsonl_rows(run_dir / "metrics.jsonl")
+        if not rows:
+            metrics = _read_json_if_exists(run_dir / "metrics.json")
+            rows = [metrics] if metrics else []
+        for row in rows:
+            if _is_budget_preflight_skip(row):
+                continue
+            point = _metric_point(row, len(points) + 1)
+            if point:
+                points.append(point)
+    return points[-100:]
+
+
+def _refresh_stage_from_files(record: _RunRecord, latest_experiment: Path | None) -> None:
+    if _is_terminal(record):
+        return
+
+    stage = record.stage
+    if (record.output_dir / "datasets" / "train_data.jsonl").exists():
+        stage = max(stage, 2)
+    if (
+        (record.output_dir / "scripts" / "train.py").exists()
+        or (record.output_dir / "configs" / "current.json").exists()
+    ):
+        stage = max(stage, 3)
+    if latest_experiment and (
+        (latest_experiment / "metrics.jsonl").exists()
+        or (latest_experiment / "metrics.json").exists()
+    ):
+        stage = max(stage, 4)
+
+    if stage > record.stage:
+        _mark_stage(record, stage)
+
+
+def _refresh_record_from_files(record: _RunRecord) -> None:
+    _merge_logs(record, _logs_from_observability(record))
+
+    diary_path = record.output_dir / "logs" / "research_diary.jsonl"
+    if diary_path.exists():
+        record.iterations = _iterations_from_diary(str(diary_path))
+        record.cost_spent = max(record.cost_spent, _cost_from_diary(diary_path))
+
+    metrics = _metrics_from_experiments(record)
+    if metrics:
+        record.metrics = metrics
+
+    latest_experiment = _latest_experiment_dir(record)
+    artifact_experiment = _latest_artifact_experiment_dir(record)
+    _refresh_stage_from_files(record, latest_experiment)
+    if artifact_experiment and record.result is None:
+        record.artifacts = _artifacts_from_result(
+            record,
+            {
+                "weights_path": str(artifact_experiment),
+                "research_diary_path": str(diary_path) if diary_path.exists() else None,
+            },
+        )
+
+
+def _read_json_if_exists(path: Path | None) -> dict[str, Any] | None:
+    if path is None or not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _env_flag_enabled(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _resolve_reported_path(record: _RunRecord, value: Any) -> Path | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+
+    raw_path = Path(value).expanduser()
+    if raw_path.is_absolute():
+        return raw_path
+
+    candidates = [
+        raw_path,
+        record.output_dir / raw_path,
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return raw_path
+
+
+def _artifact_view(
+    *,
+    run_id: str,
+    name: str,
+    label: str,
+    path: Path | None,
+    content_type: str,
+    downloadable: bool,
+) -> ArtifactView:
+    exists = bool(path and path.is_file())
+    return ArtifactView(
+        name=name,
+        label=label,
+        path=str(path) if path else None,
+        exists=exists,
+        sizeBytes=path.stat().st_size if exists and path is not None else None,
+        contentType=content_type,
+        downloadPath=f"/api/runs/{run_id}/artifacts/{name}" if downloadable else None,
+    )
+
+
+def _is_run_artifact_path(record: _RunRecord, path: Path | None) -> bool:
+    if path is None or not path.is_file():
+        return False
+    try:
+        path.resolve().relative_to(record.output_dir.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def _is_run_artifact_dir(record: _RunRecord, path: Path | None) -> bool:
+    if path is None or not path.is_dir():
+        return False
+    try:
+        path.resolve().relative_to(record.output_dir.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def _path_is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve().relative_to(parent.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def _latest_data_generator_manifest(record: _RunRecord) -> tuple[dict[str, Any] | None, Path | None]:
+    latest = _read_json_if_exists(record.output_dir / "data_generator" / "latest_run.json")
+    if not latest:
+        return None, None
+
+    manifest_path = _resolve_reported_path(record, latest.get("manifest_path"))
+    if (
+        not _is_run_artifact_path(record, manifest_path)
+        or manifest_path is None
+        or manifest_path.name != "artifact_manifest.json"
+    ):
+        return None, None
+    return _read_json_if_exists(manifest_path), manifest_path
+
+
+def _data_generator_artifact_dir(
+    record: _RunRecord,
+    manifest: dict[str, Any],
+    manifest_path: Path,
+) -> Path | None:
+    artifact_dir = _resolve_reported_path(record, manifest.get("artifact_dir"))
+    if not _is_run_artifact_dir(record, artifact_dir):
+        artifact_dir = manifest_path.parent
+    return artifact_dir if _is_run_artifact_dir(record, artifact_dir) else None
+
+
+def _data_generator_artifact_paths(record: _RunRecord) -> dict[str, Path]:
+    manifest, manifest_path = _latest_data_generator_manifest(record)
+    if not manifest or manifest_path is None:
+        return {}
+
+    artifact_dir = _data_generator_artifact_dir(record, manifest, manifest_path)
+    if artifact_dir is None:
+        return {}
+
+    files = manifest.get("files")
+    files = files if isinstance(files, dict) else {}
+    paths: dict[str, Path] = {"data_manifest": manifest_path}
+
+    for name, (_, manifest_key, filename, _) in DATA_GENERATOR_ARTIFACT_DEFINITIONS.items():
+        if name == "data_manifest":
+            continue
+        reported = files.get(manifest_key)
+        path = _resolve_reported_path(record, reported) if reported else artifact_dir / filename
+        if (
+            _is_run_artifact_path(record, path)
+            and path is not None
+            and path.name == filename
+            and _path_is_within(path, artifact_dir)
+        ):
+            paths[name] = path
+
+    return paths
+
+
+def _artifacts_from_result(record: _RunRecord, result: dict[str, Any]) -> RunArtifactsView:
+    model_path = _resolve_reported_path(record, result.get("weights_path"))
+    diary_path = _resolve_reported_path(record, result.get("research_diary_path"))
+
+    files: list[ArtifactView] = []
+    artifact_paths: dict[str, Path] = {}
+    artifact_content_types: dict[str, str] = {}
+
+    for name, (label, filename, content_type) in ARTIFACT_DEFINITIONS.items():
+        if name == "diary":
+            path = diary_path
+        else:
+            path = model_path / filename if model_path and filename else None
+        downloadable = _is_run_artifact_path(record, path)
+        view = _artifact_view(
+            run_id=record.run_id,
+            name=name,
+            label=label,
+            path=path,
+            content_type=content_type,
+            downloadable=downloadable,
+        )
+        files.append(view)
+        if downloadable and path is not None:
+            artifact_paths[name] = path
+            artifact_content_types[name] = content_type
+
+    data_paths = _data_generator_artifact_paths(record)
+    if data_paths:
+        for name, (label, _, _, content_type) in DATA_GENERATOR_ARTIFACT_DEFINITIONS.items():
+            path = data_paths.get(name)
+            downloadable = _is_run_artifact_path(record, path)
+            view = _artifact_view(
+                run_id=record.run_id,
+                name=name,
+                label=label,
+                path=path,
+                content_type=content_type,
+                downloadable=downloadable,
+            )
+            files.append(view)
+            if downloadable and path is not None:
+                artifact_paths[name] = path
+                artifact_content_types[name] = content_type
+
+    manifest = _read_json_if_exists(artifact_paths.get("manifest"))
+    checkpoints = manifest.get("checkpoints", {}) if manifest else {}
+    metrics = _read_json_if_exists(artifact_paths.get("metrics"))
+    sample = _read_json_if_exists(artifact_paths.get("sample"))
+
+    record.artifact_paths = artifact_paths
+    record.artifact_content_types = artifact_content_types
+    return RunArtifactsView(
+        modelPath=str(model_path) if model_path else None,
+        checkpoints=checkpoints if isinstance(checkpoints, dict) else {},
+        metrics=metrics,
+        sample=sample,
+        files=files,
+    )
+
+
+def _latest_tinker_manifest(record: _RunRecord) -> tuple[dict[str, Any] | None, Path | None]:
+    path = record.artifact_paths.get("manifest")
+    if path is None:
+        run_dir = _latest_artifact_experiment_dir(record) or _latest_experiment_dir(record)
+        path = run_dir / "manifest.json" if run_dir else None
+    return _read_json_if_exists(path), path
+
+
+def _latest_data_generator_debug(record: _RunRecord) -> tuple[dict[str, Any] | None, Path | None]:
+    debug_path = _data_generator_artifact_paths(record).get("data_debug_context")
+    if debug_path is None:
+        return None, None
+    return _read_json_if_exists(debug_path), debug_path
+
+
+def _training_backend_from_manifest(manifest: dict[str, Any] | None) -> str | None:
+    if not manifest:
+        return None
+    backend = manifest.get("backend") or manifest.get("training_backend")
+    if isinstance(backend, str) and backend.strip():
+        return backend.strip()
+
+    checkpoints = manifest.get("checkpoints")
+    if isinstance(checkpoints, dict):
+        values = [str(value) for value in checkpoints.values() if value]
+        if any(value.startswith("dry-run://") for value in values):
+            return "dry_run"
+        if any(value.startswith("tinker://") for value in values):
+            return "tinker"
+    return None
+
+
+def _data_format_meta(debug: dict[str, Any] | None) -> dict[str, Any]:
+    if not debug:
+        return {}
+    raw_data = debug.get("raw_data")
+    if not isinstance(raw_data, dict):
+        return {}
+    format_meta = raw_data.get("format_meta")
+    return format_meta if isinstance(format_meta, dict) else {}
+
+
+def _provenance_for_record(record: _RunRecord) -> RunProvenanceView:
+    manifest, manifest_path = _latest_tinker_manifest(record)
+    data_debug, data_debug_path = _latest_data_generator_debug(record)
+
+    training_backend = _training_backend_from_manifest(manifest)
+    data_mode = None
+    mode_c_fallback = None
+    if data_debug:
+        data_mode = data_debug.get("mode_used")
+        mode_c_fallback = data_debug.get("mode_c_fallback")
+        source_metadata = data_debug.get("source_metadata")
+        if mode_c_fallback is None and isinstance(source_metadata, dict):
+            mode_c_fallback = source_metadata.get("mode_c_fallback")
+
+    budget_preflight_skipped = bool(manifest and manifest.get("budget_preflight_skipped"))
+    cost = record.result.get("cost") if isinstance(record.result, dict) else None
+    manifest_cost = manifest.get("cost") if isinstance(manifest, dict) else None
+    budget_skip_reason = None
+    if isinstance(manifest_cost, dict):
+        budget_skip_reason = manifest_cost.get("termination_reason")
+    if not budget_skip_reason and isinstance(cost, dict):
+        budget_skip_reason = cost.get("termination_reason")
+    if budget_skip_reason != "budget_limit":
+        budget_skip_reason = None
+
+    no_spend = _env_flag_enabled("NO_SPEND")
+    backend_key = (training_backend or "").replace("-", "_").lower()
+    configured_backend = os.getenv("TINKER_BACKEND", "").strip().replace("-", "_").lower()
+
+    live_services: list[str] = []
+    if not no_spend and backend_key in {"tinker", "tinker_sft"}:
+        live_services.append("Tinker")
+
+    format_meta = _data_format_meta(data_debug)
+    if not no_spend and format_meta.get("search_backend"):
+        live_services.append(str(format_meta["search_backend"]))
+    if not no_spend and format_meta.get("teacher_used"):
+        live_services.append("Teacher LLM")
+
+    evidence: list[str] = []
+    if _env_flag_enabled("NO_SPEND"):
+        evidence.append("env:NO_SPEND=1")
+    if configured_backend:
+        evidence.append(f"env:TINKER_BACKEND={configured_backend}")
+    if manifest_path and manifest_path.is_file():
+        evidence.append(str(manifest_path))
+    if data_debug_path and data_debug_path.is_file():
+        evidence.append(str(data_debug_path))
+
+    if no_spend:
+        spend_mode = "no_spend"
+    elif budget_preflight_skipped:
+        spend_mode = "budget_skipped"
+    elif backend_key == "dry_run" or configured_backend == "dry_run":
+        spend_mode = "dry_run"
+    elif live_services:
+        spend_mode = "live"
+    else:
+        spend_mode = "local"
+
+    return RunProvenanceView(
+        spendMode=spend_mode,
+        trainingBackend=training_backend,
+        dataMode=str(data_mode) if data_mode else None,
+        modeCFallback=str(mode_c_fallback) if mode_c_fallback else None,
+        budgetPreflightSkipped=budget_preflight_skipped,
+        budgetSkipReason=budget_skip_reason,
+        liveServices=list(dict.fromkeys(live_services)),
+        evidence=evidence,
+    )
+
+
+def _budget_preflight_skip_reason_from_result(
+    record: _RunRecord,
+    result: dict[str, Any],
+) -> str | None:
+    cost = result.get("cost") or {}
+    if cost.get("termination_reason") != "budget_limit":
+        return None
+
+    model_path = _resolve_reported_path(record, result.get("weights_path"))
+    manifest = _read_json_if_exists(model_path / "manifest.json") if model_path else None
+    if not _is_budget_preflight_skip(manifest):
+        return None
+
+    reason = str((manifest or {}).get("budget_skip_reason") or "").strip()
+    return reason or "budget preflight skipped the Tinker launch"
+
+
+def _selected_training_terminal_state(
+    record: _RunRecord,
+    result: dict[str, Any],
+) -> tuple[str | None, str | None]:
+    model_path = _resolve_reported_path(record, result.get("weights_path"))
+    manifest = _read_json_if_exists(model_path / "manifest.json") if model_path else None
+    status = str((manifest or {}).get("status") or "").strip().upper()
+    if status not in {"FAILED", "CANCELLED"}:
+        return None, None
+
+    reason = str(
+        (manifest or {}).get("error")
+        or (manifest or {}).get("reason")
+        or (manifest or {}).get("status_reason")
+        or ""
+    ).strip()
+    if not reason:
+        reason = f"selected training artifact reported status {status}"
+    return status.lower(), reason
+
+
+def _store_manager_result(record: _RunRecord, result: dict[str, Any]) -> None:
+    budget_skip_reason = _budget_preflight_skip_reason_from_result(record, result)
+    terminal_status, terminal_reason = _selected_training_terminal_state(record, result)
+    record.result = result
+    record.cost_spent = float((result.get("cost") or {}).get("total_usd") or 0.0)
+    metric = _metric_from_result(result)
+    if not budget_skip_reason and not record.metrics:
+        record.metrics = [metric] if metric else []
+    record.iterations = _iterations_from_diary(result.get("research_diary_path"))
+    record.artifacts = _artifacts_from_result(record, result)
+    _complete_all_stages(record)
+    if budget_skip_reason:
+        record.status = "cancelled"
+        record.error = budget_skip_reason
+        _append_log(
+            record,
+            "Manager",
+            f"Training skipped by budget guard: {budget_skip_reason}",
+            "warning",
+        )
+    elif terminal_status:
+        record.status = terminal_status
+        record.error = terminal_reason
+        _append_log(
+            record,
+            "Manager",
+            f"Training artifact ended with status {terminal_status}: {terminal_reason}",
+            "error" if terminal_status == "failed" else "warning",
+        )
+    else:
+        record.status = "complete"
+        _append_log(record, "Manager", "Training pipeline complete", "success")
+
+
+def _run_manager(record: _RunRecord) -> None:
+    with _LOCK:
+        _mark_stage(record, 0)
+        _append_log(record, "Manager", "Run accepted")
+        if record.request.data_path:
+            _append_log(record, "DataGen", f"Dataset source: {record.request.data_path}")
+        _append_log(record, "Manager", "Manager graph is running")
+
+    try:
+        with output_root(record.output_dir), cancellation_context(
+            record.cancel_event,
+            record.active_tinker_jobs,
+        ):
+            raise_if_cancelled()
+            result = invoke_manager_graph(
+                record.request.prompt,
+                record.request.budget,
+                record.request.data_path,
+                task_type_hint=record.request.task_type,
+            )
+            raise_if_cancelled()
+    except RunCancelled:
+        with _LOCK:
+            _refresh_record_from_files(record)
+            _mark_cancelled(record)
+        return
+    except Exception as exc:  # surfaced to the browser as a failed run state
+        with _LOCK:
+            _refresh_record_from_files(record)
+            _fail_current_stage(record, str(exc))
+        return
+
+    with _LOCK:
+        _refresh_record_from_files(record)
+        if record.cancel_event.is_set():
+            _mark_cancelled(record)
+        else:
+            _store_manager_result(record, dict(result))
+
+
+def _to_state(record: _RunRecord) -> RunState:
+    return RunState(
+        run_id=record.run_id,
+        status=record.status,
+        stage=record.stage,
+        prompt=record.request.prompt,
+        budget=record.request.budget,
+        taskType=record.request.task_type,
+        dataPath=record.request.data_path,
+        costSpent=record.cost_spent,
+        metrics=record.metrics,
+        iterations=record.iterations,
+        logs=record.logs,
+        stages=record.stages,
+        artifacts=record.artifacts,
+        provenance=_provenance_for_record(record),
+        result=record.result,
+        error=record.error,
+    )
+
+
+@app.get("/api/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/api/runs", response_model=RunCreated)
+def create_run(request: RunRequest) -> RunCreated:
+    normalized_data_path = _normalize_data_path_for_run(request.data_path)
+    request = _copy_request_with_data_path(request, normalized_data_path)
+
+    run_id = str(uuid.uuid4())
+    output_dir = RUN_OUTPUT_ROOT / run_id
+    record = _RunRecord(
+        run_id=run_id,
+        request=request,
+        output_dir=output_dir,
+        stages=_initial_stages(),
+    )
+    with _LOCK:
+        _RUNS[run_id] = record
+
+    thread = threading.Thread(target=_run_manager, args=(record,), daemon=True)
+    record.worker_thread = thread
+    thread.start()
+    return RunCreated(run_id=run_id, status="running")
+
+
+@app.get("/api/runs/{run_id}", response_model=RunState)
+def get_run(run_id: str) -> RunState:
+    with _LOCK:
+        record = _RUNS.get(run_id)
+        if record is None:
+            raise HTTPException(status_code=404, detail="run not found")
+        _refresh_record_from_files(record)
+        return _to_state(record)
+
+
+@app.post("/api/runs/{run_id}/cancel", response_model=RunState)
+def cancel_run(run_id: str) -> RunState:
+    with _LOCK:
+        record = _RUNS.get(run_id)
+        if record is None:
+            raise HTTPException(status_code=404, detail="run not found")
+        _request_cancel(record)
+        _refresh_record_from_files(record)
+        return _to_state(record)
+
+
+@app.get("/api/runs/{run_id}/artifacts/{artifact_name}")
+def get_run_artifact(run_id: str, artifact_name: str) -> FileResponse:
+    with _LOCK:
+        record = _RUNS.get(run_id)
+        if record is None:
+            raise HTTPException(status_code=404, detail="run not found")
+        if (
+            artifact_name not in ARTIFACT_DEFINITIONS
+            and artifact_name not in DATA_GENERATOR_ARTIFACT_DEFINITIONS
+        ):
+            raise HTTPException(status_code=404, detail="artifact not found")
+        _refresh_record_from_files(record)
+        path = record.artifact_paths.get(artifact_name)
+        content_type = record.artifact_content_types.get(artifact_name)
+
+    if path is None or not path.is_file() or content_type is None:
+        raise HTTPException(status_code=404, detail="artifact not found")
+    return FileResponse(path, media_type=content_type, filename=path.name)
+
+
+def _reset_runs_for_tests() -> None:
+    with _LOCK:
+        _RUNS.clear()

--- a/src/server/schemas.py
+++ b/src/server/schemas.py
@@ -1,0 +1,99 @@
+"""Pydantic schemas for the browser-facing run API."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class RunRequest(BaseModel):
+    prompt: str = Field(min_length=10, max_length=2000)
+    budget: float = Field(gt=0, le=500)
+    task_type: Literal["classification", "regression", "fine-tuning"] = "fine-tuning"
+    data_path: str | None = Field(default=None, max_length=1000)
+
+
+class RunCreated(BaseModel):
+    run_id: str
+    status: Literal["running"]
+
+
+class PipelineStage(BaseModel):
+    id: int
+    label: str
+    status: Literal["pending", "in-progress", "complete", "failed", "cancelled"]
+
+
+class MetricPoint(BaseModel):
+    loss: float
+    accuracy: float
+    primaryMetric: float | None = None
+    primaryMetricLabel: str = "Primary Score"
+    iteration: int
+
+
+class IterationView(BaseModel):
+    id: str
+    experiment: str
+    diff: str | None = None
+    loss: float
+    f1: float
+    primaryMetric: float | None = None
+    primaryMetricLabel: str = "Primary Score"
+    status: Literal["KEPT", "REVERTED", "PENDING"]
+
+
+class LogEntryView(BaseModel):
+    time: str
+    component: str
+    message: str
+    type: Literal["default", "success", "warning", "error"]
+
+
+class ArtifactView(BaseModel):
+    name: str
+    label: str
+    path: str | None = None
+    exists: bool
+    sizeBytes: int | None = None
+    contentType: str
+    downloadPath: str | None = None
+
+
+class RunArtifactsView(BaseModel):
+    modelPath: str | None = None
+    checkpoints: dict[str, Any] = Field(default_factory=dict)
+    metrics: dict[str, Any] | None = None
+    sample: dict[str, Any] | None = None
+    files: list[ArtifactView] = Field(default_factory=list)
+
+
+class RunProvenanceView(BaseModel):
+    spendMode: str = "unknown"
+    trainingBackend: str | None = None
+    dataMode: str | None = None
+    modeCFallback: str | None = None
+    budgetPreflightSkipped: bool = False
+    budgetSkipReason: str | None = None
+    liveServices: list[str] = Field(default_factory=list)
+    evidence: list[str] = Field(default_factory=list)
+
+
+class RunState(BaseModel):
+    run_id: str
+    status: Literal["running", "cancelling", "cancelled", "complete", "failed"]
+    stage: int
+    prompt: str
+    budget: float
+    taskType: Literal["classification", "regression", "fine-tuning"]
+    dataPath: str | None = None
+    costSpent: float
+    metrics: list[MetricPoint]
+    iterations: list[IterationView]
+    logs: list[LogEntryView]
+    stages: list[PipelineStage]
+    artifacts: RunArtifactsView | None = None
+    provenance: RunProvenanceView = Field(default_factory=RunProvenanceView)
+    result: dict[str, Any] | None = None
+    error: str | None = None

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -6,10 +6,13 @@ import pytest
 from unittest.mock import MagicMock, patch
 from src.manager.manager import (
     _handoff_to_dataset_result,
+    _parse_task_reasoning_response,
     build_manager_graph,
     build_orchestration_config,
+    invoke_manager_graph,
     log_decision,
     orchestrate_node,
+    query_data_node,
     reason_about_task,
 )
 from src.types import OrchestrationConfig, TaskReasoning
@@ -66,7 +69,8 @@ def test_log_decision_writes_to_disk(tmp_path):
     assert entry["config_snapshot"]["prompt"] == "test task"
 
 
-def test_reason_about_task_returns_task_reasoning():
+def test_reason_about_task_returns_task_reasoning(monkeypatch):
+    monkeypatch.setenv("MANAGER_REASONER", "claude")
     mock_response = MagicMock()
     mock_response.content = [MagicMock(text=json.dumps(MOCK_REASONING))]
 
@@ -77,6 +81,255 @@ def test_reason_about_task_returns_task_reasoning():
     assert result["task_type"] == "text-classification"
     assert result["training_type"] == "SFT"
     assert "learning_rate" in result["hyperparameters"]
+
+
+def test_reason_about_task_parses_fenced_json_response(monkeypatch):
+    monkeypatch.setenv("MANAGER_REASONER", "claude")
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text=f"```json\n{json.dumps(MOCK_REASONING)}\n```")]
+
+    with patch("anthropic.Anthropic") as MockClient:
+        MockClient.return_value.messages.create.return_value = mock_response
+        result = reason_about_task("classify movie sentiment", 50.0, False)
+
+    assert result["task_type"] == "text-classification"
+    assert result["suggested_base_model"] == "bert-base-uncased"
+
+
+def test_reason_about_task_uses_local_fallback_without_anthropic_key(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("MANAGER_REASONER", raising=False)
+
+    def fail_anthropic():
+        raise AssertionError("Anthropic should not be constructed in auto mode without a key")
+
+    monkeypatch.setattr("anthropic.Anthropic", fail_anthropic)
+
+    result = reason_about_task("Classify support tickets by urgency", 5.0, False)
+
+    assert result["task_type"] == "text-classification"
+    assert result["training_type"] == "SFT"
+    assert result["suggested_base_model"] is None
+    assert result["hyperparameters"]["num_epochs"] == 1
+    assert result["hyperparameters"]["max_steps"] == 5
+    assert "Local deterministic planner" in result["notes"]
+
+
+def test_reason_about_task_local_mode_overrides_available_key(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "present-but-not-used")
+    monkeypatch.setenv("MANAGER_REASONER", "local")
+
+    def fail_anthropic():
+        raise AssertionError("MANAGER_REASONER=local should not construct Anthropic")
+
+    monkeypatch.setattr("anthropic.Anthropic", fail_anthropic)
+
+    result = reason_about_task("Summarize customer support transcripts", 5.0, True)
+
+    assert result["task_type"] == "summarization"
+    assert result["data_format"] == "jsonl with messages or input/output fields"
+
+
+def test_reason_about_task_no_spend_overrides_claude_mode(monkeypatch):
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "present-but-not-used")
+    monkeypatch.setenv("MANAGER_REASONER", "claude")
+
+    def fail_anthropic():
+        raise AssertionError("NO_SPEND should not construct Anthropic")
+
+    monkeypatch.setattr("anthropic.Anthropic", fail_anthropic)
+
+    result = reason_about_task("Classify support tickets by urgency", 5.0, False)
+
+    assert result["task_type"] == "text-classification"
+    assert result["training_type"] == "SFT"
+    assert "Local deterministic planner" in result["notes"]
+
+
+def test_reason_about_task_invalid_reasoner_mode_fails(monkeypatch):
+    monkeypatch.setenv("MANAGER_REASONER", "maybe")
+
+    with pytest.raises(ValueError, match="MANAGER_REASONER"):
+        reason_about_task("classify movie sentiment", 50.0, False)
+
+
+def test_parse_task_reasoning_response_rejects_missing_keys():
+    payload = {
+        "task_type": "text-classification",
+        "data_format": "jsonl",
+    }
+
+    with pytest.raises(ValueError, match="missing keys"):
+        _parse_task_reasoning_response(json.dumps(payload))
+
+
+def test_parse_task_reasoning_response_rejects_non_json():
+    with pytest.raises(ValueError, match="not valid JSON"):
+        _parse_task_reasoning_response("Here is the plan: use SFT.")
+
+
+def test_reason_about_task_includes_task_type_hint(monkeypatch):
+    monkeypatch.setenv("MANAGER_REASONER", "claude")
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text=json.dumps(MOCK_REASONING))]
+
+    with patch("anthropic.Anthropic") as MockClient:
+        client = MockClient.return_value
+        client.messages.create.return_value = mock_response
+        reason_about_task(
+            "predict support ticket resolution time",
+            12.5,
+            True,
+            task_type_hint="regression",
+        )
+
+    payload = client.messages.create.call_args.kwargs["messages"][0]["content"]
+    assert "Requested UI task type: regression" in payload
+
+
+def test_query_data_node_uses_programmatic_data_path_without_input(tmp_path, monkeypatch):
+    data_path = tmp_path / "train.jsonl"
+    data_path.write_text('{"input":"x","output":"y"}\n', encoding="utf-8")
+
+    def fail_input(_prompt):
+        raise AssertionError("query_data_node should not prompt when data_path is set")
+
+    monkeypatch.setattr("builtins.input", fail_input)
+
+    out = query_data_node(
+        {
+            "prompt": "classify",
+            "budget": 5.0,
+            "data_path": str(data_path),
+            "has_data": True,
+            "task_reasoning": None,
+            "config": None,
+            "result": None,
+        }
+    )
+
+    assert out == {"has_data": True, "data_path": str(data_path.resolve())}
+
+
+def test_query_data_node_preserves_hf_dataset_source(monkeypatch):
+    def fail_input(_prompt):
+        raise AssertionError("query_data_node should not prompt when data_path is set")
+
+    monkeypatch.setattr("builtins.input", fail_input)
+
+    out = query_data_node(
+        {
+            "prompt": "classify",
+            "budget": 5.0,
+            "data_path": "hf://SetFit/sst2",
+            "has_data": True,
+            "task_reasoning": None,
+            "config": None,
+            "result": None,
+        }
+    )
+
+    assert out == {"has_data": True, "data_path": "hf://SetFit/sst2"}
+
+
+def test_query_data_node_does_not_treat_missing_relative_file_as_hf(monkeypatch):
+    def fail_input(_prompt):
+        raise AssertionError("query_data_node should not prompt when data_path is set")
+
+    monkeypatch.setattr("builtins.input", fail_input)
+
+    out = query_data_node(
+        {
+            "prompt": "classify",
+            "budget": 5.0,
+            "data_path": "data/train.jsonl",
+            "has_data": True,
+            "task_reasoning": None,
+            "config": None,
+            "result": None,
+        }
+    )
+
+    assert out == {"has_data": False, "data_path": None}
+
+
+def test_query_data_node_treats_eof_as_no_data(monkeypatch):
+    def raise_eof(_prompt):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", raise_eof)
+
+    out = query_data_node(
+        {
+            "prompt": "build an assistant",
+            "budget": 5.0,
+            "data_path": None,
+            "has_data": False,
+            "task_reasoning": None,
+            "config": None,
+            "result": None,
+        }
+    )
+
+    assert out == {"has_data": False, "data_path": None}
+
+
+def test_query_data_node_can_skip_interactive_prompt(monkeypatch):
+    def fail_input(_prompt):
+        raise AssertionError("query_data_node should not prompt in noninteractive mode")
+
+    monkeypatch.setattr("builtins.input", fail_input)
+
+    out = query_data_node(
+        {
+            "prompt": "build an assistant",
+            "budget": 5.0,
+            "data_path": None,
+            "has_data": False,
+            "interactive_data_prompt": False,
+            "task_reasoning": None,
+            "config": None,
+            "result": None,
+        }
+    )
+
+    assert out == {"has_data": False, "data_path": None}
+
+
+def test_invoke_manager_graph_defaults_to_noninteractive_mode(monkeypatch):
+    captured = {}
+
+    class FakeGraph:
+        def invoke(self, state):
+            captured.update(state)
+            return {"result": {"weights_path": "model"}}
+
+    monkeypatch.setattr(
+        "src.manager.manager.build_manager_graph",
+        lambda: FakeGraph(),
+    )
+
+    assert invoke_manager_graph("build an assistant", 5.0) == {"weights_path": "model"}
+    assert captured["interactive_data_prompt"] is False
+    assert captured["has_data"] is False
+
+
+def test_invoke_manager_graph_can_opt_into_interactive_prompt(monkeypatch):
+    captured = {}
+
+    class FakeGraph:
+        def invoke(self, state):
+            captured.update(state)
+            return {"result": {"weights_path": "model"}}
+
+    monkeypatch.setattr(
+        "src.manager.manager.build_manager_graph",
+        lambda: FakeGraph(),
+    )
+
+    invoke_manager_graph("build an assistant", 5.0, interactive_data_prompt=True)
+    assert captured["interactive_data_prompt"] is True
 
 
 def test_invoke_manager_graph_returns_trained_model():
@@ -105,6 +358,26 @@ def test_handoff_to_dataset_result_empty_records(tmp_path, monkeypatch):
     result = _handoff_to_dataset_result(handoff)
     assert result["validation_report"]["passed"] is False
     assert result["validation_report"]["issues"] != []
+
+
+def test_handoff_to_dataset_result_preserves_datagen_validation(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    handoff = {
+        "mode_used": "C",
+        "raw_data": {"records": [{"input": "hello", "output": "1"}] * 10},
+        "validation_report": {
+            "passed": True,
+            "issues": ["synthetic data generated by fallback"],
+            "sample_accuracy_estimate": 0.72,
+        },
+    }
+    result = _handoff_to_dataset_result(handoff)
+
+    assert result["validation_report"]["passed"] is True
+    assert result["validation_report"]["issues"] == [
+        "synthetic data generated by fallback"
+    ]
+    assert result["validation_report"]["sample_accuracy_estimate"] == 0.72
 
 
 # ── orchestrate_node (mocked sub-agents) ─────────────────────────────────────
@@ -165,3 +438,36 @@ def test_orchestrate_node_returns_trained_model(tmp_path, monkeypatch):
     assert "result" in out
     assert out["result"]["n_iterations"] == 3
     assert out["result"]["cost"]["total_usd"] == 1.0
+
+
+def test_orchestrate_node_stops_before_training_on_untrainable_dataset(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    fake_handoff = {
+        "mode_used": "C",
+        "curation_payload": {
+            "records": [
+                {
+                    "content": "A raw web page without an assistant target.",
+                    "source_kind": "web_page",
+                    "source_locator": "https://example.com/raw",
+                }
+            ]
+        },
+        "validation_report": {
+            "passed": False,
+            "issues": ["raw web pages require structuring before training"],
+            "sample_accuracy_estimate": 0.0,
+        },
+    }
+
+    with patch("src.data_generator.graph.invoke_data_generator_graph",
+               return_value=fake_handoff), \
+         patch("src.decision_engine.decision_engine.run_decision_engine") as mock_de, \
+         patch("src.autoresearch.autoresearch.invoke_autoresearch_graph") as mock_ar, \
+         patch("src.observability.observability.log_event"):
+
+        with pytest.raises(ValueError, match="DataGen did not produce a trainable dataset"):
+            orchestrate_node(_make_orchestrate_state())
+
+    mock_de.assert_not_called()
+    mock_ar.assert_not_called()

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -9,6 +9,7 @@ from src.observability.observability import (
     write_json_log,
     get_budget_display,
 )
+from src.runtime_context import output_root
 from src.types import AgentName, LogLevel
 
 
@@ -59,3 +60,16 @@ def test_log_event_writes_to_disk(tmp_path):
     assert parsed["agent"] == AgentName.DATA_GEN
     assert parsed["message"] == "dataset found"
     assert "timestamp" in parsed
+
+
+def test_log_event_uses_active_output_root(tmp_path):
+    run_root = tmp_path / "run-123"
+
+    with output_root(run_root):
+        log_event(AgentName.MANAGER, LogLevel.INFO, "run scoped")
+
+    log_file = run_root / "logs" / "run.jsonl"
+    assert log_file.is_file()
+    parsed = json.loads(log_file.read_text().splitlines()[0])
+    assert parsed["message"] == "run scoped"
+    assert not (tmp_path / "outputs" / "logs" / "run.jsonl").exists()

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -1,0 +1,1658 @@
+"""Tests for the browser-facing FastAPI run bridge."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.runtime_context import get_output_root
+from src.server import app as server_app
+
+
+def _write_tinker_artifacts(
+    run_dir: Path,
+    *,
+    run_id: str,
+    state_path: str,
+    sampler_path: str | None = None,
+    train_loss: float = 0.31,
+    val_loss: float = 0.29,
+    test_loss: float = 0.33,
+    primary_metric: float = 0.775,
+    sample_text: str = "sample completion",
+    metric_rows: list[dict] | None = None,
+    backend: str | None = None,
+    budget_preflight_skipped: bool = False,
+    termination_reason: str | None = None,
+    status: str = "COMPLETED",
+    error: str | None = None,
+) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    checkpoints = {"state_path": state_path}
+    if sampler_path:
+        checkpoints["sampler_path"] = sampler_path
+    manifest = {
+        "run_id": run_id,
+        "status": status,
+        "checkpoints": checkpoints,
+    }
+    if backend:
+        manifest["backend"] = backend
+    if budget_preflight_skipped:
+        manifest["budget_preflight_skipped"] = True
+    if termination_reason:
+        manifest["cost"] = {"termination_reason": termination_reason}
+    if error:
+        manifest["error"] = error
+    (run_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    (run_dir / "metrics.json").write_text(
+        json.dumps(
+            {
+                "train_loss": train_loss,
+                "val_loss": val_loss,
+                "test_loss": test_loss,
+                "primary_metric": primary_metric,
+            }
+        ),
+        encoding="utf-8",
+    )
+    rows = metric_rows or [
+        {"step": 1, "val_loss": val_loss, "primary_metric": primary_metric}
+    ]
+    (run_dir / "metrics.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+    (run_dir / "sample.json").write_text(
+        json.dumps({"text": sample_text}),
+        encoding="utf-8",
+    )
+
+
+def _write_budget_skip_artifacts(run_dir: Path, *, run_id: str) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    sentinel_metrics = {
+        "train_loss": 1_000_000_000.0,
+        "val_loss": 1_000_000_000.0,
+        "test_loss": 1_000_000_000.0,
+        "primary_metric": 0.0,
+    }
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "run_id": run_id,
+                "status": "CANCELLED",
+                "budget_preflight_skipped": True,
+                "budget_skip_reason": "estimated run cost exceeds remaining budget",
+                "checkpoints": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "metrics.json").write_text(json.dumps(sentinel_metrics), encoding="utf-8")
+    (run_dir / "metrics.jsonl").write_text(
+        json.dumps(
+            {
+                "step": 0,
+                **sentinel_metrics,
+                "budget_preflight_skipped": True,
+                "reason": "estimated run cost exceeds remaining budget",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (run_dir / "sample.json").write_text(json.dumps({"text": ""}), encoding="utf-8")
+
+
+def _write_data_generator_debug_artifacts(
+    root: Path,
+    *,
+    mode_used: str = "C",
+    mode_c_fallback: str | None = "synthetic",
+) -> None:
+    artifact_dir = root / "data_generator" / "artifacts"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    debug_path = artifact_dir / "debug_context.json"
+    manifest_path = artifact_dir / "artifact_manifest.json"
+    handoff_path = artifact_dir / "raw_handoff_data.json"
+    report_path = artifact_dir / "human_readable.md"
+    source_report_path = artifact_dir / "source_human_readable.md"
+    handoff_path.write_text(
+        json.dumps(
+            {
+                "target_subagent": "data_curation",
+                "action": "curate_dataset",
+                "mode_used": mode_used,
+                "curation_payload": {"record_count": 1},
+            }
+        ),
+        encoding="utf-8",
+    )
+    report_path.write_text("# Curation report\n\n1 trainable row.\n", encoding="utf-8")
+    source_report_path.write_text("# Source report\n\nSynthetic fallback.\n", encoding="utf-8")
+    debug_path.write_text(
+        json.dumps(
+            {
+                "mode_used": mode_used,
+                "mode_c_fallback": mode_c_fallback,
+                "source_metadata": {
+                    "mode": mode_used,
+                    "mode_c_fallback": mode_c_fallback,
+                },
+                "raw_data": {
+                    "format_meta": {
+                        "mode_c_backend": "synthetic",
+                        "mode_c_fallback": mode_c_fallback,
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "mode_used": mode_used,
+                "artifact_dir": str(artifact_dir),
+                "files": {
+                    "handoff_payload": str(handoff_path),
+                    "curation_human_readable": str(report_path),
+                    "debug_context": str(debug_path),
+                    "source_human_readable": str(source_report_path),
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (root / "data_generator" / "latest_run.json").write_text(
+        json.dumps({"mode_used": mode_used, "manifest_path": str(manifest_path)}),
+        encoding="utf-8",
+    )
+
+
+def _fake_budget_skipped_model(tmp_path):
+    run_dir = tmp_path / "experiments" / "budget-skipped-run"
+    _write_budget_skip_artifacts(run_dir, run_id="budget-skipped-run")
+    diary_path = tmp_path / "logs" / "research_diary.jsonl"
+    diary_path.parent.mkdir(parents=True, exist_ok=True)
+    diary_path.write_text("", encoding="utf-8")
+    return {
+        "weights_path": str(run_dir),
+        "metrics": {
+            "scalar": 0.0,
+            "metrics": {
+                "train_loss": 1_000_000_000.0,
+                "val_loss": 1_000_000_000.0,
+                "primary_metric": 0.0,
+            },
+            "critique": "budget preflight skipped the Tinker launch",
+        },
+        "cost": {
+            "data_gen_usd": 0.0,
+            "training_usd": 0.0,
+            "llm_calls_usd": 0.0,
+            "total_usd": 0.0,
+            "termination_reason": "budget_limit",
+        },
+        "n_iterations": 0,
+        "research_diary_path": str(diary_path),
+    }
+
+
+def _fake_model(tmp_path, *, total_cost=1.25, with_artifacts=False):
+    diary_path = tmp_path / "diary.jsonl"
+    diary_path.write_text(
+        json.dumps(
+            {
+                "iteration": 1,
+                "hypothesis": "Decrease learning rate",
+                "patch": "- learning_rate: 0.0002\n+ learning_rate: 0.0001",
+                "metrics": {
+                    "train_loss": 0.31,
+                    "val_loss": 0.29,
+                    "primary_metric": 0.775,
+                },
+                "decision": "KEPT",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    weights_path = "outputs/experiments/run/model"
+    if with_artifacts:
+        run_dir = tmp_path / "experiments" / "tinker-run"
+        weights_path = str(run_dir)
+        _write_tinker_artifacts(
+            run_dir,
+            run_id="tinker-run",
+            state_path="tinker://state/abc",
+            sampler_path="tinker://sampler/abc",
+            backend="tinker_sft",
+        )
+    return {
+        "weights_path": weights_path,
+        "metrics": {
+            "scalar": 0.775,
+            "metrics": {
+                "train_loss": 0.31,
+                "val_loss": 0.29,
+                "primary_metric": 0.775,
+            },
+            "critique": "ok",
+        },
+        "cost": {
+            "data_gen_usd": 0.0,
+            "training_usd": total_cost,
+            "llm_calls_usd": 0.0,
+            "total_usd": total_cost,
+            "termination_reason": "training_complete",
+        },
+        "n_iterations": 1,
+        "research_diary_path": str(diary_path),
+    }
+
+
+def _wait_for_status(client: TestClient, run_id: str, status: str):
+    deadline = time.time() + 5
+    last = None
+    while time.time() < deadline:
+        response = client.get(f"/api/runs/{run_id}")
+        response.raise_for_status()
+        last = response.json()
+        if last["status"] == status:
+            return last
+        time.sleep(0.05)
+    raise AssertionError(f"run did not reach {status}; last state={last}")
+
+
+def _fail_live_service(name: str):
+    def _fail(*_args, **_kwargs):
+        raise AssertionError(f"{name} should not be used in this test")
+
+    return _fail
+
+
+def _install_no_live_service_fences(monkeypatch):
+    monkeypatch.setattr("builtins.input", _fail_live_service("user input"))
+    monkeypatch.setattr("anthropic.Anthropic", _fail_live_service("Claude"))
+
+    try:
+        import requests
+
+        monkeypatch.setattr(requests, "get", _fail_live_service("requests.get"))
+    except Exception:
+        pass
+
+    from src.autoresearch import autoresearch as ar
+    from src.data_generator import mode_b
+    from src.data_generator.mode_c import nodes as mode_c_nodes
+    from src.data_generator.mode_c import synthetic as mode_c_synthetic
+    from src.tinker_api import sft_runner
+
+    monkeypatch.setattr(ar, "_MAX_ITERATIONS", 1)
+    monkeypatch.setattr(
+        mode_b,
+        "_fetch_with_hf_datasets",
+        _fail_live_service("Hugging Face dataset fetch"),
+    )
+    monkeypatch.setattr(
+        mode_c_nodes,
+        "search_web_sources",
+        _fail_live_service("Tavily web search"),
+    )
+    monkeypatch.setattr(
+        mode_c_nodes,
+        "crawl_and_extract_pages",
+        _fail_live_service("web crawl"),
+    )
+    monkeypatch.setattr(
+        mode_c_nodes,
+        "structure_web_sources_for_sft",
+        _fail_live_service("Mode C web teacher structuring"),
+    )
+    monkeypatch.setattr(
+        mode_c_synthetic,
+        "_anthropic_client",
+        _fail_live_service("Mode C synthetic teacher"),
+    )
+    monkeypatch.setattr(
+        sft_runner,
+        "_load_tinker_deps",
+        _fail_live_service("Tinker SDK"),
+    )
+
+
+def setup_function():
+    server_app._reset_runs_for_tests()
+
+
+def test_health_check():
+    client = TestClient(server_app.app)
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_cors_allows_alternate_local_dev_ports():
+    client = TestClient(server_app.app)
+
+    response = client.options(
+        "/api/runs",
+        headers={
+            "Origin": "http://127.0.0.1:5177",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "http://127.0.0.1:5177"
+
+
+def test_cors_origins_can_be_extended_from_env(monkeypatch):
+    monkeypatch.setenv(
+        "MANAGER_API_CORS_ORIGINS",
+        "https://preview.example.com, http://localhost:5173",
+    )
+
+    origins = server_app._cors_origins_from_env()
+
+    assert origins.count("http://localhost:5173") == 1
+    assert "https://preview.example.com" in origins
+
+
+def test_create_run_completes_with_manager_result(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    calls = []
+    roots = []
+
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
+        calls.append((prompt, budget, data_path, task_type_hint))
+        root = get_output_root()
+        assert root is not None
+        roots.append(root)
+
+        from src.manager.manager import build_orchestration_config, log_decision
+
+        log_decision(
+            "server_run",
+            "run-scoped output test",
+            build_orchestration_config(
+                {
+                    "task_type": "text-classification",
+                    "data_format": "jsonl",
+                    "training_type": "SFT",
+                    "suggested_base_model": None,
+                    "hyperparameters": {},
+                    "notes": "test",
+                },
+                prompt,
+                budget,
+                False,
+            ),
+        )
+        return _fake_model(root)
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune a small chat assistant on support tickets",
+            "budget": 25,
+            "task_type": "fine-tuning",
+            "data_path": None,
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    state = _wait_for_status(client, run_id, "complete")
+
+    assert calls == [
+        ("Fine tune a small chat assistant on support tickets", 25.0, None, "fine-tuning")
+    ]
+    assert len(roots) == 1
+    assert roots[0] == Path("outputs/api-runs") / run_id
+    assert (roots[0] / "decisions.jsonl").is_file()
+    assert not Path("decisions.jsonl").exists()
+    assert state["costSpent"] == 1.25
+    assert state["dataPath"] is None
+    assert state["metrics"][0]["loss"] == 0.29
+    assert state["metrics"][0]["accuracy"] == 0.775
+    assert state["metrics"][0]["primaryMetric"] == 0.775
+    assert state["metrics"][0]["primaryMetricLabel"] == "Primary Score"
+    assert state["iterations"][0]["status"] == "KEPT"
+    assert state["iterations"][0]["primaryMetric"] == 0.775
+    assert state["iterations"][0]["primaryMetricLabel"] == "Primary Score"
+    assert state["result"]["weights_path"] == "outputs/experiments/run/model"
+
+
+def test_create_run_surfaces_artifacts_and_allowlisted_downloads(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
+        root = get_output_root()
+        assert root is not None
+        return _fake_model(root, total_cost=0.5, with_artifacts=True)
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune a small chat assistant on support tickets",
+            "budget": 25,
+            "task_type": "fine-tuning",
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    state = _wait_for_status(client, run_id, "complete")
+
+    artifacts = state["artifacts"]
+    assert artifacts["modelPath"].endswith(f"outputs/api-runs/{run_id}/experiments/tinker-run")
+    assert artifacts["checkpoints"]["state_path"] == "tinker://state/abc"
+    assert artifacts["metrics"]["val_loss"] == 0.29
+    assert artifacts["sample"]["text"] == "sample completion"
+    assert state["provenance"]["trainingBackend"] == "tinker_sft"
+    assert state["provenance"]["spendMode"] == "live"
+    assert "Tinker" in state["provenance"]["liveServices"]
+
+    files = {item["name"]: item for item in artifacts["files"]}
+    assert files["manifest"]["exists"] is True
+    assert files["manifest"]["downloadPath"] == f"/api/runs/{run_id}/artifacts/manifest"
+    assert files["metrics_log"]["contentType"] == "application/x-ndjson"
+
+    manifest_response = client.get(files["manifest"]["downloadPath"])
+    assert manifest_response.status_code == 200
+    assert manifest_response.json()["checkpoints"]["sampler_path"] == "tinker://sampler/abc"
+
+    metrics_log_response = client.get(f"/api/runs/{run_id}/artifacts/metrics_log")
+    assert metrics_log_response.status_code == 200
+    assert '"step": 1' in metrics_log_response.text
+
+    missing_response = client.get(f"/api/runs/{run_id}/artifacts/not-real")
+    assert missing_response.status_code == 404
+
+
+def test_run_state_surfaces_provenance_from_manifests(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
+        root = get_output_root()
+        assert root is not None
+        run_dir = root / "experiments" / "dry-skip"
+        _write_tinker_artifacts(
+            run_dir,
+            run_id="dry-skip",
+            state_path="dry-run://state/abc",
+            backend="dry_run",
+            budget_preflight_skipped=True,
+            termination_reason="budget_limit",
+        )
+        _write_data_generator_debug_artifacts(root, mode_used="C", mode_c_fallback="synthetic")
+        result = _fake_model(root, total_cost=0.0)
+        result["weights_path"] = str(run_dir)
+        result["cost"]["termination_reason"] = "budget_limit"
+        return result
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune a dry-run support assistant",
+            "budget": 25,
+            "task_type": "fine-tuning",
+        },
+    )
+
+    assert response.status_code == 200
+    state = _wait_for_status(client, response.json()["run_id"], "cancelled")
+
+    provenance = state["provenance"]
+    assert provenance["spendMode"] == "budget_skipped"
+    assert provenance["trainingBackend"] == "dry_run"
+    assert provenance["dataMode"] == "C"
+    assert provenance["modeCFallback"] == "synthetic"
+    assert provenance["budgetPreflightSkipped"] is True
+    assert provenance["budgetSkipReason"] == "budget_limit"
+    assert provenance["liveServices"] == []
+    assert any(item.endswith("manifest.json") for item in provenance["evidence"])
+    assert any(item.endswith("debug_context.json") for item in provenance["evidence"])
+
+    files = {item["name"]: item for item in state["artifacts"]["files"]}
+    assert files["data_manifest"]["exists"] is True
+    assert files["data_handoff"]["exists"] is True
+    assert files["data_curation_report"]["exists"] is True
+    assert files["data_debug_context"]["downloadPath"] == (
+        f"/api/runs/{response.json()['run_id']}/artifacts/data_debug_context"
+    )
+    debug_response = client.get(
+        f"/api/runs/{response.json()['run_id']}/artifacts/data_debug_context"
+    )
+    assert debug_response.status_code == 200
+    assert debug_response.json()["mode_used"] == "C"
+    source_report_response = client.get(
+        f"/api/runs/{response.json()['run_id']}/artifacts/data_source_report"
+    )
+    assert source_report_response.status_code == 200
+    assert "Synthetic fallback" in source_report_response.text
+
+
+def test_data_generator_artifact_downloads_are_allowlisted(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
+        root = get_output_root()
+        assert root is not None
+        run_dir = root / "experiments" / "dry-run"
+        _write_tinker_artifacts(
+            run_dir,
+            run_id="dry-run",
+            state_path="dry-run://state/abc",
+            backend="dry_run",
+        )
+
+        secret = tmp_path / "secret.json"
+        secret.write_text('{"secret": true}\n', encoding="utf-8")
+        artifact_dir = root / "data_generator" / "artifacts"
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        manifest_path = artifact_dir / "artifact_manifest.json"
+        safe_debug_path = artifact_dir / "debug_context.json"
+        safe_debug_path.write_text('{"mode_used": "C"}\n', encoding="utf-8")
+        hidden_path = artifact_dir / "hidden.json"
+        hidden_path.write_text('{"hidden": true}\n', encoding="utf-8")
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    "mode_used": "C",
+                    "artifact_dir": str(artifact_dir),
+                    "files": {
+                        "debug_context": str(secret),
+                        "handoff_payload": str(hidden_path),
+                        "secret": str(hidden_path),
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        (root / "data_generator" / "latest_run.json").write_text(
+            json.dumps({"mode_used": "C", "manifest_path": str(manifest_path)}),
+            encoding="utf-8",
+        )
+
+        result = _fake_model(root, total_cost=0.0)
+        result["weights_path"] = str(run_dir)
+        return result
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune with guarded DataGen artifact downloads",
+            "budget": 25,
+            "task_type": "fine-tuning",
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    state = _wait_for_status(client, run_id, "complete")
+    files = {item["name"]: item for item in state["artifacts"]["files"]}
+
+    assert files["data_manifest"]["downloadPath"] == (
+        f"/api/runs/{run_id}/artifacts/data_manifest"
+    )
+    assert files["data_debug_context"]["exists"] is False
+    assert files["data_debug_context"]["downloadPath"] is None
+    assert files["data_handoff"]["exists"] is False
+    assert files["data_handoff"]["downloadPath"] is None
+    assert "secret" not in files
+    assert client.get(f"/api/runs/{run_id}/artifacts/data_manifest").status_code == 200
+    assert client.get(f"/api/runs/{run_id}/artifacts/data_debug_context").status_code == 404
+    assert client.get(f"/api/runs/{run_id}/artifacts/secret").status_code == 404
+
+
+def test_data_generator_manifest_path_must_stay_inside_run(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
+        root = get_output_root()
+        assert root is not None
+        run_dir = root / "experiments" / "dry-run"
+        _write_tinker_artifacts(
+            run_dir,
+            run_id="dry-run",
+            state_path="dry-run://state/abc",
+            backend="dry_run",
+        )
+
+        external_manifest = tmp_path / "external_manifest.json"
+        external_manifest.write_text(
+            json.dumps({"files": {"debug_context": str(tmp_path / "secret.json")}}),
+            encoding="utf-8",
+        )
+        (root / "data_generator").mkdir(parents=True, exist_ok=True)
+        (root / "data_generator" / "latest_run.json").write_text(
+            json.dumps({"mode_used": "C", "manifest_path": str(external_manifest)}),
+            encoding="utf-8",
+        )
+
+        result = _fake_model(root, total_cost=0.0)
+        result["weights_path"] = str(run_dir)
+        return result
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune with an escaped DataGen manifest",
+            "budget": 25,
+            "task_type": "fine-tuning",
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    state = _wait_for_status(client, run_id, "complete")
+    files = {item["name"]: item for item in state["artifacts"]["files"]}
+    assert "data_manifest" not in files
+    assert client.get(f"/api/runs/{run_id}/artifacts/data_manifest").status_code == 404
+
+
+def test_api_run_routes_data_generator_artifacts_under_run_root(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    external_dir = tmp_path / "external-data-generator-artifacts"
+    monkeypatch.setenv("DATA_GENERATOR_ARTIFACT_DIR", str(external_dir))
+
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
+        root = get_output_root()
+        assert root is not None
+        run_dir = root / "experiments" / "dry-run"
+        _write_tinker_artifacts(
+            run_dir,
+            run_id="dry-run",
+            state_path="dry-run://state/abc",
+            backend="dry_run",
+        )
+
+        from src.data_generator.artifacts import save_subagent2_artifacts
+
+        save_subagent2_artifacts(
+            {
+                "target_subagent": "data_curation",
+                "action": "structure_data",
+                "mode_used": "C",
+                "curation_payload": {
+                    "schema_version": "data_curation_input.v1",
+                    "record_count": 1,
+                    "records": [{"messages": [{"role": "user", "content": "Hi"}]}],
+                },
+                "curation_human_readable": "Sub-Agent 2 Curation Input\nRecord count: 1",
+                "human_readable": "Mode C source report",
+            }
+        )
+
+        result = _fake_model(root, total_cost=0.0)
+        result["weights_path"] = str(run_dir)
+        return result
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune while preserving DataGen evidence under run root",
+            "budget": 25,
+            "task_type": "fine-tuning",
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    state = _wait_for_status(client, run_id, "complete")
+    files = {item["name"]: item for item in state["artifacts"]["files"]}
+
+    assert not external_dir.exists()
+    assert files["data_manifest"]["exists"] is True
+    assert files["data_manifest"]["path"].endswith(
+        f"outputs/api-runs/{run_id}/data_generator/artifacts/artifact_manifest.json"
+    )
+    assert files["data_debug_context"]["downloadPath"] == (
+        f"/api/runs/{run_id}/artifacts/data_debug_context"
+    )
+    assert client.get(f"/api/runs/{run_id}/artifacts/data_manifest").status_code == 200
+    assert client.get(f"/api/runs/{run_id}/artifacts/data_debug_context").status_code == 200
+
+
+def test_running_run_refreshes_logs_iterations_metrics_and_artifacts(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    ready = threading.Event()
+    release = threading.Event()
+
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
+        root = get_output_root()
+        assert root is not None
+
+        from src.observability.observability import log_event
+        from src.types import AgentName, LogLevel
+
+        log_event(AgentName.DATA_GEN, LogLevel.INFO, "dataset found", {})
+        diary_path = root / "logs" / "research_diary.jsonl"
+        diary_path.parent.mkdir(parents=True, exist_ok=True)
+        diary_path.write_text(
+            json.dumps(
+                {
+                    "iteration": 1,
+                    "hypothesis": "Increase learning rate",
+                    "patch": "- learning_rate: 0.0001\n+ learning_rate: 0.0005",
+                    "metrics": {"val_loss": 0.4, "primary_metric": 0.714},
+                    "decision": "PENDING",
+                    "cost_usd": 0.42,
+                }
+            )
+            + "\nnot-json-yet",
+            encoding="utf-8",
+        )
+        _write_tinker_artifacts(
+            root / "experiments" / "live-progress",
+            run_id="live-progress",
+            state_path="tinker://state/progress",
+            val_loss=0.4,
+            primary_metric=0.714,
+            sample_text="progress sample",
+            metric_rows=[
+                {"step": 1, "val_loss": 0.52, "primary_metric": 0.61},
+                {"step": 2, "val_loss": 0.4, "primary_metric": 0.714},
+            ],
+        )
+        ready.set()
+        assert release.wait(timeout=5)
+        return _fake_model(root, total_cost=0.5)
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune while surfacing live progress",
+            "budget": 25,
+            "task_type": "fine-tuning",
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    assert ready.wait(timeout=5)
+
+    state = client.get(f"/api/runs/{run_id}").json()
+    assert state["status"] == "running"
+    assert state["stage"] >= 4
+    assert state["costSpent"] == 0.42
+    assert state["logs"][0]["component"] == "DataGen"
+    assert state["iterations"][0]["status"] == "PENDING"
+    assert [metric["loss"] for metric in state["metrics"]] == [0.52, 0.4]
+    assert [metric["accuracy"] for metric in state["metrics"]] == [0.61, 0.714]
+    assert state["artifacts"]["checkpoints"]["state_path"] == "tinker://state/progress"
+
+    metrics_log = client.get(f"/api/runs/{run_id}/artifacts/metrics_log")
+    assert metrics_log.status_code == 200
+    assert '"step": 1' in metrics_log.text
+    assert '"step": 2' in metrics_log.text
+
+    release.set()
+    state = _wait_for_status(client, run_id, "complete")
+    assert state["status"] == "complete"
+    assert [metric["loss"] for metric in state["metrics"]] == [0.52, 0.4]
+    assert [metric["accuracy"] for metric in state["metrics"]] == [0.61, 0.714]
+
+
+def test_running_run_hides_budget_skip_sentinel_metrics(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    ready = threading.Event()
+    release = threading.Event()
+
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
+        root = get_output_root()
+        assert root is not None
+        diary_path = root / "logs" / "research_diary.jsonl"
+        diary_path.parent.mkdir(parents=True, exist_ok=True)
+        diary_path.write_text(
+            json.dumps(
+                {
+                    "iteration": 1,
+                    "hypothesis": "Increase learning rate",
+                    "patch": "- learning_rate: 0.0001\n+ learning_rate: 0.0002",
+                    "metrics": {"val_loss": 0.42, "primary_metric": 0.704},
+                    "decision": "REVERTED",
+                    "cost_usd": 1.12,
+                }
+            )
+            + "\n"
+            + json.dumps(
+                {
+                    "iteration": 2,
+                    "hypothesis": "Increase batch size",
+                    "patch": "- batch_size: 4\n+ batch_size: 5",
+                    "metrics": {
+                        "train_loss": 1_000_000_000.0,
+                        "val_loss": 1_000_000_000.0,
+                        "primary_metric": 0.0,
+                    },
+                    "decision": "REVERTED",
+                    "cost_usd": 0.0,
+                    "notes": "Skipped: budget preflight rejected the Tinker run",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        _write_tinker_artifacts(
+            root / "experiments" / "completed-run",
+            run_id="completed-run",
+            state_path="tinker://state/completed",
+            val_loss=0.42,
+            primary_metric=0.704,
+            metric_rows=[
+                {"step": 1, "val_loss": 0.6, "primary_metric": 0.625},
+                {"step": 2, "val_loss": 0.42, "primary_metric": 0.704},
+            ],
+        )
+        _write_budget_skip_artifacts(
+            root / "experiments" / "budget-skipped-run",
+            run_id="budget-skipped-run",
+        )
+        ready.set()
+        assert release.wait(timeout=5)
+        result = _fake_model(root, total_cost=1.12)
+        result["research_diary_path"] = str(diary_path)
+        return result
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune while hiding budget skip sentinels",
+            "budget": 2,
+            "task_type": "fine-tuning",
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    assert ready.wait(timeout=5)
+
+    state = client.get(f"/api/runs/{run_id}").json()
+    assert [metric["loss"] for metric in state["metrics"]] == [0.6, 0.42]
+    assert [metric["accuracy"] for metric in state["metrics"]] == [0.625, 0.704]
+    assert [item["experiment"] for item in state["iterations"]] == [
+        "Increase learning rate"
+    ]
+
+    release.set()
+    state = _wait_for_status(client, run_id, "complete")
+    assert [metric["loss"] for metric in state["metrics"]] == [0.6, 0.42]
+    assert [metric["accuracy"] for metric in state["metrics"]] == [0.625, 0.704]
+    assert [item["experiment"] for item in state["iterations"]] == [
+        "Increase learning rate"
+    ]
+
+
+def test_budget_preflight_skip_is_not_reported_as_complete(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def fake_invoke(prompt, budget, data_path=None, **_kwargs):
+        root = get_output_root()
+        assert root is not None
+        return _fake_budget_skipped_model(root)
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune with a budget too small to start Tinker",
+            "budget": 1,
+            "task_type": "fine-tuning",
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    state = _wait_for_status(client, run_id, "cancelled")
+
+    assert state["status"] == "cancelled"
+    assert state["error"] == "estimated run cost exceeds remaining budget"
+    assert state["costSpent"] == 0.0
+    assert state["metrics"] == []
+    assert state["iterations"] == []
+    assert state["result"]["cost"]["termination_reason"] == "budget_limit"
+    assert state["artifacts"]["modelPath"].endswith("experiments/budget-skipped-run")
+    assert state["artifacts"]["checkpoints"] == {}
+    assert any("budget guard" in item["message"].lower() for item in state["logs"])
+
+    manifest_response = client.get(f"/api/runs/{run_id}/artifacts/manifest")
+    assert manifest_response.status_code == 200
+    assert manifest_response.json()["budget_preflight_skipped"] is True
+
+
+@pytest.mark.parametrize(
+    ("manifest_status", "api_status", "log_type"),
+    [
+        ("FAILED", "failed", "error"),
+        ("CANCELLED", "cancelled", "warning"),
+    ],
+)
+def test_selected_training_artifact_terminal_status_controls_api_status(
+    tmp_path,
+    monkeypatch,
+    manifest_status,
+    api_status,
+    log_type,
+):
+    monkeypatch.chdir(tmp_path)
+
+    def fake_invoke(prompt, budget, data_path=None, **_kwargs):
+        root = get_output_root()
+        assert root is not None
+        run_dir = root / "experiments" / "terminal-artifact"
+        _write_tinker_artifacts(
+            run_dir,
+            run_id="terminal-artifact",
+            state_path="tinker://state/terminal",
+            status=manifest_status,
+            error="runner reported terminal artifact status",
+        )
+        result = _fake_model(root, total_cost=1.25)
+        result["weights_path"] = str(run_dir)
+        return result
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune with a terminal artifact status",
+            "budget": 10,
+            "task_type": "fine-tuning",
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    state = _wait_for_status(client, run_id, api_status)
+
+    assert state["status"] == api_status
+    assert state["error"] == "runner reported terminal artifact status"
+    assert state["artifacts"]["modelPath"].endswith("experiments/terminal-artifact")
+    assert any(
+        item["type"] == log_type and "terminal artifact status" in item["message"]
+        for item in state["logs"]
+    )
+    manifest_response = client.get(f"/api/runs/{run_id}/artifacts/manifest")
+    assert manifest_response.status_code == 200
+    assert manifest_response.json()["status"] == manifest_status
+
+
+def test_running_run_keeps_previous_artifacts_when_newer_experiment_is_incomplete(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    first_ready = threading.Event()
+    create_incomplete = threading.Event()
+    incomplete_ready = threading.Event()
+    release = threading.Event()
+
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
+        root = get_output_root()
+        assert root is not None
+        _write_tinker_artifacts(
+            root / "experiments" / "complete-a",
+            run_id="complete-a",
+            state_path="tinker://state/a",
+            val_loss=0.4,
+            primary_metric=0.714,
+        )
+        first_ready.set()
+        assert create_incomplete.wait(timeout=5)
+        time.sleep(0.02)
+        incomplete_dir = root / "experiments" / "in-progress-b"
+        incomplete_dir.mkdir(parents=True, exist_ok=True)
+        (incomplete_dir / "metrics.jsonl").write_text(
+            json.dumps({"step": 1, "val_loss": 0.8, "primary_metric": 0.556}) + "\n",
+            encoding="utf-8",
+        )
+        incomplete_ready.set()
+        assert release.wait(timeout=5)
+        return _fake_model(root, total_cost=0.5, with_artifacts=True)
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune while keeping stable artifact links",
+            "budget": 25,
+            "task_type": "fine-tuning",
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    assert first_ready.wait(timeout=5)
+
+    state = client.get(f"/api/runs/{run_id}").json()
+    assert state["status"] == "running"
+    assert state["artifacts"]["modelPath"].endswith("experiments/complete-a")
+    assert state["artifacts"]["checkpoints"]["state_path"] == "tinker://state/a"
+    assert client.get(f"/api/runs/{run_id}/artifacts/manifest").status_code == 200
+
+    create_incomplete.set()
+    assert incomplete_ready.wait(timeout=5)
+    state = client.get(f"/api/runs/{run_id}").json()
+    assert state["status"] == "running"
+    assert state["metrics"][-1]["loss"] == 0.8
+    assert state["artifacts"]["modelPath"].endswith("experiments/complete-a")
+    assert state["artifacts"]["checkpoints"]["state_path"] == "tinker://state/a"
+    manifest_response = client.get(f"/api/runs/{run_id}/artifacts/manifest")
+    assert manifest_response.status_code == 200
+    assert manifest_response.json()["checkpoints"]["state_path"] == "tinker://state/a"
+
+    release.set()
+    assert _wait_for_status(client, run_id, "complete")["status"] == "complete"
+
+
+def test_running_run_switches_artifacts_after_newer_experiment_completes(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    first_ready = threading.Event()
+    create_second = threading.Event()
+    second_ready = threading.Event()
+    release = threading.Event()
+
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
+        root = get_output_root()
+        assert root is not None
+        _write_tinker_artifacts(
+            root / "experiments" / "complete-a",
+            run_id="complete-a",
+            state_path="tinker://state/a",
+        )
+        first_ready.set()
+        assert create_second.wait(timeout=5)
+        time.sleep(0.02)
+        _write_tinker_artifacts(
+            root / "experiments" / "complete-b",
+            run_id="complete-b",
+            state_path="tinker://state/b",
+            val_loss=0.2,
+            primary_metric=0.833,
+            sample_text="newer sample",
+        )
+        second_ready.set()
+        assert release.wait(timeout=5)
+        return _fake_model(root, total_cost=0.5, with_artifacts=True)
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune while switching completed artifact links",
+            "budget": 25,
+            "task_type": "fine-tuning",
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    assert first_ready.wait(timeout=5)
+
+    state = client.get(f"/api/runs/{run_id}").json()
+    assert state["artifacts"]["modelPath"].endswith("experiments/complete-a")
+    assert state["artifacts"]["checkpoints"]["state_path"] == "tinker://state/a"
+
+    create_second.set()
+    assert second_ready.wait(timeout=5)
+    state = client.get(f"/api/runs/{run_id}").json()
+    assert state["status"] == "running"
+    assert state["artifacts"]["modelPath"].endswith("experiments/complete-b")
+    assert state["artifacts"]["checkpoints"]["state_path"] == "tinker://state/b"
+    manifest_response = client.get(f"/api/runs/{run_id}/artifacts/manifest")
+    assert manifest_response.status_code == 200
+    assert manifest_response.json()["checkpoints"]["state_path"] == "tinker://state/b"
+
+    release.set()
+    assert _wait_for_status(client, run_id, "complete")["status"] == "complete"
+
+
+def test_cancel_running_run_stops_at_safe_boundary(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    entered = threading.Event()
+
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
+        root = get_output_root()
+        assert root is not None
+
+        from src.runtime_context import active_tinker_job, cancellation_requested
+
+        with active_tinker_job("server-active-job"):
+            entered.set()
+            while not cancellation_requested():
+                time.sleep(0.01)
+        return _fake_model(root, total_cost=99.0, with_artifacts=True)
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune a cancellable support assistant",
+            "budget": 25,
+            "task_type": "fine-tuning",
+        },
+    )
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    assert entered.wait(timeout=5)
+
+    cancel_response = client.post(f"/api/runs/{run_id}/cancel")
+    assert cancel_response.status_code == 200
+    assert cancel_response.json()["status"] == "cancelling"
+
+    from src.tinker_api.tinker_api import is_cancelled
+
+    assert is_cancelled("server-active-job")
+    state = _wait_for_status(client, run_id, "cancelled")
+    assert state["status"] == "cancelled"
+    assert state["stages"][state["stage"]]["status"] == "cancelled"
+    assert state["result"] is None
+    assert any("cancel" in item["message"].lower() for item in state["logs"])
+
+
+def test_cancel_no_spend_dry_run_tinker_run(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("TINKER_API_KEY", raising=False)
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+
+    from src.autoresearch.config import TrainingConfig
+    from src.tinker_api import sft_runner, tinker_api
+
+    started = threading.Event()
+    original_record_tokens = tinker_api.record_tokens
+
+    def slow_first_step(job_id: str, n_tokens: int) -> None:
+        if not started.is_set():
+            started.set()
+            time.sleep(0.2)
+        original_record_tokens(job_id, n_tokens)
+
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
+        root = get_output_root()
+        assert root is not None
+        return sft_runner.run_tinker_sft_experiment(
+            TrainingConfig(model_name="Qwen/Qwen3.5-9B", batch_size=1),
+            [{"input": "Question", "output": "Answer"}],
+            run_id="server-dry-run",
+            max_steps=250,
+            output_dir=str(root / "experiments"),
+        )
+
+    monkeypatch.setattr(sft_runner, "record_tokens", slow_first_step)
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+
+    client = TestClient(server_app.app)
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune a cancellable no-spend dry-run assistant",
+            "budget": 3,
+            "task_type": "fine-tuning",
+        },
+    )
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    assert started.wait(timeout=5)
+
+    cancel_response = client.post(f"/api/runs/{run_id}/cancel")
+    assert cancel_response.status_code == 200
+    assert cancel_response.json()["status"] in {"cancelling", "cancelled"}
+
+    state = _wait_for_status(client, run_id, "cancelled")
+    manifest_path = (
+        tmp_path
+        / "outputs"
+        / "api-runs"
+        / run_id
+        / "experiments"
+        / "server-dry-run"
+        / "manifest.json"
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert state["status"] == "cancelled"
+    assert manifest["status"] == "CANCELLED"
+    assert tinker_api.is_cancelled("server-dry-run")
+
+
+def test_cancel_missing_run_returns_404():
+    client = TestClient(server_app.app)
+    response = client.post("/api/runs/not-a-run/cancel")
+    assert response.status_code == 404
+
+
+def test_cancel_completed_run_is_idempotent(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
+        root = get_output_root()
+        assert root is not None
+        return _fake_model(root, total_cost=0.5)
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune and finish before cancel",
+            "budget": 25,
+            "task_type": "fine-tuning",
+        },
+    )
+
+    run_id = response.json()["run_id"]
+    _wait_for_status(client, run_id, "complete")
+    cancel_response = client.post(f"/api/runs/{run_id}/cancel")
+    assert cancel_response.status_code == 200
+    assert cancel_response.json()["status"] == "complete"
+
+
+def test_create_run_passes_existing_local_data_path(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    data_path = tmp_path / "train.jsonl"
+    data_path.write_text('{"input":"great","output":"positive"}\n', encoding="utf-8")
+    calls = []
+
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
+        calls.append((prompt, budget, data_path, task_type_hint))
+        root = get_output_root()
+        assert root is not None
+        return _fake_model(root, total_cost=0.25)
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune on this labeled local JSONL data",
+            "budget": 20,
+            "task_type": "fine-tuning",
+            "data_path": str(data_path),
+        },
+    )
+
+    assert response.status_code == 200
+    state = _wait_for_status(client, response.json()["run_id"], "complete")
+    assert calls[0][2] == str(data_path.resolve())
+    assert calls[0][3] == "fine-tuning"
+    assert state["dataPath"] == str(data_path.resolve())
+    assert any("Dataset source:" in item["message"] for item in state["logs"])
+
+
+@pytest.mark.parametrize(
+    ("submitted", "expected"),
+    [
+        ("hf://SetFit/sst2", "hf://SetFit/sst2"),
+        ("https://huggingface.co/datasets/SetFit/sst2", "hf://SetFit/sst2"),
+        ("SetFit/sst2", "hf://SetFit/sst2"),
+    ],
+)
+def test_create_run_accepts_hugging_face_data_sources(tmp_path, monkeypatch, submitted, expected):
+    monkeypatch.chdir(tmp_path)
+    calls = []
+
+    def fake_invoke(prompt, budget, data_path=None, task_type_hint=None):
+        calls.append((prompt, budget, data_path, task_type_hint))
+        root = get_output_root()
+        assert root is not None
+        return _fake_model(root, total_cost=0.2)
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fake_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune on a public Hugging Face sentiment dataset",
+            "budget": 20,
+            "task_type": "classification",
+            "data_path": submitted,
+        },
+    )
+
+    assert response.status_code == 200
+    state = _wait_for_status(client, response.json()["run_id"], "complete")
+    assert calls[0][2] == expected
+    assert calls[0][3] == "classification"
+    assert state["dataPath"] == expected
+
+
+def test_create_run_local_jsonl_reaches_tinker_dry_run_without_live_credentials(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    data_path = tmp_path / "train.jsonl"
+    data_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"input": "I loved the movie.", "output": "positive"}),
+                json.dumps({"input": "The wait was frustrating.", "output": "negative"}),
+                json.dumps({"input": "Service was quick.", "output": "positive"}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.setenv("MANAGER_REASONER", "local")
+    monkeypatch.setenv("AUTORESEARCH_PROPOSER", "local")
+    monkeypatch.setenv("AUTORESEARCH_EVAL_ADAPTATION", "off")
+    monkeypatch.delenv("TINKER_BACKEND", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("TINKER_API_KEY", raising=False)
+
+    _install_no_live_service_fences(monkeypatch)
+
+    client = TestClient(server_app.app)
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune a sentiment classifier using this labeled JSONL file",
+            "budget": 20,
+            "task_type": "classification",
+            "data_path": str(data_path),
+        },
+    )
+
+    assert response.status_code == 200
+    state = _wait_for_status(client, response.json()["run_id"], "complete")
+
+    assert state["dataPath"] == str(data_path.resolve())
+    assert state["result"]["n_iterations"] == 1
+    assert any(
+        f"Dataset source: {data_path.resolve()}" in item["message"]
+        for item in state["logs"]
+    )
+
+    artifacts = state["artifacts"]
+    assert artifacts is not None
+    assert artifacts["sample"]["backend"] == "dry_run"
+    assert artifacts["checkpoints"]["state_path"].startswith("dry-run://state/")
+
+    manifest_file = next(
+        file
+        for file in artifacts["files"]
+        if file["name"] == "manifest" and file["path"]
+    )
+    manifest = json.loads(Path(manifest_file["path"]).read_text(encoding="utf-8"))
+    assert manifest["backend"] == "dry_run"
+    assert manifest["training_examples"] > 0
+
+    download = client.get(manifest_file["downloadPath"])
+    assert download.status_code == 200
+    assert download.json()["backend"] == "dry_run"
+
+
+def test_create_run_hf_data_path_reaches_tinker_dry_run_without_live_credentials(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.setenv("MANAGER_REASONER", "local")
+    monkeypatch.setenv("AUTORESEARCH_PROPOSER", "local")
+    monkeypatch.setenv("AUTORESEARCH_EVAL_ADAPTATION", "off")
+    monkeypatch.setenv("DATA_GENERATOR_OFFLINE", "1")
+    monkeypatch.setenv("DATA_GENERATOR_MAX_ROWS_PER_DATASET", "6")
+    monkeypatch.delenv("TINKER_BACKEND", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("TINKER_API_KEY", raising=False)
+
+    _install_no_live_service_fences(monkeypatch)
+
+    client = TestClient(server_app.app)
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune a classifier using this Hugging Face sentiment dataset",
+            "budget": 20,
+            "task_type": "classification",
+            "data_path": "hf://SetFit/sst2",
+        },
+    )
+
+    assert response.status_code == 200
+    state = _wait_for_status(client, response.json()["run_id"], "complete")
+
+    assert state["dataPath"] == "hf://SetFit/sst2"
+    assert 0.0 <= state["costSpent"] <= 20.0
+    assert state["result"]["n_iterations"] == 1
+    assert any(
+        "Dataset source: hf://SetFit/sst2" in item["message"]
+        for item in state["logs"]
+    )
+
+    artifacts = state["artifacts"]
+    assert artifacts is not None
+    assert artifacts["metrics"]["train_loss"] >= 0.0
+    assert artifacts["sample"]["backend"] == "dry_run"
+    assert artifacts["checkpoints"]["state_path"].startswith("dry-run://state/")
+
+    manifest_path = next(
+        Path(file["path"])
+        for file in artifacts["files"]
+        if file["name"] == "manifest" and file["path"]
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["backend"] == "dry_run"
+    assert manifest["dataset_path"].endswith("train_data.jsonl")
+    assert manifest["training_examples"] > 0
+
+
+def test_create_run_without_data_path_reaches_mode_c_tinker_dry_run_without_live_credentials(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.setenv("MANAGER_REASONER", "local")
+    monkeypatch.setenv("AUTORESEARCH_PROPOSER", "local")
+    monkeypatch.setenv("AUTORESEARCH_EVAL_ADAPTATION", "off")
+    monkeypatch.setenv("DATA_GENERATOR_SYNTHETIC_OFFLINE", "1")
+    monkeypatch.setenv("DATA_GENERATOR_MODE_C_BACKEND", "synthetic")
+    monkeypatch.setenv("DATA_GENERATOR_MAX_ROWS_PER_DATASET", "6")
+    monkeypatch.delenv("TINKER_BACKEND", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("TINKER_API_KEY", raising=False)
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+
+    _install_no_live_service_fences(monkeypatch)
+
+    client = TestClient(server_app.app)
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune a classifier for urgent support ticket triage",
+            "budget": 20,
+            "task_type": "classification",
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    state = _wait_for_status(client, run_id, "complete")
+
+    assert state["dataPath"] is None
+    assert 0.0 <= state["costSpent"] <= 20.0
+    assert state["result"]["n_iterations"] == 1
+    assert not any(
+        "Dataset source:" in item["message"]
+        for item in state["logs"]
+    )
+
+    artifacts = state["artifacts"]
+    assert artifacts is not None
+    assert f"outputs/api-runs/{run_id}/experiments/" in artifacts["modelPath"]
+    assert artifacts["metrics"]["train_loss"] >= 0.0
+    assert artifacts["sample"]["backend"] == "dry_run"
+    assert artifacts["sample"]["text"]
+    assert artifacts["checkpoints"]["state_path"].startswith("dry-run://state/")
+
+    files = {item["name"]: item for item in artifacts["files"]}
+    for name in ("manifest", "metrics", "metrics_log", "sample", "diary"):
+        assert files[name]["exists"] is True
+        assert files[name]["downloadPath"] == f"/api/runs/{run_id}/artifacts/{name}"
+
+    manifest_response = client.get(files["manifest"]["downloadPath"])
+    assert manifest_response.status_code == 200
+    manifest = manifest_response.json()
+    assert manifest["backend"] == "dry_run"
+    assert manifest["dataset_path"].endswith("train_data.jsonl")
+    assert manifest["training_examples"] > 0
+    assert manifest["split_examples"]["train"] > 0
+
+    metrics_log_response = client.get(files["metrics_log"]["downloadPath"])
+    assert metrics_log_response.status_code == 200
+    assert '"step": 1' in metrics_log_response.text
+
+    sample_response = client.get(files["sample"]["downloadPath"])
+    assert sample_response.status_code == 200
+    assert sample_response.json()["backend"] == "dry_run"
+
+
+def test_create_run_surfaces_manager_failure(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def fail_invoke(prompt, budget, data_path=None, task_type_hint=None):
+        assert get_output_root() is not None
+        raise RuntimeError("DataGen did not produce a trainable dataset")
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fail_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Train a classifier from public web data",
+            "budget": 20,
+            "task_type": "classification",
+        },
+    )
+
+    assert response.status_code == 200
+    state = _wait_for_status(client, response.json()["run_id"], "failed")
+    assert "DataGen did not produce a trainable dataset" in state["error"]
+    assert state["stages"][state["stage"]]["status"] == "failed"
+    assert state["logs"][0]["type"] == "error"
+
+
+def test_missing_data_path_is_rejected_before_background_run(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def fail_invoke(prompt, budget, data_path=None, task_type_hint=None):
+        raise AssertionError("manager should not be called for missing data_path")
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fail_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune on my local data",
+            "budget": 20,
+            "task_type": "fine-tuning",
+            "data_path": "/path/that/does/not/exist.jsonl",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "existing local path or Hugging Face source" in response.text
+
+
+def test_missing_relative_data_path_is_not_treated_as_hf_source(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def fail_invoke(prompt, budget, data_path=None, task_type_hint=None):
+        raise AssertionError("manager should not be called for missing data_path")
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fail_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune on my relative local data path",
+            "budget": 20,
+            "task_type": "fine-tuning",
+            "data_path": "data/train.jsonl",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "existing local path or Hugging Face source" in response.text
+
+
+def test_unsupported_remote_data_path_is_rejected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def fail_invoke(prompt, budget, data_path=None, task_type_hint=None):
+        raise AssertionError("manager should not be called for unsupported data_path")
+
+    monkeypatch.setattr(server_app, "invoke_manager_graph", fail_invoke)
+    client = TestClient(server_app.app)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "prompt": "Fine tune on a remote source",
+            "budget": 20,
+            "task_type": "fine-tuning",
+            "data_path": "https://example.com/train.jsonl",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "existing local path or Hugging Face source" in response.text


### PR DESCRIPTION
Replacement consolidated PR 4/8.

Supersedes draft PRs: #46, #50, #73, #74, #76, #77, #78, #82, #83, #84, #86, #88, #98, #99, #100, #104, #111, backend/API parts of #113.

Scope:
- Manager validation gate, robust JSON parsing, local/noninteractive Manager execution, task-type hints.
- FastAPI run API, run-scoped output isolation, artifact allowlist/downloads, progress refresh, cancellation.
- API dry-run smokes for HF, local JSONL, and no-data paths.
- DataGen provenance artifact exposure and terminal backend stage states.

Validation on final replacement stack:
- `python3 -m compileall src`
- `env -u ANTHROPIC_API_KEY -u TINKER_API_KEY -u TAVILY_API_KEY UV_NO_NETWORK=1 uv run --with pytest --with fastapi --with httpx --with langgraph --with anthropic python -m pytest -q` -> `339 passed, 10 skipped`
- `ml-agent-frontend`: `npm run lint && npm run build`
- `spec-site`: `npm run lint && npm run build`

No live services or paid jobs were run for this consolidation.
