### PR TITLE
[codex] consolidated no-spend offline guards

### DIFF
--- a/autoresearch/prepare.py
+++ b/autoresearch/prepare.py
@@ -54,12 +54,62 @@ BOS_TOKEN = "<|reserved_0|>"
 # Data download
 # ---------------------------------------------------------------------------
 
+OFFLINE_DOWNLOAD_ENV_VARS = ("NO_SPEND", "DATA_GENERATOR_OFFLINE")
+
+
+def _env_flag_enabled(name):
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _active_download_blockers():
+    return [name for name in OFFLINE_DOWNLOAD_ENV_VARS if _env_flag_enabled(name)]
+
+
+def _shard_filename(index):
+    return f"shard_{index:05d}.parquet"
+
+
+def _shard_path(index):
+    return os.path.join(DATA_DIR, _shard_filename(index))
+
+
+def _required_shard_ids(num_shards):
+    num_train = min(num_shards, MAX_SHARD)
+    ids = list(range(num_train))
+    if VAL_SHARD not in ids:
+        ids.append(VAL_SHARD)
+    return ids
+
+
+def _format_missing_shards(missing_ids, limit=8):
+    filenames = [_shard_filename(i) for i in missing_ids[:limit]]
+    extra = len(missing_ids) - len(filenames)
+    if extra > 0:
+        filenames.append(f"... and {extra} more")
+    return ", ".join(filenames)
+
+
+def _raise_if_download_blocked(missing_ids):
+    blockers = _active_download_blockers()
+    if not blockers:
+        return
+
+    blocker_text = " or ".join(f"{name}=1" for name in blockers)
+    missing_text = _format_missing_shards(missing_ids)
+    raise RuntimeError(
+        f"Data download disabled by {blocker_text}; missing required cached shards "
+        f"at {DATA_DIR}: {missing_text}. Pre-populate the cache or unset the offline/no-spend guard."
+    )
+
+
 def download_single_shard(index):
     """Download one parquet shard with retries. Returns True on success."""
-    filename = f"shard_{index:05d}.parquet"
-    filepath = os.path.join(DATA_DIR, filename)
+    filename = _shard_filename(index)
+    filepath = _shard_path(index)
     if os.path.exists(filepath):
         return True
+
+    _raise_if_download_blocked([index])
 
     url = f"{BASE_URL}/{filename}"
     max_attempts = 5
@@ -91,16 +141,16 @@ def download_single_shard(index):
 def download_data(num_shards, download_workers=8):
     """Download training shards + pinned validation shard."""
     os.makedirs(DATA_DIR, exist_ok=True)
-    num_train = min(num_shards, MAX_SHARD)
-    ids = list(range(num_train))
-    if VAL_SHARD not in ids:
-        ids.append(VAL_SHARD)
+    ids = _required_shard_ids(num_shards)
 
     # Count what's already downloaded
-    existing = sum(1 for i in ids if os.path.exists(os.path.join(DATA_DIR, f"shard_{i:05d}.parquet")))
+    missing = [i for i in ids if not os.path.exists(_shard_path(i))]
+    existing = len(ids) - len(missing)
     if existing == len(ids):
         print(f"Data: all {len(ids)} shards already downloaded at {DATA_DIR}")
         return
+
+    _raise_if_download_blocked(missing)
 
     needed = len(ids) - existing
     print(f"Data: downloading {needed} shards ({existing} already exist)...")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = -s
+testpaths = tests
+norecursedirs = outputs/reference

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,15 @@
 anthropic>=0.40.0
 langgraph>=0.2.0
 requests>=2.31.0
-PyMuPDF>=1.24.0
-trafilatura>=1.12.0
 tavily-python>=0.5.0
+trafilatura>=1.12.0
+PyMuPDF>=1.24.0
 datasets>=2.18.0
 huggingface-hub>=0.23.0
 transformers>=4.40.0
 peft>=0.10.0
 torch>=2.2.0
 pytest>=8.0.0
-# Tinker SDK path
 tinker
 tinker-cookbook
 fastapi>=0.115.0

