### PR TITLE
[codex] consolidated frontend product API experience

### DIFF
--- a/ml-agent-frontend/README.md
+++ b/ml-agent-frontend/README.md
@@ -10,6 +10,40 @@ npm run dev        # http://localhost:5173
 npm run build      # production build → dist/
 ```
 
+By default the UI calls the real Manager API at `/api`; Vite proxies that path
+to the local backend during development:
+
+```bash
+cd ..
+uvicorn src.server.app:app --reload --port 8000
+
+cd ml-agent-frontend
+npm run dev
+```
+
+To point at a different backend, set `VITE_API_BASE_URL` to the API prefix, for
+example `VITE_API_BASE_URL=http://localhost:8000/api npm run dev`.
+
+For static UI demos without a backend, opt into the local simulation:
+
+```bash
+VITE_USE_SIMULATION=1 npm run dev
+npm run build:simulation
+npm run preview:simulation
+```
+
+`VITE_*` values are baked into the built bundle. Static previews and Vercel
+deployments without a Manager API should use `npm run build:simulation`; otherwise
+the app will correctly try to call `/api` and report that the backend is missing.
+
+For a deployed frontend backed by a remote Manager API, build with the API prefix
+and allow that frontend origin on the backend:
+
+```bash
+VITE_API_BASE_URL=https://manager.example.com/api npm run build
+MANAGER_API_CORS_ORIGINS=https://frontend-preview.example.com uvicorn src.server.app:app
+```
+
 ## Deploy (Vercel)
 
 ```bash
@@ -17,5 +51,8 @@ vercel --prod
 # Build command: npm run build
 # Output directory: dist
 ```
+
+For demo-only Vercel previews that do not have a Manager API attached, use
+`npm run build:simulation` as the build command.
 
 Bundle: ~168 KB gzipped.

--- a/ml-agent-frontend/package.json
+++ b/ml-agent-frontend/package.json
@@ -6,8 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "build:simulation": "VITE_USE_SIMULATION=1 tsc -b && VITE_USE_SIMULATION=1 vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "preview:simulation": "npm run build:simulation && vite preview"
   },
   "dependencies": {
     "react": "^19.2.5",

--- a/ml-agent-frontend/src/App.tsx
+++ b/ml-agent-frontend/src/App.tsx
@@ -1,18 +1,23 @@
 import { useTrainingSimulation } from './hooks/useTrainingSimulation';
+import { useTrainingRun } from './hooks/useTrainingRun';
+import { isBackendApiConfigured } from './api/runs';
 import InputForm from './components/InputForm';
 import Dashboard from './components/Dashboard';
-import type { TaskType } from './types';
+import type { StartTraining } from './types';
 
 export default function App() {
-  const { state, start, reset } = useTrainingSimulation();
+  const simulation = useTrainingSimulation();
+  const backend = useTrainingRun();
+  const controller = isBackendApiConfigured() ? backend : simulation;
+  const { state, start, reset, cancel } = controller;
 
-  const handleStart = (prompt: string, budget: number, taskType: TaskType) => {
-    start(prompt, budget, taskType);
+  const handleStart: StartTraining = (prompt, budget, taskType, dataPath = null) => {
+    return start(prompt, budget, taskType, dataPath);
   };
 
   if (state.status === 'idle') {
     return <InputForm onStart={handleStart} />;
   }
 
-  return <Dashboard state={state} onReset={reset} />;
+  return <Dashboard state={state} onReset={reset} onCancel={cancel} />;
 }

--- a/ml-agent-frontend/src/api/runs.ts
+++ b/ml-agent-frontend/src/api/runs.ts
@@ -1,0 +1,119 @@
+import type { TaskType, TrainingState } from '../types';
+
+export interface CreateRunResponse {
+  run_id: string;
+  status: 'running';
+}
+
+export interface BackendRunState extends TrainingState {
+  run_id: string;
+  dataPath?: string | null;
+  result?: Record<string, unknown> | null;
+}
+
+interface CreateRunRequest {
+  prompt: string;
+  budget: number;
+  task_type: TaskType;
+  data_path?: string | null;
+}
+
+function envFlagEnabled(value: string | undefined): boolean {
+  return ['1', 'true', 'yes', 'on'].includes(value?.trim().toLowerCase() ?? '');
+}
+
+export function isSimulationModeConfigured(): boolean {
+  return envFlagEnabled(import.meta.env.VITE_USE_SIMULATION);
+}
+
+export function getApiBaseUrl(): string | null {
+  if (isSimulationModeConfigured()) return null;
+
+  const value = import.meta.env.VITE_API_BASE_URL?.trim();
+  const configured = value || '/api';
+  return configured.replace(/\/$/, '');
+}
+
+export function isBackendApiConfigured(): boolean {
+  return !isSimulationModeConfigured();
+}
+
+export function resolveApiHrefFromBase(
+  baseUrl: string | null,
+  downloadPath?: string | null
+): string | null {
+  if (!baseUrl || !downloadPath) return null;
+
+  if (/^https?:\/\//i.test(downloadPath)) {
+    return downloadPath;
+  }
+
+  const path = downloadPath.startsWith('/') ? downloadPath : `/${downloadPath}`;
+  if (path === baseUrl || path.startsWith(`${baseUrl}/`)) {
+    return path;
+  }
+
+  try {
+    const base = new URL(baseUrl);
+    if (path === base.pathname || path.startsWith(`${base.pathname}/`)) {
+      return `${base.origin}${path}`;
+    }
+  } catch {
+    // Relative API base, handled below.
+  }
+
+  return `${baseUrl}${path}`;
+}
+
+export function resolveApiHref(downloadPath?: string | null): string | null {
+  return resolveApiHrefFromBase(getApiBaseUrl(), downloadPath);
+}
+
+async function requestJson<T>(path: string, options?: RequestInit): Promise<T> {
+  const baseUrl = getApiBaseUrl();
+  if (!baseUrl) {
+    throw new Error('Backend API is not configured.');
+  }
+
+  const headers = new Headers(options?.headers);
+  headers.set('Content-Type', 'application/json');
+  const url = `${baseUrl}${path}`;
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      ...options,
+      headers,
+    });
+  } catch {
+    throw new Error(
+      `Manager API is not reachable at ${baseUrl}. Start the backend, set VITE_API_BASE_URL to its /api prefix, or set VITE_USE_SIMULATION=1 for a static demo.`
+    );
+  }
+  if (!response.ok) {
+    const body = await response.text();
+    const detail = body.trim() && !body.trim().startsWith('<')
+      ? body.trim()
+      : `Manager API request failed with status ${response.status}.`;
+    throw new Error(
+      `${detail} Check that the Manager API is running and VITE_API_BASE_URL points to its /api prefix.`
+    );
+  }
+  return response.json() as Promise<T>;
+}
+
+export function createRun(request: CreateRunRequest): Promise<CreateRunResponse> {
+  return requestJson<CreateRunResponse>('/runs', {
+    method: 'POST',
+    body: JSON.stringify(request),
+  });
+}
+
+export function getRun(runId: string): Promise<BackendRunState> {
+  return requestJson<BackendRunState>(`/runs/${runId}`);
+}
+
+export function cancelRun(runId: string): Promise<BackendRunState> {
+  return requestJson<BackendRunState>(`/runs/${runId}/cancel`, {
+    method: 'POST',
+  });
+}

--- a/ml-agent-frontend/src/components/ActivityLog.tsx
+++ b/ml-agent-frontend/src/components/ActivityLog.tsx
@@ -8,8 +8,13 @@ interface Props {
 const typeColor: Record<LogEntry['type'], string> = {
   success: 'var(--success)',
   warning: 'var(--warning)',
+  error: 'var(--danger)',
   default: 'var(--text-muted)',
 };
+
+function logKey(entry: LogEntry, index: number): string {
+  return [entry.time, entry.component, entry.type, entry.message, index].join('|');
+}
 
 export default function ActivityLog({ logs }: Props) {
   return (
@@ -46,7 +51,7 @@ export default function ActivityLog({ logs }: Props) {
           <span style={{ color: 'var(--text-muted)' }}>Waiting for pipeline to start…</span>
         )}
         {logs.map((entry, i) => (
-          <div key={i} style={{ display: 'flex', gap: '0.625rem' }}>
+          <div key={logKey(entry, i)} style={{ display: 'flex', gap: '0.625rem' }}>
             <span style={{ color: 'var(--text-muted)', flexShrink: 0 }}>[{entry.time}]</span>
             <span style={{ color: 'var(--accent)', flexShrink: 0 }}>{entry.component}:</span>
             <span style={{ color: typeColor[entry.type] }}>{entry.message}</span>

--- a/ml-agent-frontend/src/components/Dashboard.tsx
+++ b/ml-agent-frontend/src/components/Dashboard.tsx
@@ -1,3 +1,4 @@
+import { resolveApiHref } from '../api/runs';
 import type { TrainingState } from '../types';
 import PipelineProgress from './PipelineProgress';
 import MetricsGrid from './MetricsGrid';
@@ -5,10 +6,18 @@ import MetricsChart from './MetricsChart';
 import IterationsList from './IterationsList';
 import ActivityLog from './ActivityLog';
 import FinalResults from './FinalResults';
+import {
+  formatPrimaryMetric,
+  iterationMetricValue,
+  metricPointValue,
+  primaryMetricLabel,
+  shortMetricLabel,
+} from '../utils/metricDisplay';
 
 interface Props {
   state: TrainingState;
   onReset: () => void;
+  onCancel: () => void;
 }
 
 const headerStyle: React.CSSProperties = {
@@ -24,8 +33,26 @@ const headerStyle: React.CSSProperties = {
 };
 
 function StatusDot({ status }: { status: TrainingState['status'] }) {
-  const color = status === 'complete' ? 'var(--success)' : status === 'running' ? 'var(--accent)' : 'var(--text-muted)';
-  const label = status === 'complete' ? 'COMPLETE' : status === 'running' ? 'RUNNING' : 'IDLE';
+  const color =
+    status === 'complete'
+      ? 'var(--success)'
+      : status === 'failed'
+        ? 'var(--danger)'
+        : status === 'running' || status === 'cancelling'
+          ? 'var(--accent)'
+          : 'var(--text-muted)';
+  const label =
+    status === 'complete'
+      ? 'COMPLETE'
+      : status === 'failed'
+        ? 'FAILED'
+        : status === 'cancelled'
+          ? 'CANCELLED'
+          : status === 'cancelling'
+            ? 'CANCELLING'
+            : status === 'running'
+          ? 'RUNNING'
+          : 'IDLE';
 
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
@@ -36,7 +63,7 @@ function StatusDot({ status }: { status: TrainingState['status'] }) {
           borderRadius: '50%',
           background: color,
           display: 'inline-block',
-          animation: status === 'running' ? 'pulse 1.5s ease-in-out infinite' : 'none',
+          animation: status === 'running' || status === 'cancelling' ? 'pulse 1.5s ease-in-out infinite' : 'none',
         }}
       />
       <span style={{ fontSize: '11px', fontWeight: 600, letterSpacing: '0.1em', color }}>
@@ -46,7 +73,244 @@ function StatusDot({ status }: { status: TrainingState['status'] }) {
   );
 }
 
-export default function Dashboard({ state, onReset }: Props) {
+function titleCaseToken(value: string) {
+  return value
+    .replace(/[_-]+/g, ' ')
+    .replace(/\b\w/g, char => char.toUpperCase());
+}
+
+function spendModeLabel(value?: string | null) {
+  switch (value) {
+    case 'no_spend':
+      return 'NO_SPEND';
+    case 'dry_run':
+      return 'Dry-run';
+    case 'budget_skipped':
+      return 'Budget skipped';
+    case 'live':
+      return 'Live services';
+    case 'local':
+      return 'Local';
+    default:
+      return value ? titleCaseToken(value) : null;
+  }
+}
+
+function backendLabel(value?: string | null) {
+  const normalized = value?.replace('-', '_').toLowerCase();
+  if (normalized === 'dry_run') return 'Tinker dry-run';
+  if (normalized === 'tinker' || normalized === 'tinker_sft') return 'Live Tinker';
+  return value ? titleCaseToken(value) : null;
+}
+
+function ProvenanceBadges({ state }: { state: TrainingState }) {
+  const provenance = state.provenance;
+  if (!provenance) return null;
+
+  const badges = Array.from(new Set([
+    spendModeLabel(provenance.spendMode),
+    backendLabel(provenance.trainingBackend),
+    provenance.dataMode ? `Mode ${provenance.dataMode}` : null,
+    provenance.modeCFallback ? `${titleCaseToken(provenance.modeCFallback)} fallback` : null,
+    provenance.budgetPreflightSkipped ? 'Budget skipped' : null,
+    provenance.liveServices.length > 0 ? `Live: ${provenance.liveServices.join(', ')}` : null,
+  ].filter((label): label is string => Boolean(label))));
+
+  if (badges.length === 0) return null;
+
+  return (
+    <div
+      aria-label="Run provenance"
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '0.4rem',
+        marginTop: '-0.75rem',
+        marginBottom: '1.25rem',
+      }}
+    >
+      {badges.map(label => (
+        <span
+          key={label}
+          style={{
+            fontSize: '11px',
+            color: 'var(--text-secondary)',
+            background: 'var(--bg-elevated)',
+            border: '0.5px solid var(--border)',
+            borderRadius: '4px',
+            padding: '2px 8px',
+            lineHeight: 1.6,
+          }}
+        >
+          {label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function TerminalArtifacts({ state, onReset }: Props) {
+  const isFailed = state.status === 'failed';
+  const tone = isFailed ? 'var(--danger)' : 'var(--warning)';
+  const lastMetric = state.metrics[state.metrics.length - 1];
+  const bestIter = state.iterations.find(i => i.status === 'KEPT') ?? state.iterations[0];
+  const artifactFiles = state.artifacts?.files.filter(file => file.exists) ?? [];
+  const checkpointEntries = Object.entries(state.artifacts?.checkpoints ?? {}).filter(([, value]) => value);
+  const bestLabel = primaryMetricLabel(bestIter?.primaryMetricLabel ?? lastMetric?.primaryMetricLabel);
+  const latestLabel = primaryMetricLabel(lastMetric?.primaryMetricLabel ?? bestLabel);
+  const compactPath = (value?: string | null) => {
+    if (!value) return '—';
+    if (value.length <= 72) return value;
+    return `…${value.slice(-69)}`;
+  };
+  const results = [
+    {
+      key: 'checkpoint-score',
+      label: `Checkpoint ${shortMetricLabel(bestLabel)}`,
+      value: formatPrimaryMetric(iterationMetricValue(bestIter), bestLabel),
+    },
+    {
+      key: 'latest-primary-score',
+      label: latestLabel,
+      value: formatPrimaryMetric(metricPointValue(lastMetric), latestLabel),
+    },
+    { key: 'budget-used', label: 'Budget Used', value: `$${state.costSpent.toFixed(2)}` },
+  ];
+
+  return (
+    <section
+      style={{
+        background: 'var(--bg-surface)',
+        border: `0.5px solid ${tone}`,
+        borderRadius: 'var(--radius)',
+        padding: '1.5rem',
+        marginBottom: '1.5rem',
+      }}
+      aria-label={isFailed ? 'Failed run artifacts' : 'Cancelled run artifacts'}
+    >
+      <div style={{ marginBottom: '1.25rem', textAlign: 'center' }}>
+        <span style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '0.4rem',
+          fontSize: '11px',
+          fontWeight: 600,
+          letterSpacing: '0.1em',
+          color: tone,
+          background: 'var(--bg-elevated)',
+          border: `0.5px solid ${tone}`,
+          borderRadius: '4px',
+          padding: '3px 10px',
+          marginBottom: '0.75rem',
+        }}>
+          {isFailed ? 'FAILED RUN ARTIFACTS' : 'CANCELLED RUN ARTIFACTS'}
+        </span>
+        <p style={{ fontSize: '13px', color: 'var(--text-secondary)', marginTop: '0.25rem' }}>
+          {isFailed
+            ? 'This run failed before completion. Any checkpoint metrics and downloadable files produced before failure are still available.'
+            : 'This run was cancelled before completion. The latest checkpoint metrics and downloadable files are still available.'}
+        </p>
+      </div>
+
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(3, 1fr)',
+        gap: '12px',
+        marginBottom: '1.5rem',
+      }}>
+        {results.map(({ key, label, value }) => (
+          <div key={key} style={{
+            background: 'var(--bg-elevated)',
+            border: '0.5px solid var(--border)',
+            borderRadius: '6px',
+            padding: '0.75rem',
+            textAlign: 'center',
+          }}>
+            <p style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '0.25rem' }}>{label}</p>
+            <p style={{ fontSize: '22px', fontWeight: 500, color: 'var(--text-primary)', fontVariantNumeric: 'tabular-nums' }}>{value}</p>
+          </div>
+        ))}
+      </div>
+
+      <div style={{
+        borderTop: '0.5px solid var(--border)',
+        paddingTop: '1rem',
+        marginBottom: '1.5rem',
+      }}>
+        <p style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '0.5rem' }}>
+          Available Files
+        </p>
+        <div style={{ display: 'grid', gap: '0.4rem' }}>
+          {state.artifacts?.modelPath && (
+            <div style={{ display: 'grid', gridTemplateColumns: '96px 1fr', gap: '0.75rem', alignItems: 'center' }}>
+              <span style={{ fontSize: '11px', color: 'var(--text-muted)' }}>Model</span>
+              <code style={{ fontSize: '11px', color: 'var(--text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {compactPath(state.artifacts.modelPath)}
+              </code>
+            </div>
+          )}
+          {artifactFiles.map(file => {
+            const href = resolveApiHref(file.downloadPath);
+            return (
+              <div
+                key={file.downloadPath ?? file.path ?? file.name}
+                style={{ display: 'grid', gridTemplateColumns: '96px 1fr auto', gap: '0.75rem', alignItems: 'center' }}
+              >
+                <span style={{ fontSize: '11px', color: 'var(--text-muted)' }}>{file.label}</span>
+                <code style={{ fontSize: '11px', color: 'var(--text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {compactPath(file.path)}
+                </code>
+                {href && (
+                  <a
+                    href={href}
+                    target="_blank"
+                    rel="noreferrer"
+                    style={{ fontSize: '11px', color: 'var(--accent)', textDecoration: 'none' }}
+                  >
+                    Open
+                  </a>
+                )}
+              </div>
+            );
+          })}
+          {checkpointEntries.map(([key, value]) => (
+            <div key={key} style={{ display: 'grid', gridTemplateColumns: '96px 1fr', gap: '0.75rem', alignItems: 'center' }}>
+              <span style={{ fontSize: '11px', color: 'var(--text-muted)' }}>{key}</span>
+              <code style={{ fontSize: '11px', color: 'var(--text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {String(value)}
+              </code>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', justifyContent: 'center' }}>
+        <button
+          onClick={onReset}
+          style={{
+            padding: '0.5rem 1rem',
+            background: 'transparent',
+            border: '0.5px solid var(--border)',
+            borderRadius: '6px',
+            color: 'var(--text-secondary)',
+            fontSize: '13px',
+            cursor: 'pointer',
+            fontFamily: 'inherit',
+          }}
+          aria-label="Try another training run"
+        >
+          Try Another
+        </button>
+      </div>
+    </section>
+  );
+}
+
+export default function Dashboard({ state, onReset, onCancel }: Props) {
+  const canCancel = state.status === 'running' || state.status === 'cancelling';
+  const hasCancelledArtifacts = state.status === 'cancelled' && Boolean(state.artifacts);
+  const hasTerminalArtifacts = (state.status === 'cancelled' || state.status === 'failed') && Boolean(state.artifacts);
+
   return (
     <div style={{ minHeight: '100vh' }}>
       <style>{`
@@ -68,22 +332,43 @@ export default function Dashboard({ state, onReset }: Props) {
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
           <StatusDot status={state.status} />
-          <button
-            onClick={onReset}
-            style={{
-              padding: '4px 10px',
-              background: 'transparent',
-              border: '0.5px solid var(--border)',
-              borderRadius: '6px',
-              color: 'var(--text-secondary)',
-              fontSize: '12px',
-              cursor: 'pointer',
-              fontFamily: 'inherit',
-            }}
-            aria-label="Reset training"
-          >
-            Reset
-          </button>
+          {canCancel ? (
+            <button
+              onClick={onCancel}
+              disabled={state.status === 'cancelling'}
+              style={{
+                padding: '4px 10px',
+                background: 'transparent',
+                border: '0.5px solid var(--warning)',
+                borderRadius: '6px',
+                color: 'var(--warning)',
+                fontSize: '12px',
+                cursor: state.status === 'cancelling' ? 'not-allowed' : 'pointer',
+                opacity: state.status === 'cancelling' ? 0.7 : 1,
+                fontFamily: 'inherit',
+              }}
+              aria-label="Cancel training"
+            >
+              {state.status === 'cancelling' ? 'Cancelling...' : 'Cancel'}
+            </button>
+          ) : (
+            <button
+              onClick={onReset}
+              style={{
+                padding: '4px 10px',
+                background: 'transparent',
+                border: '0.5px solid var(--border)',
+                borderRadius: '6px',
+                color: 'var(--text-secondary)',
+                fontSize: '12px',
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+              }}
+              aria-label="Reset training"
+            >
+              Reset
+            </button>
+          )}
         </div>
       </header>
 
@@ -103,6 +388,22 @@ export default function Dashboard({ state, onReset }: Props) {
         }}>
           <span style={{ fontSize: '12px', color: 'var(--text-muted)', flexShrink: 0 }}>Objective</span>
           <span style={{ fontSize: '13px', color: 'var(--text-secondary)', flex: 1 }}>{state.prompt}</span>
+          {state.dataPath && (
+            <span style={{
+              fontSize: '11px',
+              color: 'var(--text-muted)',
+              border: '0.5px solid var(--border)',
+              borderRadius: '4px',
+              padding: '2px 8px',
+              maxWidth: '320px',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              flexShrink: 1,
+            }}>
+              {state.dataPath}
+            </span>
+          )}
           <span style={{
             fontSize: '11px',
             color: 'var(--accent)',
@@ -116,8 +417,52 @@ export default function Dashboard({ state, onReset }: Props) {
           </span>
         </div>
 
+        <ProvenanceBadges state={state} />
+
         {/* Pipeline + budget */}
         <PipelineProgress stages={state.stages} costSpent={state.costSpent} budget={state.budget} />
+
+        {state.status === 'failed' && (
+          <section
+            style={{
+              background: 'var(--danger-dim)',
+              border: '0.5px solid var(--danger)',
+              borderRadius: 'var(--radius)',
+              padding: '0.875rem 1rem',
+              marginBottom: '1.5rem',
+            }}
+            role="alert"
+          >
+            <p style={{ fontSize: '12px', fontWeight: 600, color: 'var(--danger)', marginBottom: '0.25rem' }}>
+              Run failed
+            </p>
+            <p style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>
+              {state.error ?? 'The backend run ended before producing a model.'}
+            </p>
+          </section>
+        )}
+
+        {state.status === 'cancelled' && (
+          <section
+            style={{
+              background: 'var(--bg-surface)',
+              border: '0.5px solid var(--warning)',
+              borderRadius: 'var(--radius)',
+              padding: '0.875rem 1rem',
+              marginBottom: '1.5rem',
+            }}
+            role="status"
+          >
+            <p style={{ fontSize: '12px', fontWeight: 600, color: 'var(--warning)', marginBottom: '0.25rem' }}>
+              Run cancelled
+            </p>
+            <p style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>
+              {hasCancelledArtifacts
+                ? 'The backend stopped the training pipeline, but checkpoint and artifact files are available below.'
+                : 'The backend stopped the training pipeline at the next safe checkpoint.'}
+            </p>
+          </section>
+        )}
 
         {/* 4 metric cards */}
         <MetricsGrid metrics={state.metrics} costSpent={state.costSpent} budget={state.budget} />
@@ -140,6 +485,7 @@ export default function Dashboard({ state, onReset }: Props) {
         {state.status === 'complete' && (
           <FinalResults state={state} onReset={onReset} />
         )}
+        {hasTerminalArtifacts && <TerminalArtifacts state={state} onReset={onReset} onCancel={onCancel} />}
       </main>
     </div>
   );

--- a/ml-agent-frontend/src/components/FinalResults.tsx
+++ b/ml-agent-frontend/src/components/FinalResults.tsx
@@ -1,4 +1,12 @@
+import { resolveApiHref } from '../api/runs';
 import type { TrainingState } from '../types';
+import {
+  formatPrimaryMetric,
+  iterationMetricValue,
+  metricPointValue,
+  primaryMetricLabel,
+  shortMetricLabel,
+} from '../utils/metricDisplay';
 import Tooltip from './Tooltip';
 
 interface Props {
@@ -7,48 +15,74 @@ interface Props {
 }
 
 const RESULT_TOOLTIPS: Record<string, { label: string; body: string }> = {
-  'Final F1': {
-    label: 'Final F1 Score',
-    body: 'Balances precision and recall into one number. Ranges from 0 to 1 — higher is better, especially useful when classes are imbalanced.',
+  score: {
+    label: 'Primary Metric',
+    body: 'The higher-is-better score returned by the evaluation step. Tinker SFT runs report the normalized primary score derived from validation loss.',
   },
-  'Val Accuracy': {
-    label: 'Validation Accuracy',
-    body: 'The model\'s correct-prediction rate on held-out data it has never seen. This is the more honest measure of real-world performance.',
-  },
-  'Total Cost': {
-    label: 'Total Compute Cost',
-    body: 'The full cost of this training run across all pipeline stages, billed against your original budget cap.',
+  'Budget Used': {
+    label: 'Budget Accounted',
+    body: 'The amount counted against this run\'s budget cap. Dry-run and no-spend runs use reserved or estimated budget, not provider-billed spend.',
   },
 };
+type ResultTooltipKey = keyof typeof RESULT_TOOLTIPS;
 
 export default function FinalResults({ state, onReset }: Props) {
   const lastMetric = state.metrics[state.metrics.length - 1];
   const bestIter = state.iterations.find(i => i.status === 'KEPT') ?? state.iterations[0];
+  const artifactFiles = state.artifacts?.files.filter(file => file.exists) ?? [];
+  const checkpointEntries = Object.entries(state.artifacts?.checkpoints ?? {}).filter(([, value]) => value);
+  const bestLabel = primaryMetricLabel(bestIter?.primaryMetricLabel ?? lastMetric?.primaryMetricLabel);
+  const finalScoreLabel = `Final ${shortMetricLabel(bestLabel)}`;
+  const latestLabel = primaryMetricLabel(lastMetric?.primaryMetricLabel ?? bestLabel);
+  const finalScoreValue = bestIter ? iterationMetricValue(bestIter) : metricPointValue(lastMetric);
+  const diaryArtifact = artifactFiles.find(file => file.name === 'diary' && file.downloadPath);
+  const diaryHref = resolveApiHref(diaryArtifact?.downloadPath);
 
-  const handleExportDiary = () => {
-    const diary = {
+  const handleExportSnapshot = () => {
+    const snapshot = {
       prompt: state.prompt,
       budget: state.budget,
       taskType: state.taskType,
+      dataPath: state.dataPath ?? null,
       costSpent: state.costSpent,
       iterations: state.iterations,
       metrics: state.metrics,
       logs: state.logs,
+      artifacts: state.artifacts ?? null,
+      result: state.result ?? null,
     };
-    const blob = new Blob([JSON.stringify(diary, null, 2)], { type: 'application/json' });
+    if (state.provenance) {
+      Object.assign(snapshot, { provenance: state.provenance });
+    }
+    const blob = new Blob([JSON.stringify(snapshot, null, 2)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = 'research-diary.json';
+    a.download = 'run-snapshot.json';
     a.click();
     URL.revokeObjectURL(url);
   };
 
-  const results = [
-    { label: 'Final F1', value: bestIter ? bestIter.f1.toFixed(3) : '—' },
-    { label: 'Val Accuracy', value: lastMetric ? `${(lastMetric.accuracy * 100).toFixed(1)}%` : '—' },
-    { label: 'Total Cost', value: `$${state.costSpent.toFixed(2)}` },
+  const results: Array<{ key: string; label: string; value: string; tooltipKey: ResultTooltipKey }> = [
+    {
+      key: 'final-score',
+      label: finalScoreLabel,
+      value: formatPrimaryMetric(finalScoreValue, bestLabel),
+      tooltipKey: 'score',
+    },
+    {
+      key: 'latest-primary-score',
+      label: latestLabel,
+      value: formatPrimaryMetric(metricPointValue(lastMetric), latestLabel),
+      tooltipKey: 'score',
+    },
+    { key: 'budget-used', label: 'Budget Used', value: `$${state.costSpent.toFixed(2)}`, tooltipKey: 'Budget Used' },
   ];
+  const compactPath = (value?: string | null) => {
+    if (!value) return '—';
+    if (value.length <= 72) return value;
+    return `…${value.slice(-69)}`;
+  };
 
   return (
     <section
@@ -90,10 +124,10 @@ export default function FinalResults({ state, onReset }: Props) {
         gap: '12px',
         marginBottom: '1.5rem',
       }}>
-        {results.map(({ label, value }) => {
-          const tip = RESULT_TOOLTIPS[label];
+        {results.map(({ key, label, value, tooltipKey }) => {
+          const tip = RESULT_TOOLTIPS[tooltipKey];
           return (
-            <div key={label} style={{
+            <div key={key} style={{
               background: 'var(--bg-elevated)',
               border: '0.5px solid var(--border)',
               borderRadius: '6px',
@@ -109,46 +143,111 @@ export default function FinalResults({ state, onReset }: Props) {
         })}
       </div>
 
+      {state.artifacts && (
+        <div style={{
+          borderTop: '0.5px solid var(--border)',
+          paddingTop: '1rem',
+          marginBottom: '1.5rem',
+          textAlign: 'left',
+        }}>
+          <p style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '0.5rem' }}>
+            Artifacts
+          </p>
+          <div style={{ display: 'grid', gap: '0.4rem' }}>
+            {state.artifacts.modelPath && (
+              <div style={{ display: 'grid', gridTemplateColumns: '96px 1fr', gap: '0.75rem', alignItems: 'center' }}>
+                <span style={{ fontSize: '11px', color: 'var(--text-muted)' }}>Model</span>
+                <code style={{ fontSize: '11px', color: 'var(--text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {compactPath(state.artifacts.modelPath)}
+                </code>
+              </div>
+            )}
+            {artifactFiles.map(file => {
+              const href = resolveApiHref(file.downloadPath);
+              return (
+                <div
+                  key={file.downloadPath ?? file.path ?? file.name}
+                  style={{ display: 'grid', gridTemplateColumns: '96px 1fr auto', gap: '0.75rem', alignItems: 'center' }}
+                >
+                  <span style={{ fontSize: '11px', color: 'var(--text-muted)' }}>{file.label}</span>
+                  <code style={{ fontSize: '11px', color: 'var(--text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {compactPath(file.path)}
+                  </code>
+                  {href && (
+                    <a
+                      href={href}
+                      target="_blank"
+                      rel="noreferrer"
+                      style={{ fontSize: '11px', color: 'var(--accent)', textDecoration: 'none' }}
+                    >
+                      Open
+                    </a>
+                  )}
+                </div>
+              );
+            })}
+            {checkpointEntries.map(([key, value]) => (
+              <div key={key} style={{ display: 'grid', gridTemplateColumns: '96px 1fr', gap: '0.75rem', alignItems: 'center' }}>
+                <span style={{ fontSize: '11px', color: 'var(--text-muted)' }}>{key}</span>
+                <code style={{ fontSize: '11px', color: 'var(--text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {String(value)}
+                </code>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'center', flexWrap: 'wrap' }}>
         <span style={{ position: 'relative', display: 'inline-flex', alignItems: 'center', gap: '4px' }}>
-          <button
-            onClick={handleExportDiary}
-            style={{
-              padding: '0.5rem 1rem',
-              background: 'var(--accent-dim)',
-              border: '0.5px solid var(--accent)',
-              borderRadius: '6px',
-              color: 'var(--accent)',
-              fontSize: '13px',
-              cursor: 'pointer',
-              fontFamily: 'inherit',
-            }}
-            aria-label="Export research diary as JSON"
-          >
-            Export Research Diary
-          </button>
+          {diaryHref ? (
+            <a
+              href={diaryHref}
+              target="_blank"
+              rel="noreferrer"
+              style={{
+                padding: '0.5rem 1rem',
+                background: 'var(--accent-dim)',
+                border: '0.5px solid var(--accent)',
+                borderRadius: '6px',
+                color: 'var(--accent)',
+                fontSize: '13px',
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+                textDecoration: 'none',
+              }}
+              aria-label="Open backend research diary artifact"
+            >
+              Open Research Diary
+            </a>
+          ) : (
+            <button
+              onClick={handleExportSnapshot}
+              style={{
+                padding: '0.5rem 1rem',
+                background: 'var(--accent-dim)',
+                border: '0.5px solid var(--accent)',
+                borderRadius: '6px',
+                color: 'var(--accent)',
+                fontSize: '13px',
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+              }}
+              aria-label="Export run snapshot as JSON"
+            >
+              Export Run Snapshot
+            </button>
+          )}
           <Tooltip
-            label="Export Research Diary"
-            body="Downloads a JSON file with every experiment, metric, and log event from this run. Useful for reproducibility and offline analysis."
+            label={diaryHref ? 'Research Diary' : 'Run Snapshot'}
+            body={
+              diaryHref
+                ? 'Opens the backend research diary artifact produced by AutoResearch for this run.'
+                : 'Exports the visible run state as JSON. This is a UI snapshot, not a backend research diary artifact.'
+            }
             placement="top"
           />
         </span>
-        <button
-          onClick={() => alert('Deploy endpoint: configure in production')}
-          style={{
-            padding: '0.5rem 1rem',
-            background: 'var(--success-dim)',
-            border: '0.5px solid var(--success)',
-            borderRadius: '6px',
-            color: 'var(--success)',
-            fontSize: '13px',
-            cursor: 'pointer',
-            fontFamily: 'inherit',
-          }}
-          aria-label="Deploy model"
-        >
-          Deploy Model
-        </button>
         <button
           onClick={onReset}
           style={{

--- a/ml-agent-frontend/src/components/InputForm.tsx
+++ b/ml-agent-frontend/src/components/InputForm.tsx
@@ -1,9 +1,13 @@
 import { useState } from 'react';
-import type { TaskType } from '../types';
+import type { StartTraining, TaskType } from '../types';
 
 interface Props {
-  onStart: (prompt: string, budget: number, taskType: TaskType) => void;
+  onStart: StartTraining;
 }
+
+const MIN_BUDGET = 1;
+const MAX_BUDGET = 500;
+const DEFAULT_BUDGET = '50';
 
 const styles: Record<string, React.CSSProperties> = {
   wrapper: {
@@ -144,27 +148,30 @@ const styles: Record<string, React.CSSProperties> = {
 
 export default function InputForm({ onStart }: Props) {
   const [prompt, setPrompt] = useState('');
-  const [budget, setBudget] = useState(50);
+  const [budgetInput, setBudgetInput] = useState(DEFAULT_BUDGET);
   const [taskType, setTaskType] = useState<TaskType>('classification');
+  const [dataPath, setDataPath] = useState('');
   const [error, setError] = useState('');
 
   const handleSubmit = () => {
+    const budget = Number(budgetInput);
     if (prompt.trim().length < 10) {
       setError('Prompt must be at least 10 characters.');
       return;
     }
-    if (budget < 10 || budget > 500) {
-      setError('Budget must be between $10 and $500.');
+    if (!Number.isFinite(budget) || budget < MIN_BUDGET || budget > MAX_BUDGET) {
+      setError(`Budget must be between $${MIN_BUDGET} and $${MAX_BUDGET}.`);
       return;
     }
     setError('');
-    onStart(prompt.trim(), budget, taskType);
+    onStart(prompt.trim(), budget, taskType, dataPath.trim() || null);
   };
 
   const handleReset = () => {
     setPrompt('');
-    setBudget(50);
+    setBudgetInput(DEFAULT_BUDGET);
     setTaskType('classification');
+    setDataPath('');
     setError('');
   };
 
@@ -194,6 +201,20 @@ export default function InputForm({ onStart }: Props) {
             </span>
           </div>
 
+          <div style={styles.field}>
+            <label style={styles.label} htmlFor="dataPath">Dataset Source</label>
+            <input
+              id="dataPath"
+              type="text"
+              style={styles.input}
+              placeholder="/data/train.jsonl or hf://SetFit/sst2"
+              value={dataPath}
+              onChange={e => setDataPath(e.target.value)}
+              maxLength={1000}
+              aria-label="Dataset source"
+            />
+          </div>
+
           <div style={styles.row}>
             <div style={styles.field}>
               <label style={styles.label} htmlFor="budget">Budget Cap (USD)</label>
@@ -201,11 +222,11 @@ export default function InputForm({ onStart }: Props) {
                 id="budget"
                 type="number"
                 style={styles.input}
-                value={budget}
-                min={10}
-                max={500}
-                step={5}
-                onChange={e => setBudget(Number(e.target.value))}
+                value={budgetInput}
+                min={MIN_BUDGET}
+                max={MAX_BUDGET}
+                step={0.5}
+                onChange={e => setBudgetInput(e.target.value)}
                 aria-label="Budget cap in dollars"
               />
             </div>

--- a/ml-agent-frontend/src/components/IterationsList.tsx
+++ b/ml-agent-frontend/src/components/IterationsList.tsx
@@ -1,4 +1,5 @@
 import type { Iteration } from '../types';
+import { formatPrimaryMetric, iterationMetricValue, shortMetricLabel } from '../utils/metricDisplay';
 import Tooltip from './Tooltip';
 
 interface Props {
@@ -79,7 +80,7 @@ export default function IterationsList({ iterations }: Props) {
         >
           {iterations.map((iter, idx) => (
             <div
-              key={iter.id}
+              key={`${iter.id}:${idx}`}
               role="listitem"
               style={{
                 display: 'flex',
@@ -102,7 +103,7 @@ export default function IterationsList({ iterations }: Props) {
                   L {iter.loss.toFixed(3)}
                 </span>
                 <span style={{ fontSize: '11px', color: 'var(--text-muted)', flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
-                  F1 {iter.f1.toFixed(3)}
+                  {shortMetricLabel(iter.primaryMetricLabel)} {formatPrimaryMetric(iterationMetricValue(iter), iter.primaryMetricLabel)}
                 </span>
                 <StatusBadge status={iter.status} />
               </div>

--- a/ml-agent-frontend/src/components/MetricsChart.tsx
+++ b/ml-agent-frontend/src/components/MetricsChart.tsx
@@ -9,6 +9,7 @@ import {
   Legend,
 } from 'recharts';
 import type { MetricPoint } from '../types';
+import { formatPrimaryMetric, metricPointValue, primaryMetricLabel } from '../utils/metricDisplay';
 import TooltipInfo from './Tooltip';
 
 interface Props {
@@ -24,10 +25,11 @@ const tooltipStyle: React.CSSProperties = {
 };
 
 export default function MetricsChart({ metrics }: Props) {
+  const latestLabel = primaryMetricLabel(metrics[metrics.length - 1]?.primaryMetricLabel);
   const data = metrics.map(m => ({
     iter: m.iteration,
     loss: m.loss,
-    accuracy: +(m.accuracy * 100).toFixed(2),
+    primaryScore: metricPointValue(m) ?? 0,
   }));
 
   return (
@@ -45,7 +47,7 @@ export default function MetricsChart({ metrics }: Props) {
         <p style={{ fontSize: '12px', color: 'var(--text-muted)' }}>Training Curves</p>
         <TooltipInfo
           label="Training Curves"
-          body="Plots loss and accuracy together over time. Diverging curves (loss up, accuracy down) signal overfitting; converging curves signal healthy learning."
+          body="Plots loss and the primary evaluation score together over time. Tinker SFT score is normalized from validation loss, so higher is better."
         />
       </div>
       {data.length === 0 ? (
@@ -73,23 +75,25 @@ export default function MetricsChart({ metrics }: Props) {
             <YAxis
               yAxisId="acc"
               orientation="right"
-              domain={[70, 100]}
+              domain={[0, 1]}
               tick={{ fill: 'var(--text-muted)', fontSize: 10 }}
               tickLine={false}
               axisLine={{ stroke: 'var(--border)' }}
-              tickFormatter={v => `${v}%`}
+              tickFormatter={v => formatPrimaryMetric(Number(v), latestLabel)}
             />
             <Tooltip
               contentStyle={tooltipStyle}
               labelFormatter={v => `Iteration ${v}`}
               formatter={(value, name) => {
                 const v = Number(value);
-                return name === 'loss' ? [v.toFixed(4), 'Loss'] : [`${v.toFixed(1)}%`, 'Accuracy'];
+                return name === 'loss'
+                  ? [v.toFixed(4), 'Loss']
+                  : [formatPrimaryMetric(v, latestLabel), latestLabel];
               }}
             />
             <Legend
               wrapperStyle={{ fontSize: '11px', color: 'var(--text-muted)' }}
-              formatter={(value) => value === 'loss' ? 'Training Loss' : 'Val Accuracy'}
+              formatter={(value) => value === 'loss' ? 'Training Loss' : latestLabel}
             />
             <Line
               yAxisId="loss"
@@ -103,7 +107,7 @@ export default function MetricsChart({ metrics }: Props) {
             <Line
               yAxisId="acc"
               type="monotone"
-              dataKey="accuracy"
+              dataKey="primaryScore"
               stroke="var(--success)"
               strokeWidth={1.5}
               dot={false}

--- a/ml-agent-frontend/src/components/MetricsGrid.tsx
+++ b/ml-agent-frontend/src/components/MetricsGrid.tsx
@@ -1,4 +1,5 @@
 import type { MetricPoint } from '../types';
+import { formatPrimaryMetric, metricPointValue, primaryMetricLabel } from '../utils/metricDisplay';
 import Tooltip from './Tooltip';
 
 interface Props {
@@ -12,17 +13,17 @@ const TOOLTIPS: Record<string, { label: string; body: string }> = {
     label: 'Training Loss',
     body: 'Measures how wrong the model\'s predictions are on training data. Lower is better — a steadily decreasing value means the model is learning.',
   },
-  accuracy: {
-    label: 'Validation Accuracy',
-    body: 'The model\'s correct-prediction rate on held-out data it has never seen. This is the more honest measure of real-world performance.',
+  primary: {
+    label: 'Primary Metric',
+    body: 'The higher-is-better score returned by the evaluation step. Tinker SFT runs report the normalized primary score derived from validation loss.',
   },
   cost: {
-    label: 'Accumulated Cost',
-    body: 'Total compute spend so far across all pipeline stages. Updates in real time so you can monitor burn against your budget.',
+    label: 'Budget Accounted',
+    body: 'Amount counted against the run budget so far. Dry-run and no-spend runs use reserved or estimated budget, not provider-billed spend.',
   },
   iter: {
-    label: 'Experiment Iterations',
-    body: 'How many hyperparameter configurations have been tried out of the planned total. More iterations generally improve the final model but cost more.',
+    label: 'Metric Points',
+    body: 'How many metric points the backend has reported for this run. The API does not expose a planned total for every backend.',
   },
 };
 
@@ -59,9 +60,10 @@ function MetricCard({ label, value, tooltipKey }: CardProps) {
 export default function MetricsGrid({ metrics, costSpent }: Props) {
   const last = metrics[metrics.length - 1];
   const loss = last ? last.loss.toFixed(4) : '—';
-  const accuracy = last ? `${(last.accuracy * 100).toFixed(1)}%` : '—';
+  const scoreLabel = primaryMetricLabel(last?.primaryMetricLabel);
+  const score = formatPrimaryMetric(metricPointValue(last), scoreLabel);
   const cost = `$${costSpent.toFixed(2)}`;
-  const iter = `${metrics.length}/${Math.max(metrics.length, 12)}`;
+  const metricCount = metrics.length ? String(metrics.length) : '—';
 
   return (
     <div
@@ -74,9 +76,9 @@ export default function MetricsGrid({ metrics, costSpent }: Props) {
       aria-label="Training metrics"
     >
       <MetricCard label="Training Loss" value={loss} tooltipKey="loss" />
-      <MetricCard label="Val Accuracy" value={accuracy} tooltipKey="accuracy" />
-      <MetricCard label="Cost Spent" value={cost} tooltipKey="cost" />
-      <MetricCard label="Iterations" value={iter} tooltipKey="iter" />
+      <MetricCard label={scoreLabel} value={score} tooltipKey="primary" />
+      <MetricCard label="Budget Used" value={cost} tooltipKey="cost" />
+      <MetricCard label="Metric Points" value={metricCount} tooltipKey="iter" />
     </div>
   );
 }

--- a/ml-agent-frontend/src/components/PipelineProgress.tsx
+++ b/ml-agent-frontend/src/components/PipelineProgress.tsx
@@ -34,6 +34,20 @@ function StageIcon({ status }: { status: PipelineStage['status'] }) {
       </span>
     );
   }
+  if (status === 'failed') {
+    return (
+      <span style={{ ...base, background: 'rgba(239, 68, 68, 0.12)', color: 'var(--danger)', border: '0.5px solid var(--danger)' }}>
+        !
+      </span>
+    );
+  }
+  if (status === 'cancelled') {
+    return (
+      <span style={{ ...base, background: 'rgba(245, 158, 11, 0.12)', color: 'var(--warning)', border: '0.5px solid var(--warning)' }}>
+        x
+      </span>
+    );
+  }
   return (
     <span style={{ ...base, background: 'transparent', color: 'var(--text-muted)', border: '0.5px solid var(--border)' }}>
       ○
@@ -44,6 +58,13 @@ function StageIcon({ status }: { status: PipelineStage['status'] }) {
 export default function PipelineProgress({ stages, costSpent, budget }: Props) {
   const pct = budget > 0 ? Math.min((costSpent / budget) * 100, 100) : 0;
   const barColor = pct >= 70 ? 'var(--danger)' : pct >= 50 ? 'var(--warning)' : 'var(--accent)';
+  const stageColor = (status: PipelineStage['status']) => {
+    if (status === 'in-progress') return 'var(--accent)';
+    if (status === 'failed') return 'var(--danger)';
+    if (status === 'cancelled') return 'var(--warning)';
+    if (status === 'complete') return 'var(--text-secondary)';
+    return 'var(--text-muted)';
+  };
 
   return (
     <section style={{ marginBottom: '1.5rem' }}>
@@ -79,7 +100,7 @@ export default function PipelineProgress({ stages, costSpent, budget }: Props) {
               <span
                 style={{
                   fontSize: '11px',
-                  color: stage.status === 'in-progress' ? 'var(--accent)' : stage.status === 'complete' ? 'var(--text-secondary)' : 'var(--text-muted)',
+                  color: stageColor(stage.status),
                   textAlign: 'center',
                   whiteSpace: 'nowrap',
                   transition: 'color 0.3s',
@@ -109,8 +130,8 @@ export default function PipelineProgress({ stages, costSpent, budget }: Props) {
           <div style={{ display: 'flex', alignItems: 'center' }}>
             <span style={{ fontSize: '12px', color: 'var(--text-muted)' }}>Budget</span>
             <Tooltip
-              label="Live Budget Usage"
-              body="Tracks how much of your cost cap has been spent so far. Turns amber at 50% and red at 70% as a warning before the limit is hit."
+              label="Budget Usage"
+              body="Tracks budget-accounted usage against the run cap. Dry-run and no-spend runs use reserved or estimated budget, not provider-billed spend."
               placement="bottom"
             />
           </div>

--- a/ml-agent-frontend/src/components/Tooltip.tsx
+++ b/ml-agent-frontend/src/components/Tooltip.tsx
@@ -42,8 +42,6 @@ export default function Tooltip({ label, body, placement = 'top' }: Props) {
     <span style={{ position: 'relative', display: 'inline-flex', alignItems: 'center' }}>
       <button
         type="button"
-        onMouseEnter={show}
-        onMouseLeave={hide}
         onFocus={show}
         onBlur={hide}
         aria-label={`More info: ${label}`}

--- a/ml-agent-frontend/src/hooks/useTrainingRun.ts
+++ b/ml-agent-frontend/src/hooks/useTrainingRun.ts
@@ -1,0 +1,208 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { cancelRun, createRun, getRun, type BackendRunState } from '../api/runs';
+import type { PipelineStage, StartTraining, StageStatus, TaskType, TrainingState } from '../types';
+
+function makeInitialState(): TrainingState {
+  return {
+    status: 'idle',
+    stage: -1,
+    prompt: '',
+    budget: 50,
+    taskType: 'classification',
+    dataPath: null,
+    costSpent: 0,
+    metrics: [],
+    iterations: [],
+    logs: [],
+    stages: [],
+    artifacts: null,
+    provenance: null,
+    result: null,
+    error: null,
+  };
+}
+
+function makeStartingState(
+  prompt: string,
+  budget: number,
+  taskType: TaskType,
+  dataPath?: string | null
+): TrainingState {
+  return {
+    status: 'running',
+    stage: 0,
+    prompt,
+    budget,
+    taskType,
+    dataPath: dataPath ?? null,
+    costSpent: 0,
+    metrics: [],
+    iterations: [],
+    logs: [],
+    stages: [
+      { id: 0, label: 'Manager Init', status: 'in-progress' },
+      { id: 1, label: 'Data Discovery', status: 'pending' },
+      { id: 2, label: 'Model Selection', status: 'pending' },
+      { id: 3, label: 'Training', status: 'pending' },
+      { id: 4, label: 'AutoResearch', status: 'pending' },
+      { id: 5, label: 'Finalization', status: 'pending' },
+    ],
+    artifacts: null,
+    provenance: null,
+    result: null,
+    error: null,
+  };
+}
+
+function isTerminalStatus(status: TrainingState['status']) {
+  return status === 'complete' || status === 'failed' || status === 'cancelled';
+}
+
+function terminalStageStatus(status: TrainingState['status']): Extract<StageStatus, 'failed' | 'cancelled'> | null {
+  if (status === 'failed' || status === 'cancelled') return status;
+  return null;
+}
+
+function terminalStageIndex(stages: PipelineStage[], stage: number): number {
+  if (stages.length === 0) return -1;
+
+  const activeStage = stages.findIndex(item => item.status === 'in-progress');
+  if (activeStage >= 0) return activeStage;
+
+  return Math.max(0, Math.min(stage, stages.length - 1));
+}
+
+function markTerminalStage(
+  stages: PipelineStage[],
+  stage: number,
+  status: Extract<StageStatus, 'failed' | 'cancelled'>
+): PipelineStage[] {
+  const activeStage = terminalStageIndex(stages, stage);
+  if (activeStage < 0) return stages;
+
+  return stages.map((item, index) => {
+    if (index < activeStage) return { ...item, status: 'complete' };
+    if (index === activeStage) return { ...item, status };
+    return { ...item, status: 'pending' };
+  });
+}
+
+function withTerminalStages(state: TrainingState): TrainingState {
+  const status = terminalStageStatus(state.status);
+  if (!status) return state;
+
+  return {
+    ...state,
+    stages: markTerminalStage(state.stages, state.stage, status),
+  };
+}
+
+function stateFromBackend(next: BackendRunState): TrainingState {
+  return withTerminalStages({
+    status: next.status,
+    stage: next.stage,
+    prompt: next.prompt,
+    budget: next.budget,
+    taskType: next.taskType,
+    dataPath: next.dataPath ?? null,
+    costSpent: next.costSpent,
+    metrics: next.metrics,
+    iterations: next.iterations,
+    logs: next.logs,
+    stages: next.stages,
+    artifacts: next.artifacts ?? null,
+    provenance: next.provenance ?? null,
+    result: next.result ?? null,
+    error: next.error,
+    runId: next.run_id,
+  });
+}
+
+export function useTrainingRun() {
+  const [state, setState] = useState<TrainingState>(makeInitialState);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const runIdRef = useRef<string | null>(null);
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => stopPolling, [stopPolling]);
+
+  const poll = useCallback(async (runId: string) => {
+    const next = await getRun(runId);
+    setState(stateFromBackend(next));
+
+    if (isTerminalStatus(next.status)) {
+      stopPolling();
+    }
+  }, [stopPolling]);
+
+  const start = useCallback<StartTraining>(async (prompt, budget, taskType, dataPath = null) => {
+    const normalizedDataPath = dataPath?.trim() || null;
+    stopPolling();
+    setState(makeStartingState(prompt, budget, taskType, normalizedDataPath));
+
+    try {
+      const created = await createRun({
+        prompt,
+        budget,
+        task_type: taskType,
+        data_path: normalizedDataPath,
+      });
+      setState(prev => ({ ...prev, runId: created.run_id }));
+      runIdRef.current = created.run_id;
+      await poll(created.run_id);
+      pollRef.current = setInterval(() => {
+        void poll(created.run_id).catch((error: unknown) => {
+          stopPolling();
+          setState(prev => ({
+            ...withTerminalStages({ ...prev, status: 'failed' }),
+            status: 'failed',
+            error: error instanceof Error ? error.message : String(error),
+          }));
+        });
+      }, 2000);
+    } catch (error) {
+      setState(prev => ({
+        ...withTerminalStages({ ...prev, status: 'failed' }),
+        status: 'failed',
+        error: error instanceof Error ? error.message : String(error),
+      }));
+    }
+  }, [poll, stopPolling]);
+
+  const reset = useCallback(() => {
+    stopPolling();
+    runIdRef.current = null;
+    setState(makeInitialState());
+  }, [stopPolling]);
+
+  const cancel = useCallback(async () => {
+    const runId = runIdRef.current ?? state.runId;
+    if (!runId || isTerminalStatus(state.status)) {
+      return;
+    }
+
+    setState(prev => ({ ...prev, status: 'cancelling' }));
+    try {
+      const next = await cancelRun(runId);
+      setState(stateFromBackend(next));
+      if (isTerminalStatus(next.status)) {
+        stopPolling();
+      }
+    } catch (error) {
+      setState(prev => ({
+        ...withTerminalStages({ ...prev, status: 'failed' }),
+        status: 'failed',
+        error: error instanceof Error ? error.message : String(error),
+      }));
+      stopPolling();
+    }
+  }, [state.runId, state.status, stopPolling]);
+
+  return { state, start, reset, cancel };
+}

--- a/ml-agent-frontend/src/hooks/useTrainingSimulation.ts
+++ b/ml-agent-frontend/src/hooks/useTrainingSimulation.ts
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback } from 'react';
-import type { TrainingState, PipelineStage, Iteration, LogEntry } from '../types';
+import type { StartTraining, TrainingState, PipelineStage, Iteration, LogEntry } from '../types';
 
 const STAGE_LABELS = [
   'Manager Init',
@@ -11,6 +11,16 @@ const STAGE_LABELS = [
 ];
 
 const STAGE_DURATIONS = [1200, 1800, 1500, 3000, 3000, 1200]; // ms
+const SIMULATION_PROVENANCE = {
+  spendMode: 'simulation',
+  trainingBackend: 'simulation',
+  dataMode: null,
+  modeCFallback: null,
+  budgetPreflightSkipped: false,
+  budgetSkipReason: null,
+  liveServices: [],
+  evidence: [],
+};
 
 function makeStages(): PipelineStage[] {
   return STAGE_LABELS.map((label, i) => ({ id: i, label, status: 'pending' as const }));
@@ -27,36 +37,36 @@ const STAGE_LOGS: Array<Array<{ component: string; message: string; type: LogEnt
     { component: 'CostManager', message: 'Budget guardrail active — monitoring spend', type: 'success' },
   ],
   [
-    { component: 'DataGen', message: 'Querying HuggingFace Hub for matching datasets', type: 'default' },
-    { component: 'DataGen', message: 'Found 3 candidate datasets, scoring relevance', type: 'default' },
-    { component: 'DataGen', message: 'Dataset selected: 42,000 samples loaded', type: 'success' },
+    { component: 'DataGen', message: 'Simulating dataset discovery for matching sources', type: 'default' },
+    { component: 'DataGen', message: 'Simulated 3 candidate datasets and scored relevance', type: 'default' },
+    { component: 'DataGen', message: 'Simulation selected a 42,000-sample dataset profile', type: 'success' },
   ],
   [
-    { component: 'Decision', message: 'Running fine-tune vs pre-train analysis', type: 'default' },
-    { component: 'Decision', message: 'Dataset size favors fine-tuning strategy', type: 'default' },
-    { component: 'Decision', message: 'Base model selected: distilbert-base-uncased', type: 'success' },
+    { component: 'Decision', message: 'Simulating fine-tune vs pre-train analysis', type: 'default' },
+    { component: 'Decision', message: 'Simulated dataset size favors fine-tuning strategy', type: 'default' },
+    { component: 'Decision', message: 'Simulation selected base model distilbert-base-uncased', type: 'success' },
   ],
   [
-    { component: 'Tinker', message: 'Submitting training job to Tinker API', type: 'default' },
-    { component: 'Tinker', message: 'Job accepted — GPU allocation confirmed', type: 'success' },
-    { component: 'CostManager', message: 'Estimated job cost: $14.20', type: 'warning' },
-    { component: 'Tinker', message: 'Training epoch 1/3 complete', type: 'default' },
+    { component: 'Tinker', message: 'Simulating Tinker job submission', type: 'default' },
+    { component: 'Tinker', message: 'Simulation accepted job and reserved a GPU slot', type: 'success' },
+    { component: 'CostManager', message: 'Simulated budget reserve: $14.20', type: 'warning' },
+    { component: 'Tinker', message: 'Simulated training epoch 1/3 complete', type: 'default' },
   ],
   [
-    { component: 'AutoResearch', message: 'PROPOSE: creating eval suite and recording baseline', type: 'default' },
-    { component: 'AutoResearch', message: 'Hypothesis: decrease learning_rate 3e-4→1.5e-4 (local ±20%)', type: 'default' },
-    { component: 'AutoResearch', message: 'KEPT — val_loss improved 0.312→0.289 (+7.4%)', type: 'success' },
-    { component: 'AutoResearch', message: 'Hypothesis: increase lora_rank 16→32 (random search)', type: 'default' },
-    { component: 'AutoResearch', message: 'KEPT — F1 improved 0.871→0.901 (+3.4%)', type: 'success' },
-    { component: 'AutoResearch', message: 'Hypothesis: increase learning_rate 1.5e-4→6e-4 (local ±20%)', type: 'default' },
-    { component: 'AutoResearch', message: 'REVERTED — loss spiked 0.289→0.334, patch rolled back', type: 'warning' },
-    { component: 'CostManager', message: 'Cumulative spend approaching 60% of budget', type: 'warning' },
-    { component: 'AutoResearch', message: 'Best config committed: lora_rank=32, lr=1.5e-4, warmup=500', type: 'success' },
+    { component: 'AutoResearch', message: 'Simulating eval-suite creation and baseline recording', type: 'default' },
+    { component: 'AutoResearch', message: 'Simulated hypothesis: decrease learning_rate 3e-4→1.5e-4', type: 'default' },
+    { component: 'AutoResearch', message: 'Simulated KEPT decision: val_loss improved 0.312→0.289', type: 'success' },
+    { component: 'AutoResearch', message: 'Simulated hypothesis: increase lora_rank 16→32', type: 'default' },
+    { component: 'AutoResearch', message: 'Simulated KEPT decision: F1 improved 0.871→0.901', type: 'success' },
+    { component: 'AutoResearch', message: 'Simulated hypothesis: increase learning_rate 1.5e-4→6e-4', type: 'default' },
+    { component: 'AutoResearch', message: 'Simulated REVERTED decision: loss spiked 0.289→0.334', type: 'warning' },
+    { component: 'CostManager', message: 'Simulated budget reserve approaching 60% of cap', type: 'warning' },
+    { component: 'AutoResearch', message: 'Simulated best config: lora_rank=32, lr=1.5e-4, warmup=500', type: 'success' },
   ],
   [
-    { component: 'Manager', message: 'Collecting final metrics and artifacts', type: 'default' },
-    { component: 'Observability', message: 'Research diary serialized to JSON', type: 'success' },
-    { component: 'Manager', message: 'Training pipeline complete', type: 'success' },
+    { component: 'Manager', message: 'Collecting simulated final metrics and artifacts', type: 'default' },
+    { component: 'Observability', message: 'Simulated research diary serialized to JSON', type: 'success' },
+    { component: 'Manager', message: 'Simulation pipeline complete', type: 'success' },
   ],
 ];
 
@@ -64,37 +74,37 @@ const ITERATIONS: Array<Omit<Iteration, 'id'>> = [
   {
     experiment: 'Decrease learning_rate 3e-4→1.5e-4 to reduce loss spikes.',
     diff: '- learning_rate: 0.0003\n+ learning_rate: 0.00015',
-    loss: 0.289, f1: 0.871, status: 'KEPT',
+    loss: 0.289, f1: 0.871, primaryMetric: 0.871, primaryMetricLabel: 'F1', status: 'KEPT',
   },
   {
     experiment: 'Increase lora_rank 16→32 to expand model capacity for task.',
     diff: '- lora_rank: 16\n+ lora_rank: 32',
-    loss: 0.271, f1: 0.901, status: 'KEPT',
+    loss: 0.271, f1: 0.901, primaryMetric: 0.901, primaryMetricLabel: 'F1', status: 'KEPT',
   },
   {
     experiment: 'Increase learning_rate 1.5e-4→6.1e-4 (local ±20% perturbation).',
     diff: '- learning_rate: 0.00015\n+ learning_rate: 0.00061',
-    loss: 0.334, f1: 0.862, status: 'REVERTED',
+    loss: 0.334, f1: 0.862, primaryMetric: 0.862, primaryMetricLabel: 'F1', status: 'REVERTED',
   },
   {
     experiment: 'Increase warmup_steps 100→500 to stabilize early training.',
     diff: '- warmup_steps: 100\n+ warmup_steps: 500',
-    loss: 0.248, f1: 0.914, status: 'KEPT',
+    loss: 0.248, f1: 0.914, primaryMetric: 0.914, primaryMetricLabel: 'F1', status: 'KEPT',
   },
   {
     experiment: 'Decrease dropout 0.1→0.06 (local ±20% perturbation).',
     diff: '- dropout: 0.1\n+ dropout: 0.06',
-    loss: 0.243, f1: 0.917, status: 'KEPT',
+    loss: 0.243, f1: 0.917, primaryMetric: 0.917, primaryMetricLabel: 'F1', status: 'KEPT',
   },
   {
     experiment: 'Increase num_epochs 3→4 to allow longer convergence.',
     diff: '- num_epochs: 3\n+ num_epochs: 4',
-    loss: 0.261, f1: 0.908, status: 'REVERTED',
+    loss: 0.261, f1: 0.908, primaryMetric: 0.908, primaryMetricLabel: 'F1', status: 'REVERTED',
   },
   {
     experiment: 'Decrease learning_rate 1.5e-4→1.2e-4 (local ±20% perturbation).',
     diff: '- learning_rate: 0.00015\n+ learning_rate: 0.00012',
-    loss: 0.231, f1: 0.923, status: 'KEPT',
+    loss: 0.231, f1: 0.923, primaryMetric: 0.923, primaryMetricLabel: 'F1', status: 'KEPT',
   },
 ];
 
@@ -105,11 +115,15 @@ export function useTrainingSimulation() {
     prompt: '',
     budget: 50,
     taskType: 'classification',
+    dataPath: null,
     costSpent: 0,
     metrics: [],
     iterations: [],
     logs: [],
     stages: makeStages(),
+    artifacts: null,
+    result: null,
+    provenance: null,
   });
 
   const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
@@ -131,7 +145,8 @@ export function useTrainingSimulation() {
     });
   }, []);
 
-  const start = useCallback((prompt: string, budget: number, taskType: TrainingState['taskType']) => {
+  const start = useCallback<StartTraining>((prompt, budget, taskType, dataPath = null) => {
+    const normalizedDataPath = dataPath?.trim() || null;
     clearTimers();
     setState({
       status: 'running',
@@ -139,11 +154,15 @@ export function useTrainingSimulation() {
       prompt,
       budget,
       taskType,
+      dataPath: normalizedDataPath,
       costSpent: 0,
       metrics: [],
       iterations: [],
       logs: [],
       stages: makeStages(),
+      artifacts: null,
+      result: null,
+      provenance: SIMULATION_PROVENANCE,
     });
 
     let cursor = 0; // ms elapsed
@@ -177,7 +196,16 @@ export function useTrainingSimulation() {
           schedule(() => {
             setState(prev => ({
               ...prev,
-              metrics: [...prev.metrics, { loss, accuracy, iteration: prev.metrics.length + 1 }],
+              metrics: [
+                ...prev.metrics,
+                {
+                  loss,
+                  accuracy,
+                  primaryMetric: accuracy,
+                  primaryMetricLabel: 'Accuracy',
+                  iteration: prev.metrics.length + 1,
+                },
+              ],
             }));
           }, stageStart + t * 500 + 200);
         }
@@ -237,7 +265,7 @@ export function useTrainingSimulation() {
 
     // Mark complete
     schedule(() => {
-      setState(prev => ({ ...prev, status: 'complete', stage: 5 }));
+      setState(prev => ({ ...prev, status: 'complete', stage: 5, provenance: SIMULATION_PROVENANCE }));
     }, cursor + 100);
   }, [schedule, appendLog]);
 
@@ -249,13 +277,34 @@ export function useTrainingSimulation() {
       prompt: '',
       budget: 50,
       taskType: 'classification',
+      dataPath: null,
       costSpent: 0,
       metrics: [],
       iterations: [],
       logs: [],
       stages: makeStages(),
+      artifacts: null,
+      result: null,
+      provenance: null,
     });
   }, []);
 
-  return { state, start, reset };
+  const cancel = useCallback(() => {
+    clearTimers();
+    setState(prev => ({
+      ...prev,
+      status: prev.status === 'running' ? 'cancelled' : prev.status,
+      logs: [
+        {
+          time: new Date().toLocaleTimeString('en-US', { hour12: false }),
+          component: 'Manager',
+          message: 'Run cancelled',
+          type: 'warning',
+        },
+        ...prev.logs,
+      ],
+    }));
+  }, []);
+
+  return { state, start, reset, cancel };
 }

--- a/ml-agent-frontend/src/types.ts
+++ b/ml-agent-frontend/src/types.ts
@@ -1,7 +1,15 @@
-export type StageStatus = 'pending' | 'in-progress' | 'complete';
+export type StageStatus = 'pending' | 'in-progress' | 'complete' | 'failed' | 'cancelled';
 export type TaskType = 'classification' | 'regression' | 'fine-tuning';
-export type LogType = 'default' | 'success' | 'warning';
+export type LogType = 'default' | 'success' | 'warning' | 'error';
 export type IterationStatus = 'KEPT' | 'REVERTED' | 'PENDING';
+export type RunStatus = 'idle' | 'running' | 'cancelling' | 'cancelled' | 'complete' | 'failed';
+
+export type StartTraining = (
+  prompt: string,
+  budget: number,
+  taskType: TaskType,
+  dataPath?: string | null
+) => void | Promise<void>;
 
 export interface PipelineStage {
   id: number;
@@ -12,6 +20,8 @@ export interface PipelineStage {
 export interface MetricPoint {
   loss: number;
   accuracy: number;
+  primaryMetric?: number | null;
+  primaryMetricLabel?: string | null;
   iteration: number;
 }
 
@@ -21,6 +31,8 @@ export interface Iteration {
   diff?: string;
   loss: number;
   f1: number;
+  primaryMetric?: number | null;
+  primaryMetricLabel?: string | null;
   status: IterationStatus;
 }
 
@@ -31,15 +43,50 @@ export interface LogEntry {
   type: LogType;
 }
 
+export interface ArtifactFile {
+  name: string;
+  label: string;
+  path?: string | null;
+  exists: boolean;
+  sizeBytes?: number | null;
+  contentType: string;
+  downloadPath?: string | null;
+}
+
+export interface RunArtifacts {
+  modelPath?: string | null;
+  checkpoints: Record<string, unknown>;
+  metrics?: Record<string, unknown> | null;
+  sample?: Record<string, unknown> | null;
+  files: ArtifactFile[];
+}
+
+export interface RunProvenance {
+  spendMode: string;
+  trainingBackend?: string | null;
+  dataMode?: string | null;
+  modeCFallback?: string | null;
+  budgetPreflightSkipped: boolean;
+  budgetSkipReason?: string | null;
+  liveServices: string[];
+  evidence: string[];
+}
+
 export interface TrainingState {
-  status: 'idle' | 'running' | 'complete';
+  status: RunStatus;
   stage: number;
   prompt: string;
   budget: number;
   taskType: TaskType;
+  dataPath?: string | null;
   costSpent: number;
   metrics: MetricPoint[];
   iterations: Iteration[];
   logs: LogEntry[];
   stages: PipelineStage[];
+  artifacts?: RunArtifacts | null;
+  provenance?: RunProvenance | null;
+  result?: Record<string, unknown> | null;
+  error?: string | null;
+  runId?: string;
 }

--- a/ml-agent-frontend/src/utils/metricDisplay.ts
+++ b/ml-agent-frontend/src/utils/metricDisplay.ts
@@ -1,0 +1,34 @@
+import type { Iteration, MetricPoint } from '../types';
+
+const DEFAULT_PRIMARY_LABEL = 'Primary Score';
+
+export function primaryMetricLabel(label?: string | null): string {
+  return label?.trim() || DEFAULT_PRIMARY_LABEL;
+}
+
+export function metricPointValue(metric?: MetricPoint | null): number | null {
+  if (!metric) return null;
+  return metric.primaryMetric ?? metric.accuracy ?? null;
+}
+
+export function iterationMetricValue(iteration?: Iteration | null): number | null {
+  if (!iteration) return null;
+  return iteration.primaryMetric ?? iteration.f1 ?? null;
+}
+
+export function shortMetricLabel(label?: string | null): string {
+  const normalized = primaryMetricLabel(label);
+  if (normalized.toLowerCase().includes('primary')) return 'Score';
+  if (normalized.toLowerCase().includes('accuracy')) return 'Accuracy';
+  return normalized;
+}
+
+export function formatPrimaryMetric(value: number | null | undefined, label?: string | null): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return '—';
+  const normalized = primaryMetricLabel(label).toLowerCase();
+  if (normalized.includes('accuracy')) {
+    return `${(value * 100).toFixed(1)}%`;
+  }
+  return value.toFixed(3);
+}
+

--- a/ml-agent-frontend/vite.config.ts
+++ b/ml-agent-frontend/vite.config.ts
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000',
+    },
+  },
 })


### PR DESCRIPTION
Replacement consolidated PR 5/8.

Supersedes draft PRs: #87, #89, #105, #108, #109, #110, #112, frontend parts of #113.

Scope:
- Frontend defaults to Manager API with explicit simulation mode.
- Dataset-source input, artifact download URL handling, cancellation/failure UI.
- Honest result actions, primary metric labels, provenance badges, failed-run artifact panel.
- Frontend README/build script updates.

Validation on final replacement stack:
- `python3 -m compileall src`
- `env -u ANTHROPIC_API_KEY -u TINKER_API_KEY -u TAVILY_API_KEY UV_NO_NETWORK=1 uv run --with pytest --with fastapi --with httpx --with langgraph --with anthropic python -m pytest -q` -> `339 passed, 10 skipped`
- `ml-agent-frontend`: `npm run lint && npm run build`
- `spec-site`: `npm run lint && npm run build`

No live services or paid jobs were run for this consolidation.