--- a/tests/test_prepare_offline_download_guard.py
+++ b/tests/test_prepare_offline_download_guard.py
@@ -1,0 +1,124 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _fake_torch_module():
+    torch = types.ModuleType("torch")
+
+    def no_grad():
+        def decorator(func):
+            return func
+
+        return decorator
+
+    torch.no_grad = no_grad
+    return torch
+
+
+def _fail_requests_get(*args, **kwargs):
+    raise AssertionError("requests.get called")
+
+
+@pytest.fixture
+def prepare_module(monkeypatch):
+    fake_requests = types.ModuleType("requests")
+    fake_requests.RequestException = RuntimeError
+    fake_requests.get = lambda *args, **kwargs: None
+
+    fake_pyarrow = types.ModuleType("pyarrow")
+    fake_parquet = types.ModuleType("pyarrow.parquet")
+    fake_pyarrow.parquet = fake_parquet
+
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+    monkeypatch.setitem(sys.modules, "pyarrow", fake_pyarrow)
+    monkeypatch.setitem(sys.modules, "pyarrow.parquet", fake_parquet)
+    monkeypatch.setitem(sys.modules, "rustbpe", types.ModuleType("rustbpe"))
+    monkeypatch.setitem(sys.modules, "tiktoken", types.ModuleType("tiktoken"))
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch_module())
+
+    module_path = Path(__file__).resolve().parents[1] / "autoresearch" / "prepare.py"
+    module_name = "legacy_autoresearch_prepare_for_tests"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize("env_var", ["NO_SPEND", "DATA_GENERATOR_OFFLINE"])
+def test_download_data_offline_guard_fails_when_required_shards_missing(
+    tmp_path, monkeypatch, prepare_module, env_var
+):
+    monkeypatch.setenv(env_var, "1")
+    monkeypatch.setattr(prepare_module, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(prepare_module.requests, "get", _fail_requests_get)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        prepare_module.download_data(num_shards=1, download_workers=1)
+
+    message = str(excinfo.value)
+    assert f"{env_var}=1" in message
+    assert "Data download disabled" in message
+    assert "missing required cached shards" in message
+    assert "shard_00000.parquet" in message
+    assert "shard_06542.parquet" in message
+
+
+@pytest.mark.parametrize("env_var", ["NO_SPEND", "DATA_GENERATOR_OFFLINE"])
+def test_download_data_offline_guard_allows_fully_cached_shards(
+    tmp_path, monkeypatch, capsys, prepare_module, env_var
+):
+    monkeypatch.setenv(env_var, "1")
+    monkeypatch.setattr(prepare_module, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(prepare_module.requests, "get", _fail_requests_get)
+
+    for index in (0, 1, prepare_module.VAL_SHARD):
+        (tmp_path / prepare_module._shard_filename(index)).write_bytes(b"cached")
+
+    prepare_module.download_data(num_shards=2, download_workers=1)
+
+    assert "all 3 shards already downloaded" in capsys.readouterr().out
+
+
+def test_download_data_offline_guard_accepts_common_truthy_values(
+    tmp_path, monkeypatch, prepare_module
+):
+    monkeypatch.setenv("NO_SPEND", "on")
+    monkeypatch.setattr(prepare_module, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(prepare_module.requests, "get", _fail_requests_get)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        prepare_module.download_data(num_shards=1, download_workers=1)
+
+    assert "NO_SPEND=1" in str(excinfo.value)
+
+
+def test_download_single_shard_offline_guard_blocks_direct_download(
+    tmp_path, monkeypatch, prepare_module
+):
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.setattr(prepare_module, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(prepare_module.requests, "get", _fail_requests_get)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        prepare_module.download_single_shard(0)
+
+    message = str(excinfo.value)
+    assert "NO_SPEND=1" in message
+    assert "shard_00000.parquet" in message
+
+
+def test_download_single_shard_offline_guard_allows_cached_shard(
+    tmp_path, monkeypatch, prepare_module
+):
+    monkeypatch.setenv("NO_SPEND", "1")
+    monkeypatch.setattr(prepare_module, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(prepare_module.requests, "get", _fail_requests_get)
+    (tmp_path / prepare_module._shard_filename(0)).write_bytes(b"cached")
+
+    assert prepare_module.download_single_shard(0) is True


### PR DESCRIPTION
Replacement consolidated PR 6/8.

Supersedes standalone guard PRs: #103, #106. Subsystem-specific no-spend changes from #91/#92/#93/#94/#95/#101/#102/#104 are folded into the relevant subsystem replacement PRs above.

Scope:
- Offline prepare/download guard.
- Shared pytest configuration used by the consolidated validation stack.
- Live-test no-spend policy represented in the replacement stack.

Validation on final replacement stack:
- `python3 -m compileall src`
- `env -u ANTHROPIC_API_KEY -u TINKER_API_KEY -u TAVILY_API_KEY UV_NO_NETWORK=1 uv run --with pytest --with fastapi --with httpx --with langgraph --with anthropic python -m pytest -q` -> `339 passed, 10 skipped`
- `ml-agent-frontend`: `npm run lint && npm run build`
- `spec-site`: `npm run lint && npm run build`

No live services or paid jobs were run for this consolidation.
